### PR TITLE
Remove the concept of 'db' from the public API

### DIFF
--- a/core2/README.adoc
+++ b/core2/README.adoc
@@ -78,70 +78,87 @@ Transactions are slightly different to Classic:
 - `:crux.db/id` -> `:_id`. Valid ID types currently strings, numbers, dates.
 - `c2/submit-tx` returns `CompletableFuture`, deref it to get the transaction details.
 
-=== DBs
-Core2 has the concept of 'db's, similar to `crux/db` but without the ability to specify VT.
-In Core2, the upper bound for the tx-time is applied per-source; the default upper bound for VT is applied at the query level - this is because each data source has their own tx-time timeline, but VT is assumed to be a single timeline, consistent across data sources.
-
-[source,clojure]
-----
-;; simple case - use the latest tx the node has available:
-(let [db (c2/db node)]
-  ...)
-
-;; or, to read your own writes (timeout optional):
-;; `db` will await the transaction
-(let [tx (c2/submit-tx node [...])
-      db (c2/db node {:tx tx, :timeout (Duration/ofMillis 250)})]
-  ...)
-
-;; in tests, we often inline `tx`:
-(let [db (c2/db node
-                {:tx (c2/submit-tx node [...])})]
-  ...)
-----
-
-`db-async` is the same, except it runs entirely asynchronously and returns a `CompletableFuture` of the value returned from the block.
-(In fact, `db` just calls `db-async` and deref's it.)
-
 === Queries
-In a similar manner to `next.jdbc`[https://github.com/seancorfield/next-jdbc], execute Datalog queries in Core2 using `c2/plan-q`.
+In a similar manner to `next.jdbc`[https://github.com/seancorfield/next-jdbc], execute Datalog queries in Core2 using `c2/plan-query`.
 This returns a reducible sequence that you can pass to (say) `reduce`, `into` or `run!`.
 When finalised (by `reduce`) this will ensure the query results are adequately closed.
 
 [source,clojure]
 ----
 (with-open [node (c2/start-node {})]
-  (let [db (c2/db node)]
-    (into [] (c2/plan-q '{:find [?e ?name]
-                          :where [[?e :name ?name]]}
-                        db))))
+  (->> (c2/plan-query node
+                      '{:find [?e ?name]
+                        :where [[?e :name ?name]]})
+       (into [])))
 ----
 
 These queries currently return a vector of maps `[{:e ..., :name ...}, {...}]`, although this is only because it's what was closest to what we had available at the time.
 
-Note the param order is query then database (different to Classic, same as other EDN Datalog databases) - this is because Core2 queries can accept multiple DBs.
+=== Bases
+Core2 doesn't have the concept of DBs - instead, we pass the node and (optionally) a 'basis' to queries.
+In Core2, the upper bound for the tx-time is applied per-source; the default upper bound for VT is applied at the query level - this is because each data source has their own tx-time timeline, but VT is assumed to be a single timeline, consistent across data sources.
 
-Queries also accept a `:default-valid-time` option after the query itself, before any params, which applies to any entities that don't specify other valid-time constraints.
+[source,clojure]
+----
+;; simple case - use the latest tx the node has available:
+(->> (c2/plan-query node '{...})
+     (into []))
+
+;; or, to read your own writes (timeout optional):
+;; `plan-query` will await the transaction
+(->> (c2/plan-query node
+                    '{...}
+                    {:basis-tx tx,
+                     :basis-timeout (Duration/ofSeconds 1)})
+     (into []))
+----
+
+The `plan-query` functions take the node, the query, optionally the basis-map, and then a variable number of params.
+
+Params are passed after the basis map if both are present:
+
+[source,clojure]
+----
+(->> (c2/plan-query tu/*node*
+                    '{:find [?e]
+                      :in [?first-name ?last-name]
+                      :where [[?e :first-name ?first-name]
+                              [?e :last-name ?last-name]]}
+                    {:basis-tx tx}
+                    "Ivan" "Ivanov")
+     (into #{}))
+----
+
+Unlike Datomic, `$` shouldn't be included in `:in` - if/when we reinstate multiple sources to Datalog queries, I propose we include them as a named map in the basis-opts:
+
+[source,clojure]
+----
+;; something like this, anyway.
+(->> (c2/plan-query node
+                    '{:find [...]
+                      :where [[$db1 ...], [$db2 ...]]}
+                    {'$db1 {:basis-tx tx}
+                     '$db2 {:basis-tx tx}
+                     :basis-timeout (Duration/ofSeconds 1)})
+     (into []))
+----
+
+`plan-query-async` is the same, except it runs entirely asynchronously and returns a `CompletableFuture` of the query plan.
+(In fact, `plan-query` just calls `plan-query-async` and deref's it.)
+
+The basis-opts can also contain a `:default-valid-time` option, which applies to any entities that don't specify other valid-time constraints.
 This is for repeatable queries - it defaults to 'now' if not provided.
 
 [source,clojure]
 ----
-(with-open [node (c2/start-node {})]
-  (let [db (c2/db node)]
-    (into [] (c2/plan-q '{:find [?e ?name]
-                          :where [[?e :name ?name]]}
-                        {:default-valid-time #inst "..."}
-                        db))))
+(->> (c2/plan-query node
+                    '{:find [?e ?name]
+                      :where [[?e :name ?name]]}
+                    {:default-valid-time #inst "..."})
+     (into []))
 ----
 
-There is also `c2/plan-ra` which accepts a lower-level relational algebra query - have a look in `core2.logical-plan` for what can go into these plans, and `core2.tpch-queries` for examples.
-
-[source,clojure]
-----
-(with-open [node (c2/start-node {})]
-  (let [db (c2/db node)]
-    (into [] (c2/plan-ra '[:scan [{name (> name "Ivan")}]] db))))
-----
+There is also `op/plan-ra` which accepts a lower-level relational algebra query - have a look in `core2.logical-plan` for what can go into these plans, and `core2.tpch-queries` for examples.
 
 == Developing Core2
 

--- a/core2/dev/dev.clj
+++ b/core2/dev/dev.clj
@@ -5,7 +5,9 @@
             [core2.tpch :as tpch]
             [core2.util :as util]
             [integrant.core :as i]
-            [integrant.repl :as ir])
+            [integrant.repl :as ir]
+            [core2.operator :as op]
+            [core2.snapshot :as snap])
   (:import [ch.qos.logback.classic Level Logger]
            java.time.Duration
            org.slf4j.LoggerFactory))
@@ -67,5 +69,5 @@
                 #'tpch/tpch-q5-local-supplier-volume
                 #'tpch/tpch-q9-product-type-profit-measure]]
       (prn !q)
-      (let [db (c2/db node)]
-        (time (into [] (c2/plan-ra @!q db)))))))
+      (let [db (snap/snapshot (tu/component node ::snap/snapshot-factory))]
+        (time (into [] (op/plan-ra @!q db)))))))

--- a/core2/modules/bench/src/core2/bench/multinode_tpch.clj
+++ b/core2/modules/bench/src/core2/bench/multinode_tpch.clj
@@ -3,7 +3,10 @@
             [core2.bench :as bench]
             [core2.core :as c2]
             [core2.tpch :as tpch]
-            [core2.temporal :as temporal])
+            [core2.temporal :as temporal]
+            [core2.operator :as op]
+            [core2.test-util :as tu]
+            [core2.snapshot :as snap])
   (:import java.nio.file.attribute.FileAttribute
            java.nio.file.Files
            java.time.Duration
@@ -33,9 +36,10 @@
                     query tpch/tpch-q1-pricing-summary-report]
                 (letfn [(test-node [k ^core2.core.Node node]
                           (log/info "awaiting" k "node")
-                          (let [db (c2/db node {:tx last-tx, :timeout (Duration/ofHours 1)})]
+                          (let [db (snap/snapshot (tu/component node ::snap/snapshot-factory)
+                                                  last-tx (Duration/ofHours 1))]
                             (log/info "rows:"
-                                      (->> (c2/plan-ra query (merge {'$ db} (::tpch/params (meta query))))
+                                      (->> (op/plan-ra query (merge {'$ db} (::tpch/params (meta query))))
                                            (sequence)
                                            (count)))))]
                   (doseq [[k node] {:primary primary-node

--- a/core2/modules/bench/src/core2/bench/watdiv.clj
+++ b/core2/modules/bench/src/core2/bench/watdiv.clj
@@ -1,7 +1,8 @@
 (ns core2.bench.watdiv
   (:require [clojure.java.io :as io]
             [core2.bench :as bench]
-            [core2.core :as c2])
+            [core2.core :as c2]
+            [core2.test-util :as tu])
   (:import java.util.concurrent.TimeUnit))
 
 (comment
@@ -42,12 +43,13 @@
   ;; TODO currently fails because it doesn't like strings as attributes
 
   (with-open [query-rdr (io/reader query-file)]
-    (let [db (c2/db node)]
+    (let [basis-tx (c2/latest-completed-tx node)]
       (doseq [[idx query] (->> (line-seq query-rdr)
                                (map read-string)
                                (map-indexed vector))]
         (bench/with-timing (keyword (str "query-" idx))
-          (count (into [] (c2/plan-q query db))))))))
+          (count (->> (c2/plan-query tu/*node* query {:basis-tx basis-tx})
+                      (into []))))))))
 
 (comment
   (with-open [node (c2/start-node {})]

--- a/core2/modules/datasets/src/core2/ts_devices.clj
+++ b/core2/modules/datasets/src/core2/ts_devices.clj
@@ -3,7 +3,10 @@
             [clojure.instant :as inst]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [core2.core :as c2])
+            [core2.core :as c2]
+            [core2.snapshot :as snap]
+            [core2.test-util :as tu]
+            [core2.operator :as op])
   (:import java.util.zip.GZIPInputStream))
 
 (defn device-info-csv->doc [[device-id api-version manufacturer model os-name]]
@@ -133,5 +136,5 @@
 
 (comment
   (time
-   (let [db (c2/db dev/node)]
-     (into [] (c2/plan-ra query-recent-battery-temperatures db)))))
+   (let [db (snap/snapshot (tu/component dev/node ::snap/snapshot-factory))]
+     (into [] (op/plan-ra query-recent-battery-temperatures db)))))

--- a/core2/modules/kafka/test/core2/kafka_test.clj
+++ b/core2/modules/kafka/test/core2/kafka_test.clj
@@ -1,13 +1,16 @@
 (ns core2.kafka-test
   (:require [clojure.test :as t]
             [core2.core :as c2]
-            [core2.kafka :as k])
+            [core2.kafka :as k]
+            [core2.snapshot :as snap]
+            [core2.test-util :as tu]
+            [core2.operator :as op])
   (:import java.util.UUID))
 
 (t/deftest ^:kafka test-kafka
   (let [topic-name (str "core2.kafka-test." (UUID/randomUUID))]
     (with-open [node (c2/start-node {::k/log {:topic-name topic-name}})]
       (let [tx (c2/submit-tx node [[:put {:_id "foo"}]])
-            db (c2/db node {:tx tx})]
+            db (snap/snapshot (tu/component node ::snap/snapshot-factory) tx)]
         (t/is (= [{:_id "foo"}]
-                 (into [] (c2/plan-ra '[:scan [_id]] db))))))))
+                 (into [] (op/plan-ra '[:scan [_id]] db))))))))

--- a/core2/src/core2/core.clj
+++ b/core2/src/core2/core.clj
@@ -1,67 +1,65 @@
 (ns core2.core
   (:require [clojure.pprint :as pp]
-            [core2.data-source :as ds]
             [core2.datalog :as d]
             [core2.indexer :as idx]
             core2.ingest-loop
             [core2.operator :as op]
-            [core2.relation :as rel]
+            [core2.snapshot :as snap]
             [core2.tx-producer :as txp]
             [core2.util :as util]
             [juxt.clojars-mirrors.integrant.core :as ig])
-  (:import clojure.lang.IReduceInit
-           core2.data_source.IDataSourceFactory
-           core2.indexer.TransactionIndexer
+  (:import core2.indexer.TransactionIndexer
+           core2.snapshot.ISnapshotFactory
            core2.tx_producer.ITxProducer
            [java.io Closeable Writer]
            java.lang.AutoCloseable
            java.time.Duration
-           [java.util.concurrent CompletableFuture TimeUnit]
+           [java.util.concurrent CompletableFuture ExecutionException TimeUnit]
            java.util.Date
            [org.apache.arrow.memory BufferAllocator RootAllocator]))
 
 (set! *unchecked-math* :warn-on-boxed)
 
-(defprotocol PNode
+(defprotocol PClient
   (latest-completed-tx ^core2.tx.TransactionInstant [node])
 
-  (await-tx-async
-    ^java.util.concurrent.CompletableFuture #_<core2.tx.TransactionInstant> [node tx])
+  ;; we may want to go to `open-query-async`/`Stream` instead, when we have a Java API
+  (-plan-query-async ^java.util.concurrent.CompletableFuture [node query basis params]))
 
-  (db-async
-    ^java.util.concurrent.CompletableFuture #_<core2.data_source.IDataSource> [node]
-    ^java.util.concurrent.CompletableFuture #_<core2.data_source.IDataSource> [node db-opts]))
+(defprotocol PNode
+  ;; TODO in theory we shouldn't need this, but it's still used in tests
+  (await-tx-async
+    ^java.util.concurrent.CompletableFuture #_<TransactionInstant> [node tx]))
 
 (defprotocol PSubmitNode
   (submit-tx
-    ^java.util.concurrent.CompletableFuture [tx-producer tx-ops]))
+    ^java.util.concurrent.CompletableFuture #_<TransactionInstant> [tx-producer tx-ops]))
 
 (defrecord Node [^TransactionIndexer indexer
-                 ^IDataSourceFactory data-source-factory
+                 ^ISnapshotFactory snapshot-factory
                  ^ITxProducer tx-producer
                  !system
                  close-fn]
-  PNode
+  PClient
   (latest-completed-tx [_] (.latestCompletedTx indexer))
 
+  (-plan-query-async [_ query basis params]
+    (let [{:keys [default-valid-time basis-tx ^Duration basis-timeout],
+           :or {default-valid-time (Date.)}} basis]
+      (-> (snap/snapshot-async snapshot-factory basis-tx)
+          (cond-> basis-timeout (.orTimeout (.toMillis basis-timeout) TimeUnit/MILLISECONDS))
+          (util/then-apply
+            (fn [db]
+              (let [{:keys [query srcs]} (d/compile-query query params)]
+                (op/plan-ra query (merge srcs {'$ db}) {:default-valid-time default-valid-time})))))))
+
+  PNode
   (await-tx-async [_ tx]
     (-> (if-not (instance? CompletableFuture tx)
           (CompletableFuture/completedFuture tx)
           tx)
         (util/then-compose (fn [tx]
                              (.awaitTxAsync indexer tx)))))
-
-  (db-async [this]
-    (db-async this {}))
-
-  (db-async [this db-opts]
-    (let [{:keys [tx ^Duration timeout]} db-opts]
-      (-> (if tx
-            (-> (await-tx-async this tx)
-                (cond-> timeout (.orTimeout (.toMillis timeout) TimeUnit/MILLISECONDS)))
-            (CompletableFuture/completedFuture (latest-completed-tx this)))
-          (util/then-apply (fn [tx]
-                             (.getDataSource data-source-factory tx))))))
 
   PSubmitNode
   (submit-tx [_ tx-ops]
@@ -72,16 +70,30 @@
     (when close-fn
       (close-fn))))
 
-(defn db
-  ([node] @(db-async node))
-  ([node db-opts] @(db-async node db-opts)))
+(defn ^java.util.concurrent.CompletableFuture plan-query-async [node query & params]
+  (let [[basis params] (let [[maybe-basis & more-params] params]
+                         (if (map? maybe-basis)
+                           [maybe-basis more-params]
+                           [{} params]))]
+    (-plan-query-async node query basis params)))
+
+(defn plan-query [node query & params]
+  (try
+    @(apply plan-query-async node query params)
+    (catch ExecutionException e
+      (throw (.getCause e)))))
+
+(let [arglists '([node query & params]
+                 [node query basis-opts & params])]
+  (alter-meta! #'plan-query-async assoc :arglists arglists)
+  (alter-meta! #'plan-query assoc :arglists arglists))
 
 (defmethod print-method Node [_node ^Writer w] (.write w "#<Core2Node>"))
 (defmethod pp/simple-dispatch Node [it] (print-method it *out*))
 
 (defmethod ig/prep-key :core2/node [_ opts]
   (merge {:indexer (ig/ref ::idx/indexer)
-          :data-source-factory (ig/ref ::ds/data-source-factory)
+          :snapshot-factory (ig/ref ::snap/snapshot-factory)
           :tx-producer (ig/ref ::txp/tx-producer)}
          opts))
 
@@ -90,39 +102,6 @@
 
 (defmethod ig/halt-key! :core2/node [_ ^Node node]
   (.close node))
-
-(defn ^core2.ICursor open-ra
-  ([query db-or-dbs] (open-ra query db-or-dbs {}))
-
-  ([query db-or-dbs opts]
-   (let [allocator (RootAllocator.)]
-     (try
-       (-> (op/open-ra query
-                       (if (map? db-or-dbs) db-or-dbs {'$ db-or-dbs})
-                       (-> (merge {:default-valid-time (Date.)} opts)
-                           (assoc :allocator allocator)))
-           (util/and-also-close allocator))
-       (catch Throwable t
-         (util/try-close allocator)
-         (throw t))))))
-
-(defn plan-ra
-  ([query db-or-dbs] (plan-ra query db-or-dbs {}))
-  ([query db-or-dbs query-opts]
-   (reify IReduceInit
-     (reduce [_ f init]
-       (with-open [res (open-ra query db-or-dbs query-opts)]
-         (util/reduce-cursor (fn [acc rel]
-                               (reduce f acc (rel/rel->rows rel)))
-                             init
-                             res))))))
-
-(defn plan-q [query & params]
-  (let [{:keys [query srcs query-opts]} (apply d/compile-query query params)]
-    (plan-ra query srcs query-opts)))
-
-(alter-meta! #'plan-q assoc :arglists '([query & params]
-                                        [query opts & params]))
 
 (defmethod ig/init-key :core2/allocator [_ _] (RootAllocator.))
 (defmethod ig/halt-key! :core2/allocator [_ ^BufferAllocator a] (.close a))
@@ -139,7 +118,7 @@
                           :core2.metadata/metadata-manager {}
                           :core2.temporal/temporal-manager {}
                           :core2.buffer-pool/buffer-pool {}
-                          ::ds/data-source-factory {}
+                          ::snap/snapshot-factory {}
                           ::txp/tx-producer {}}
                          opts)
                    (with-default-impl :core2/log :core2.log/memory-log)

--- a/core2/src/core2/datalog.clj
+++ b/core2/src/core2/datalog.clj
@@ -95,9 +95,7 @@
                                :explain (s/explain-data ::query query)})))
     conformed-query))
 
-(defn- compile-srcs [{in-bindings :in,
-                      :or {in-bindings [[:source '$]]}}
-                     args]
+(defn- compile-srcs [{in-bindings :in} args]
   (when (not= (count in-bindings) (count args))
     (throw (err/illegal-arg :in-arity-exception {::err/message ":in arity mismatch"
                                                  :expected (s/unform ::in in-bindings)
@@ -327,20 +325,15 @@
                                    (MapEntry/create var-arg (symbol (subs (name var-arg) 1))))))))
    plan])
 
-(defn compile-query [query & args]
+(defn compile-query [query args]
   (let [conformed-query (conform-query query)
-        [query-opts args] (let [[maybe-opts & rest-args] args]
-                            (if (map? maybe-opts)
-                              [maybe-opts rest-args]
-                              [{} args]))
         {:keys [srcs table-keys]} (compile-srcs conformed-query args)]
     {:query (-> (compile-where conformed-query {:table-keys table-keys})
                 (with-group-by conformed-query)
                 (with-order-by conformed-query)
                 (with-slice conformed-query)
                 (with-renamed-find-vars conformed-query))
-     :srcs srcs
-     :query-opts query-opts}))
+     :srcs srcs}))
 
 (comment
   (compile-query '{:find [?e1 ?e2 ?a1 ?a2]
@@ -348,4 +341,4 @@
                            [?e2 :name "Ivan"]
                            [?e1 :age ?a1]
                            [?e2 :age ?a2]]}
-                 :db))
+                 [:db]))

--- a/core2/test/core2/as_of_test.clj
+++ b/core2/test/core2/as_of_test.clj
@@ -2,44 +2,59 @@
   (:require [clojure.test :as t]
             [core2.core :as c2]
             [core2.test-util :as tu]
-            [core2.temporal :as temporal]))
+            [core2.temporal :as temporal]
+            [core2.snapshot :as snap]
+            [core2.operator :as op]))
 
 (t/use-fixtures :each tu/with-node)
 
 (t/deftest test-as-of-tx
-  (let [!tx1 (c2/submit-tx tu/*node* [[:put {:_id "my-doc", :last-updated "tx1"}]])
+  (let [snapshot-factory (tu/component ::snap/snapshot-factory)
+
+        !tx1 (c2/submit-tx tu/*node* [[:put {:_id "my-doc", :last-updated "tx1"}]])
         _ (Thread/sleep 10) ; prevent same-ms transactions
         !tx2 (c2/submit-tx tu/*node* [[:put {:_id "my-doc", :last-updated "tx2"}]])]
 
-    (let [db (c2/db tu/*node* {:tx !tx2})]
-      (t/is (= #{{:last-updated "tx2"}}
-               (into #{} (c2/plan-ra '[:scan [last-updated]] db))))
+    (t/is (= #{{:last-updated "tx2"}}
+             (into #{} (op/plan-ra '[:scan [last-updated]]
+                                   (snap/snapshot snapshot-factory !tx2)))))
 
-      (t/is (= #{{:last-updated "tx2"}}
-               (into #{} (c2/plan-q '{:find [?last-updated]
-                                      :where [[?e :last-updated ?last-updated]]}
-                                    db))))
+    (t/is (= #{{:last-updated "tx2"}}
+             (->> (c2/plan-query tu/*node*
+                                 '{:find [?last-updated]
+                                   :where [[?e :last-updated ?last-updated]]}
+                                 {:basis-tx !tx2})
+                  (into #{}))))
+
+    (t/is (= #{{:last-updated "tx1"}}
+             (->> (c2/plan-query tu/*node*
+                                 '{:find [?last-updated]
+                                   :where [[?e :last-updated ?last-updated]]}
+                                 {:default-valid-time (:tx-time @!tx1)
+                                  :basis-tx !tx2})
+                  (into #{}))))
+
+    (t/testing "at tx1"
+      (t/is (= #{{:last-updated "tx1"}}
+               (into #{} (op/plan-ra '[:scan [last-updated]]
+                                     (snap/snapshot snapshot-factory !tx1)))))
 
       (t/is (= #{{:last-updated "tx1"}}
-               (into #{} (c2/plan-q '{:find [?last-updated]
-                                      :where [[?e :last-updated ?last-updated]]}
-                                    {:default-valid-time (:tx-time @!tx1)}
-                                    db)))))
-
-    (let [db (c2/db tu/*node* {:tx !tx1})]
-      (t/is (= #{{:last-updated "tx1"}}
-               (into #{} (c2/plan-ra '[:scan [last-updated]] db))))
-
-      (t/is (= #{{:last-updated "tx1"}}
-               (into #{} (c2/plan-q '{:find [?last-updated]
-                                      :where [[?e :last-updated ?last-updated]]}
-                                    db)))))))
+               (->> (c2/plan-query tu/*node*
+                                   '{:find [?last-updated]
+                                     :where [[?e :last-updated ?last-updated]]}
+                                   {:basis-tx !tx1})
+                    (into #{})))))))
 
 (t/deftest test-valid-time
-  (let [{:keys [tx-time] :as tx1} @(c2/submit-tx tu/*node* [[:put {:_id "doc", :version 1}]
+  (let [snapshot-factory (tu/component ::snap/snapshot-factory)
+
+        {:keys [tx-time] :as tx1} @(c2/submit-tx tu/*node* [[:put {:_id "doc", :version 1}]
                                                             [:put {:_id "doc-with-vt"}
                                                              {:_valid-time-start #inst "2021"}]])
-        db (c2/db tu/*node* {:tx tx1})]
+
+        db (snap/snapshot snapshot-factory tx1)]
+
     (t/is (= {"doc" {:_id "doc",
                      :_valid-time-start tx-time
                      :_valid-time-end temporal/end-of-time
@@ -50,7 +65,7 @@
                              :_valid-time-end temporal/end-of-time
                              :_tx-time-start tx-time
                              :_tx-time-end temporal/end-of-time}}
-             (->> (c2/plan-ra '[:scan [_id
+             (->> (op/plan-ra '[:scan [_id
                                        _valid-time-start _valid-time-end
                                        _tx-time-start _tx-time-end]]
                               db)

--- a/core2/test/core2/indexer_test.clj
+++ b/core2/test/core2/indexer_test.clj
@@ -410,8 +410,7 @@
             (let [system @(:!system node)
                   ^ObjectStore os (::os/file-system-object-store system)
                   ^IMetadataManager mm (::meta/metadata-manager system)
-                  ^TemporalManager tm (::temporal/temporal-manager system)
-                  ^IChunkManager idx (::idx/indexer system)]
+                  ^TemporalManager tm (::temporal/temporal-manager system)]
               (t/is (= first-half-tx-instant
                        (-> first-half-tx-instant
                            (tu/then-await-tx node (Duration/ofSeconds 5)))))

--- a/core2/test/core2/operator/scan_test.clj
+++ b/core2/test/core2/operator/scan_test.clj
@@ -1,7 +1,9 @@
 (ns core2.operator.scan-test
   (:require [clojure.test :as t]
             [core2.core :as c2]
-            [core2.test-util :as tu]))
+            [core2.test-util :as tu]
+            [core2.operator :as op]
+            [core2.snapshot :as snap]))
 
 (t/use-fixtures :each tu/with-allocator)
 
@@ -10,26 +12,28 @@
     (let [tx (c2/submit-tx node [[:put {:_id "foo", :col1 "foo1"}]
                                  [:put {:_id "bar", :col1 "bar1", :col2 "bar2"}]
                                  [:put {:_id "foo", :col2 "baz2"}]])
-          db (c2/db node {:tx tx})]
+          sf (tu/component node ::snap/snapshot-factory)]
       (t/is (= [{:_id "bar", :col1 "bar1", :col2 "bar2"}]
-               (into [] (c2/plan-ra '[:scan [_id col1 col2]] db)))))))
+               (into [] (op/plan-ra '[:scan [_id col1 col2]]
+                                    (snap/snapshot sf tx))))))))
 
 (t/deftest multiple-sources
   (with-open [node1 (c2/start-node {})
               node2 (c2/start-node {})]
-    (let [db1 (c2/db node1
-                     {:tx (c2/submit-tx node1 [[:put {:_id "foo", :col1 "col1"}]])})
-          db2 (c2/db node2
-                     {:tx (c2/submit-tx node2 [[:put {:_id "foo", :col2 "col2"}]])})]
+    (let [tx1 (c2/submit-tx node1 [[:put {:_id "foo", :col1 "col1"}]])
+          db1 (snap/snapshot (tu/component node1 ::snap/snapshot-factory) tx1)
+          tx2 (c2/submit-tx node2 [[:put {:_id "foo", :col2 "col2"}]])
+          db2 (snap/snapshot (tu/component node2 ::snap/snapshot-factory) tx2)]
       (t/is (= [{:_id "foo", :col1 "col1", :col2 "col2"}]
-               (into [] (c2/plan-ra '[:join {_id _id}
+               (into [] (op/plan-ra '[:join {_id _id}
                                       [:scan $db1 [_id col1]]
                                       [:scan $db2 [_id col2]]]
                                     {'$db1 db1, '$db2 db2})))))))
 
 (t/deftest test-duplicates-in-scan-1
   (with-open [node (c2/start-node {})]
-    (let [tx (c2/submit-tx node [[:put {:_id "foo"}]])
-          db (c2/db node {:tx tx})]
+    (let [sf (tu/component node ::snap/snapshot-factory)
+          tx (c2/submit-tx node [[:put {:_id "foo"}]])]
       (t/is (= [{:_id "foo"}]
-               (into [] (c2/plan-ra '[:scan [_id _id]] db)))))))
+               (into [] (op/plan-ra '[:scan [_id _id]]
+                                    (snap/snapshot sf tx))))))))

--- a/core2/test/core2/operator/table_test.clj
+++ b/core2/test/core2/operator/table_test.clj
@@ -1,7 +1,7 @@
 (ns core2.operator.table-test
   (:require [clojure.test :as t]
-            [core2.core :as c2]
-            [core2.test-util :as tu])
+            [core2.test-util :as tu]
+            [core2.operator :as op])
   (:import java.time.Duration))
 
 (t/use-fixtures :each tu/with-allocator)
@@ -9,23 +9,23 @@
 (t/deftest test-table
   (t/is (= [{:a 12, :b "foo" :c 1.2 :d nil :e true :f (Duration/ofHours 1)}
             {:a 100, :b "bar" :c 3.14 :d #inst "2020" :e 10 :f (Duration/ofMinutes 1)}]
-           (into [] (c2/plan-ra '[:table $table]
+           (into [] (op/plan-ra '[:table $table]
                                 {'$table [{:a 12, :b "foo" :c 1.2 :d nil :e true :f (Duration/ofHours 1)}
                                           {:a 100, :b "bar" :c 3.14 :d #inst "2020" :e 10 :f (Duration/ofMinutes 1)}]}))))
 
   (t/testing "inline table"
     (t/is (= [{:a 12, :b "foo" :c 1.2 :d nil :e true}
               {:a 100, :b "bar" :c 3.14 :d #inst "2020" :e 10}]
-             (into [] (c2/plan-ra '[:table [{:a 12, :b "foo" :c 1.2 :d nil :e true}
+             (into [] (op/plan-ra '[:table [{:a 12, :b "foo" :c 1.2 :d nil :e true}
                                             {:a 100, :b "bar" :c 3.14 :d #inst "2020" :e 10}]]
                                   {})))))
 
   (t/testing "empty"
-    (t/is (empty? (into [] (c2/plan-ra '[:table $table]
+    (t/is (empty? (into [] (op/plan-ra '[:table $table]
                                        {'$table []})))))
 
   (t/testing "requires same columns"
     (t/is (thrown? IllegalArgumentException
-                   (into [] (c2/plan-ra '[:table $table]
+                   (into [] (op/plan-ra '[:table $table]
                                         {'$table [{:a 12, :b "foo"}
                                                   {:a 100}]}))))))

--- a/core2/test/core2/test_util.clj
+++ b/core2/test/core2/test_util.clj
@@ -7,7 +7,8 @@
             [core2.relation :as rel]
             [core2.temporal :as temporal]
             [core2.types :as ty]
-            [core2.util :as util])
+            [core2.util :as util]
+            [core2.snapshot :as snap])
   (:import core2.core.Node
            core2.ICursor
            core2.object_store.FileSystemObjectStore
@@ -42,6 +43,10 @@
   (with-open [node (c2/start-node *node-opts*)]
     (binding [*node* node]
       (f))))
+
+(defn component
+  ([k] (component *node* k))
+  ([node k] (get @(:!system node) k)))
 
 (defn ->list ^java.util.List [^ValueVector v]
   (let [acc (ArrayList.)]

--- a/core2/test/core2/tpch_test.clj
+++ b/core2/test/core2/tpch_test.clj
@@ -1,11 +1,12 @@
 (ns core2.tpch-test
   (:require [clojure.java.io :as io]
             [clojure.test :as t]
-            [core2.core :as c2]
             [core2.json :as c2-json]
             [core2.test-util :as tu]
             [core2.tpch :as tpch]
-            [core2.util :as util])
+            [core2.util :as util]
+            [core2.operator :as op]
+            [core2.snapshot :as snap])
   (:import [java.nio.file Files LinkOption Path]
            [java.time Clock Duration ZoneId]))
 
@@ -23,7 +24,9 @@
                       (tu/then-await-tx node))]
       (tu/finish-chunk node)
 
-      (let [db (c2/db node {:tx last-tx, :timeout (Duration/ofMinutes 1)})]
+      (let [db (snap/snapshot (tu/component node ::snap/snapshot-factory)
+                              last-tx
+                              (Duration/ofMinutes 1))]
         (binding [*node* node, *db* db]
           (f))))))
 
@@ -47,7 +50,7 @@
 (defn run-query
   ([q] (run-query q {}))
   ([q args]
-   (into [] (c2/plan-ra q (merge {'$ *db*}
+   (into [] (op/plan-ra q (merge {'$ *db*}
                                  (::tpch/params (meta q))
                                  args)))))
 

--- a/core2/test/core2/ts_devices_small_test.clj
+++ b/core2/test/core2/ts_devices_small_test.clj
@@ -5,7 +5,9 @@
             [core2.test-util :as tu]
             [core2.ts-devices :as tsd]
             [core2.util :as util]
-            [clojure.tools.logging :as log])
+            [clojure.tools.logging :as log]
+            [core2.snapshot :as snap]
+            [core2.operator :as op])
   (:import core2.metadata.IMetadataManager
            java.time.Duration))
 
@@ -35,7 +37,7 @@
           (f))))))
 
 (t/deftest ^:timescale test-recent-battery-temperatures
-  (let [db (c2/db *node*)]
+  (let [db (snap/snapshot (tu/component ::snap/snapshot-factory))]
     (t/is (= [{:time #inst "2016-11-15T18:39:00.000-00:00",
                :device-id "demo000000",
                :battery-temperature 91.9}
@@ -66,16 +68,16 @@
               {:time #inst "2016-11-15T18:39:00.000-00:00",
                :device-id "demo000009",
                :battery-temperature 91.1}]
-             (into [] (c2/plan-ra tsd/query-recent-battery-temperatures db))))))
+             (into [] (op/plan-ra tsd/query-recent-battery-temperatures db))))))
 
 (t/deftest ^:timescale test-busiest-low-battery-devices
-  (let [db (c2/db *node*)]
+  (let [db (snap/snapshot (tu/component ::snap/snapshot-factory))]
     #_ ; TODO will fill these in once we've resolved issues in ts-devices ingest
     (t/is (= []
-             (into [] (c2/plan-ra tsd/query-busiest-low-battery-devices db))))))
+             (into [] (op/plan-ra tsd/query-busiest-low-battery-devices db))))))
 
 (t/deftest ^:timescale test-min-max-battery-levels-per-hour
-  (let [db (c2/db *node*)]
+  (let [db (snap/snapshot (tu/component ::snap/snapshot-factory))]
     #_ ; TODO will fill these in once we've resolved issues in ts-devices ingest
     (t/is (= []
-             (into [] (c2/plan-ra tsd/query-min-max-battery-levels-per-hour db))))))
+             (into [] (op/plan-ra tsd/query-min-max-battery-levels-per-hour db))))))


### PR DESCRIPTION
These are now passed as a basis-map to queries. 

* Idea is to get this change in before the remote-first API change, so that the HTTP API doesn't need to concern itself with DBs.
* Next up, I'll split out the `api` component as discussed in xtdb/xtdb#1943 before looking to finish writing the HTTP change in xtdb/core2#32. The client API isn't intended to be the final API, just the smallest change on what we have currently that can also serve as a remote client API. Aware the final version will likely be in Java too, but not a change to bring in with these PRs.
* The relational algebra engine still accepts 'snapshots', largely because it's an internal API - we could pass the basis map down further if we so wished.
* Multiple sources have temporarily been removed from the Datalog API - this is because we can only pass the query to one client (under the remote-first scheme), and clients can (currently?) only index from one tx-log. (I say 'currently?' - Datomic's client API is our prior art for a remote server indexing from multiple tx-logs)

(excerpt from README)

----

Bases

Core2 doesn't have the concept of DBs - instead, we pass the node and (optionally) a 'basis' to queries. In Core2, the upper bound for the tx-time is applied per-source; the default upper bound for VT is applied at the query level - this is because each data source has their own tx-time timeline, but VT is assumed to be a single timeline, consistent across data sources.

```clojure
;; simple case - use the latest tx the node has available:
(->> (c2/plan-query node '{...})
     (into []))

;; or, to read your own writes (timeout optional):
;; `plan-query` will await the transaction
(->> (c2/plan-query node
                    '{...}
                    {:basis-tx tx,
                     :basis-timeout (Duration/ofSeconds 1)})
     (into []))
```

The `plan-query` functions take the node, the query, optionally the basis-map, and then a variable number of params. Params are passed after the basis map if both are present:

```clojure
(->> (c2/plan-query tu/*node*
                    '{:find [?e]
                      :in [?first-name ?last-name]
                      :where [[?e :first-name ?first-name]
                              [?e :last-name ?last-name]]}
                    {:basis-tx tx}
                    "Ivan" "Ivanov")
     (into #{}))
```

`plan-query-async` is the same, except it runs entirely asynchronously and returns a `CompletableFuture` of the query plan.
(In fact, `plan-query` just calls `plan-query-async` and deref's it.)

The basis-opts can also contain a `:default-valid-time` option, which applies to any entities that don't specify other valid-time constraints. This is for repeatable queries - it defaults to 'now' if not provided.

```clojure
(->> (c2/plan-query node
                    '{:find [?e ?name]
                      :where [[?e :name ?name]]}
                    {:default-valid-time #inst "..."})
     (into []))
```
