### PR TITLE
Coalescing small cursors, #34

### DIFF
--- a/core2/core/src/core2/coalesce.clj
+++ b/core2/core/src/core2/coalesce.clj
@@ -1,0 +1,78 @@
+(ns core2.coalesce
+  (:import core2.ICursor
+           [core2.relation IAppendRelation IReadRelation]
+           java.util.function.Consumer
+           org.apache.arrow.memory.BufferAllocator)
+  (:require [core2.relation :as rel]))
+
+;; We pass the first 100 results through immediately, so that any limit-like queries don't need to wait for a full block to return rows.
+;; Then, we coalesce small blocks together into blocks of at least 100, to share the per-block costs.
+
+(deftype CoalescingCursor [^ICursor cursor
+                           ^BufferAllocator allocator
+                           ^int pass-through
+                           ^int ideal-min-block-size
+                           ^:unsynchronized-mutable ^int seen-rows]
+  ICursor
+  (tryAdvance [this c]
+    (let [!append-rel (volatile! nil)
+          !rows-appended (volatile! 0)]
+      (try
+        (loop []
+          (let [!passed-on? (volatile! false)
+                advanced? (.tryAdvance cursor (reify Consumer
+                                                (accept [_ read-rel]
+                                                  (let [^IReadRelation read-rel read-rel
+                                                        row-count (.rowCount read-rel)
+                                                        seen-rows (.seen-rows this)]
+                                                    (cond
+                                                      ;; haven't seen many rows yet, send this one straight through
+                                                      (< seen-rows pass-through)
+                                                      (do
+                                                        (set! (.seen-rows this) (+ seen-rows row-count))
+                                                        (.accept c read-rel)
+                                                        (vreset! !passed-on? true))
+
+                                                      ;; this block is big enough, and we don't have rows waiting
+                                                      ;; send it straight through, no copy.
+                                                      (and (>= row-count ideal-min-block-size)
+                                                           (nil? @!append-rel))
+                                                      (do
+                                                        (.accept c read-rel)
+                                                        (vreset! !passed-on? true))
+
+                                                      ;; otherwise, add it to the pending rows.
+                                                      :else
+                                                      (let [append-rel (vswap! !append-rel #(or % (rel/->fresh-append-relation allocator)))]
+                                                        (rel/copy-rel-from append-rel read-rel)
+                                                        (vswap! !rows-appended + row-count)))))))
+                rows-appended @!rows-appended]
+
+            (cond
+              ;; we've already passed on a block, return straight out
+              (true? @!passed-on?) true
+
+              ;; not enough rows yet, but more in the source - go around again
+              (and advanced? (< rows-appended ideal-min-block-size)) (recur)
+
+              ;; we've got rows, and either the source is done or there's enough already - send them through
+              (pos? rows-appended) (do
+                                     (.accept c (.read ^IAppendRelation @!append-rel))
+                                     true)
+
+              ;; no more rows in input, and none to pass through, we're done
+              :else false)))
+
+        (finally
+          (when-let [^IAppendRelation append-rel @!append-rel]
+            (.close append-rel))))))
+
+  (close [_]
+    (.close cursor)))
+
+(defn ^core2.ICursor ->coalescing-cursor
+  ([cursor allocator] (->coalescing-cursor cursor allocator {}))
+
+  ([cursor allocator {:keys [pass-through ideal-min-block-size]
+                      :or {pass-through 100, ideal-min-block-size 100}}]
+   (CoalescingCursor. cursor allocator pass-through ideal-min-block-size 0)))

--- a/core2/core/src/core2/operator/select.clj
+++ b/core2/core/src/core2/operator/select.clj
@@ -1,9 +1,11 @@
 (ns core2.operator.select
-  (:require [core2.relation :as rel]
+  (:require [core2.coalesce :as coalesce]
+            [core2.relation :as rel]
             [core2.util :as util])
   (:import core2.ICursor
            core2.relation.IReadRelation
-           java.util.function.Consumer))
+           java.util.function.Consumer
+           org.apache.arrow.memory.BufferAllocator))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -32,5 +34,6 @@
   (close [_]
     (util/try-close in-cursor)))
 
-(defn ->select-cursor ^core2.ICursor [^ICursor in-cursor, ^IRelationSelector selector]
-  (SelectCursor. in-cursor selector))
+(defn ->select-cursor ^core2.ICursor [^BufferAllocator allocator, ^ICursor in-cursor, ^IRelationSelector selector]
+  (-> (SelectCursor. in-cursor selector)
+      (coalesce/->coalescing-cursor allocator)))

--- a/core2/core/src/core2/relation.clj
+++ b/core2/core/src/core2/relation.clj
@@ -4,13 +4,13 @@
   (:import [core2.relation IAppendColumn IAppendRelation IReadColumn IReadRelation]
            java.nio.ByteBuffer
            java.time.Duration
-           [java.util ArrayList Collection Date Set HashMap HashSet LinkedHashMap List Map Map$Entry Set]
+           [java.util ArrayList Collection Date HashMap HashSet LinkedHashMap List Map Map$Entry Set]
            java.util.function.Function
            [java.util.stream IntStream IntStream$Builder]
            org.apache.arrow.memory.BufferAllocator
            [org.apache.arrow.vector BaseVariableWidthVector BigIntVector BitVector DurationVector Float8Vector NullVector TimeStampMilliVector ValueVector VarBinaryVector VarCharVector VectorSchemaRoot]
            org.apache.arrow.vector.complex.DenseUnionVector
-           [org.apache.arrow.vector.types.pojo ArrowType Field FieldType]))
+           [org.apache.arrow.vector.types.pojo ArrowType Field]))
 
 (definterface IAppendColumnPrivate
   (^org.apache.arrow.vector.ValueVector _getAppendVector [^org.apache.arrow.vector.types.pojo.ArrowType arrowType])

--- a/core2/core/test/core2/coalesce_test.clj
+++ b/core2/core/test/core2/coalesce_test.clj
@@ -1,0 +1,36 @@
+(ns core2.coalesce-test
+  (:require [clojure.test :as t]
+            [core2.coalesce :as coalesce]
+            [core2.test-util :as tu]
+            [core2.types :as types])
+  (:import core2.ICursor
+           org.apache.arrow.vector.types.pojo.Schema))
+
+(t/use-fixtures :each tu/with-allocator)
+
+(def ^:private schema (Schema. [(types/->field "foo" (types/->arrow-type :varchar) false)]))
+
+(t/deftest test-coalesce
+  (letfn [(coalesced-counts [counts]
+            (with-open [^ICursor cursor (let [inner (tu/->cursor schema (for [cnt counts]
+                                                                          (repeat cnt {:foo "foo"})))]
+                                          (try
+                                            (-> inner
+                                                (coalesce/->coalescing-cursor tu/*allocator*
+                                                                              {:pass-through 5, :ideal-min-block-size 10}))
+                                            (catch Throwable t
+                                              (.close inner)
+                                              (throw t))))]
+              (mapv count (tu/<-cursor cursor))))]
+
+    (t/is (= [] (coalesced-counts [])))
+    (t/is (= [1] (coalesced-counts [1])))
+    (t/is (= [6] (coalesced-counts [6])))
+
+    (t/is (= [4 2 12] (coalesced-counts [4 2 3 3 3 3]))
+          "after 5, coalesces small blocks")
+
+    (t/is (= [4 2 12 6] (coalesced-counts [4 2
+                                           3 3 3 3
+                                           3 3]))
+          "passes through incomplete final block")))

--- a/core2/core/test/core2/operator/select_test.clj
+++ b/core2/core/test/core2/operator/select_test.clj
@@ -17,7 +17,7 @@
                                       {:a 0, :b 15}]
                                      [{:a 100, :b 83}]
                                      [{:a 83, :b 100}]])
-                select-cursor (select/->select-cursor cursor
+                select-cursor (select/->select-cursor tu/*allocator* cursor
                                                       (reify IRelationSelector
                                                         (select [_ in-rel]
                                                           (let [idxs (RoaringBitmap.)

--- a/core2/core/test/core2/operator/set_test.clj
+++ b/core2/core/test/core2/operator/set_test.clj
@@ -171,6 +171,7 @@
                                 (reify core2.operator.set.IFixpointCursorFactory
                                   (createCursor [_ cursor-factory]
                                     (select/->select-cursor
+                                     tu/*allocator*
                                      (project/->project-cursor
                                       tu/*allocator*
                                       (.createCursor cursor-factory)


### PR DESCRIPTION
We coalesce small cursors in the query engine to better spread the per-block costs of each of the operators.

* Applies to scan and select cursors.
* Passes through a few blocks to begin with (until we've seen 100 rows) - if the user has a top-n query we don't want to wait around for more rows when they're going to be discarded.

resolves xtdb/xtdb#1960 