### PR TITLE
expression engine uses ArrowTypes rather than classes

### DIFF
--- a/core2/core/src/core2/expression.clj
+++ b/core2/core/src/core2/expression.clj
@@ -16,6 +16,10 @@
            [java.time.temporal ChronoField ChronoUnit]
            [java.util Date LinkedHashMap]
            org.apache.arrow.vector.BaseVariableWidthVector
+           [org.apache.arrow.vector.types.pojo
+            ArrowType$Bool ArrowType$Int ArrowType$FloatingPoint
+            ArrowType$Binary ArrowType$Utf8
+            ArrowType$Timestamp ArrowType$Duration]
            org.roaringbitmap.RoaringBitmap))
 
 (set! *unchecked-math* :warn-on-boxed)
@@ -137,30 +141,16 @@
                       (distinct)))))
 
 (def type->cast
-  {Long 'long
-   Double 'double
-   Date 'long
-   Duration 'long
-   Boolean 'boolean})
-
-(def ^:private type->boxed-type {Double/TYPE Double
-                                 Long/TYPE Long
-                                 Boolean/TYPE Boolean})
+  {(types/->arrow-type :bigint) 'long
+   (types/->arrow-type :float8) 'double
+   (types/->arrow-type :timestamp-milli) 'long
+   (types/->arrow-type :duration-milli) 'long
+   (types/->arrow-type :bit) 'boolean})
 
 (def idx-sym (gensym "idx"))
 
-(def numeric-types
-  #{Long Double})
-
-(defn- widen-numeric-types [type-x type-y]
-  (when (and (.isAssignableFrom Number type-x)
-             (.isAssignableFrom Number type-y))
-    (if (and (= type-x Long) (= type-y Long))
-      Long
-      Double)))
-
 (defmulti codegen-expr
-  (fn [{:keys [op]} {:keys [var->types]}]
+  (fn [{:keys [op]} {:keys [var->type]}]
     op))
 
 (defn resolve-string ^String [x]
@@ -175,10 +165,8 @@
     x))
 
 (defmethod codegen-expr :param [{:keys [param] :as expr} {:keys [param->type]}]
-  (let [return-type (get types/arrow-type->java-type
-                         (or (get param->type param)
-                             (throw (IllegalArgumentException. (str "parameter not provided: " param))))
-                         Comparable)]
+  (let [return-type (or (get param->type param)
+                        (throw (IllegalArgumentException. (str "parameter not provided: " param))))]
     (into {:code param
            :return-type return-type}
           (select-keys expr #{:literal}))))
@@ -209,237 +197,235 @@
         end-offset (.getInt offset-buffer (+ offset-idx BaseVariableWidthVector/OFFSET_WIDTH))]
     (.nioBuffer value-buffer offset (- end-offset offset))))
 
-(defn get-value-form [arrow-type vec-sym idx-sym]
-  `(let [~(-> vec-sym
-              (with-tag (-> arrow-type types/arrow-type->vector-type)))
-         ~vec-sym]
-     ~(condp = (types/<-arrow-type arrow-type)
-        :bit `(= 1 (.get ~vec-sym ~idx-sym))
-        :bigint `(.get ~vec-sym ~idx-sym)
-        :float8 `(.get ~vec-sym ~idx-sym)
-        :varchar `(element->nio-buffer ~vec-sym ~idx-sym)
-        :varbinary `(element->nio-buffer ~vec-sym ~idx-sym)
-        :timestamp-milli `(.get ~vec-sym ~idx-sym)
-        :duration-milli `(.get ~vec-sym ~idx-sym)
-        `(normalize-union-value (.getObject ~vec-sym ~idx-sym)))))
+(defmulti get-value-form
+  (fn [arrow-type vec-sym idx-sym]
+    (class arrow-type)))
 
-(defmethod codegen-expr :variable [{:keys [variable]} {:keys [var->types]}]
-  (let [var-types (or (get var->types variable)
-                      (throw (IllegalArgumentException. (str "unknown variable: " variable))))
-        var-type (or (when (= 1 (count var-types))
-                       (get types/arrow-type->java-type (first var-types)))
-                     Comparable)
-        arrow-type (types/class->arrow-type var-type)
+(defmethod get-value-form ArrowType$Bool [_ vec-sym idx-sym] `(= 1 (.get ~vec-sym ~idx-sym)))
+(defmethod get-value-form ArrowType$FloatingPoint [_ vec-sym idx-sym] `(.get ~vec-sym ~idx-sym))
+(defmethod get-value-form ArrowType$Int [_ vec-sym idx-sym] `(.get ~vec-sym ~idx-sym))
+(defmethod get-value-form ArrowType$Timestamp [_ vec-sym idx-sym] `(.get ~vec-sym ~idx-sym))
+(defmethod get-value-form ArrowType$Duration [_ vec-sym idx-sym] `(.get ~vec-sym ~idx-sym))
+(defmethod get-value-form ArrowType$Utf8 [_ vec-sym idx-sym] `(element->nio-buffer ~vec-sym ~idx-sym))
+(defmethod get-value-form ArrowType$Binary [_ vec-sym idx-sym] `(element->nio-buffer ~vec-sym ~idx-sym))
+(defmethod get-value-form :default [_ vec-sym idx-sym] `(normalize-union-value (.getObject ~vec-sym ~idx-sym)))
+
+(defmethod codegen-expr :variable [{:keys [variable]} {:keys [var->type]}]
+  (let [arrow-type (or (get var->type variable)
+                       (throw (IllegalArgumentException. (str "unknown variable: " variable))))
         vec-sym (gensym 'vec)]
     ;; TODO the `reader-for-type` call doesn't need to be per-elem
-    {:code `(let [~vec-sym (-> ~variable
-                               (rel/reader-for-type (-> ~(types/<-arrow-type arrow-type)
-                                                        (types/->arrow-type)))
-                               (.getVector))
+    {:code `(let [~(-> vec-sym
+                       (with-tag (or (-> arrow-type types/arrow-type->vector-type)
+                                     (throw (UnsupportedOperationException.)))))
+                  (-> ~variable
+                      (rel/reader-for-type (-> ~(types/<-arrow-type arrow-type)
+                                               (types/->arrow-type)))
+                      (.getVector))
                   ~idx-sym (.getIndex ~variable ~idx-sym)]
               ~(get-value-form arrow-type vec-sym idx-sym))
-     :return-type var-type}))
+     :return-type arrow-type}))
 
 (defmethod codegen-expr :if [{:keys [pred then else]} _]
-  (let [{then-type :return-type} then
-        {else-type :return-type} else
-        return-type (if (= then-type else-type)
-                      then-type
-                      (or (widen-numeric-types then-type else-type)
-                          Comparable))
+  (let [return-type (types/least-upper-bound [(:return-type then) (:return-type else)])
         cast (get type->cast return-type)]
-    {:code (cond->> `(~'if ~(:code pred) ~(:code then) ~(:code else))
+    {:code (cond->> (list 'if (:code pred) (:code then) (:code else))
              cast (list cast))
      :return-type return-type}))
 
 (defmulti codegen-call
   (fn [{:keys [f arg-types]}]
-    (vec (cons (keyword (name f)) arg-types))))
+    (vec (cons (keyword (name f)) (map class arg-types))))
+  :hierarchy #'types/arrow-type-hierarchy)
 
 (defmethod codegen-expr :call [{:keys [args] :as expr} _]
   (codegen-call (-> expr
                     (assoc :emitted-args (mapv :code args)
                            :arg-types (mapv :return-type args)))))
 
-(defmethod codegen-call [:= Number Number] [{:keys [emitted-args]}]
+(defmethod codegen-call [:= ::types/Number ::types/Number] [{:keys [emitted-args]}]
   {:code `(== ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:= Object Object] [{:keys [emitted-args]}]
+(defmethod codegen-call [:= ::types/Object ::types/Object] [{:keys [emitted-args]}]
   {:code `(= ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:!= Object Object] [{:keys [emitted-args]}]
+(prefer-method codegen-call [:= ::types/Number ::types/Number] [:= ::types/Object ::types/Object])
+
+(defmethod codegen-call [:!= ::types/Object ::types/Object] [{:keys [emitted-args]}]
   {:code `(not= ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:< Number Number] [{:keys [emitted-args]}]
+(prefer-method codegen-call [:!= ::types/Number ::types/Number] [:!= ::types/Object ::types/Object])
+
+(defmethod codegen-call [:< ::types/Number ::types/Number] [{:keys [emitted-args]}]
   {:code `(< ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:< Date Date] [{:keys [emitted-args]}]
+(defmethod codegen-call [:< ArrowType$Timestamp ArrowType$Timestamp] [{:keys [emitted-args]}]
   {:code `(< ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:< Duration Duration] [{:keys [emitted-args]}]
+(defmethod codegen-call [:< ArrowType$Duration ArrowType$Duration] [{:keys [emitted-args]}]
   {:code `(< ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:< Comparable Comparable] [{:keys [emitted-args]}]
+(defmethod codegen-call [:< ::types/Object ::types/Object] [{:keys [emitted-args]}]
   {:code `(neg? (compare ~@emitted-args))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:< types/byte-array-class types/byte-array-class] [{:keys [emitted-args]}]
+(defmethod codegen-call [:< ArrowType$Binary ArrowType$Binary] [{:keys [emitted-args]}]
   {:code `(neg? (compare-nio-buffers-unsigned ~@emitted-args))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:< String String] [{:keys [emitted-args]}]
+(defmethod codegen-call [:< ArrowType$Utf8 ArrowType$Utf8] [{:keys [emitted-args]}]
   {:code `(neg? (compare-nio-buffers-unsigned ~@emitted-args))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(prefer-method codegen-call [:< Number Number] [:< Comparable Comparable])
-(prefer-method codegen-call [:< Date Date] [:< Comparable Comparable])
-(prefer-method codegen-call [:< Duration Duration] [:< Comparable Comparable])
-(prefer-method codegen-call [:< String String] [:< Comparable Comparable])
+(prefer-method codegen-call [:< ::types/Number ::types/Number] [:< ::types/Object ::types/Object])
+(prefer-method codegen-call [:< ArrowType$Timestamp ArrowType$Timestamp] [:< ::types/Object ::types/Object])
+(prefer-method codegen-call [:< ArrowType$Duration ArrowType$Duration] [:< ::types/Object ::types/Object])
+(prefer-method codegen-call [:< ArrowType$Utf8 ArrowType$Utf8] [:< ::types/Object ::types/Object])
 
-(defmethod codegen-call [:<= Number Number] [{:keys [emitted-args]}]
+(defmethod codegen-call [:<= ::types/Number ::types/Number] [{:keys [emitted-args]}]
   {:code `(<= ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:<= Date Date] [{:keys [emitted-args]}]
+(defmethod codegen-call [:<= ArrowType$Timestamp ArrowType$Timestamp] [{:keys [emitted-args]}]
   {:code `(<= ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:<= Duration Duration] [{:keys [emitted-args]}]
+(defmethod codegen-call [:<= ArrowType$Duration ArrowType$Duration] [{:keys [emitted-args]}]
   {:code `(<= ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:<= Comparable Comparable] [{:keys [emitted-args]}]
+(defmethod codegen-call [:<= ::types/Object ::types/Object] [{:keys [emitted-args]}]
   {:code `(not (pos? (compare ~@emitted-args)))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:<= types/byte-array-class types/byte-array-class] [{:keys [emitted-args]}]
+(defmethod codegen-call [:<= ArrowType$Binary ArrowType$Binary] [{:keys [emitted-args]}]
   {:code `(not (pos? (compare-nio-buffers-unsigned ~@emitted-args)))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:<= String String] [{:keys [emitted-args]}]
+(defmethod codegen-call [:<= ArrowType$Utf8 ArrowType$Utf8] [{:keys [emitted-args]}]
   {:code `(not (pos? (compare-nio-buffers-unsigned ~@emitted-args)))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(prefer-method codegen-call [:<= Number Number] [:<= Comparable Comparable])
-(prefer-method codegen-call [:<= Date Date] [:<= Comparable Comparable])
-(prefer-method codegen-call [:<= Duration Duration] [:<= Comparable Comparable])
-(prefer-method codegen-call [:<= String String] [:<= Comparable Comparable])
+(prefer-method codegen-call [:<= ::types/Number ::types/Number] [:<= ::types/Object ::types/Object])
+(prefer-method codegen-call [:<= ArrowType$Timestamp ArrowType$Timestamp] [:<= ::types/Object ::types/Object])
+(prefer-method codegen-call [:<= ArrowType$Duration ArrowType$Duration] [:<= ::types/Object ::types/Object])
+(prefer-method codegen-call [:<= ArrowType$Utf8 ArrowType$Utf8] [:<= ::types/Object ::types/Object])
 
-(defmethod codegen-call [:> Number Number] [{:keys [emitted-args]}]
+(defmethod codegen-call [:> ::types/Number ::types/Number] [{:keys [emitted-args]}]
   {:code `(> ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:> Date Date] [{:keys [emitted-args]}]
+(defmethod codegen-call [:> ArrowType$Timestamp ArrowType$Timestamp] [{:keys [emitted-args]}]
   {:code `(> ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:> Duration Duration] [{:keys [emitted-args]}]
+(defmethod codegen-call [:> ArrowType$Duration ArrowType$Duration] [{:keys [emitted-args]}]
   {:code `(> ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:> Comparable Comparable] [{:keys [emitted-args]}]
+(defmethod codegen-call [:> ::types/Object ::types/Object] [{:keys [emitted-args]}]
   {:code `(pos? (compare ~@emitted-args))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:> types/byte-array-class types/byte-array-class] [{:keys [emitted-args]}]
+(defmethod codegen-call [:> ArrowType$Binary ArrowType$Binary] [{:keys [emitted-args]}]
   {:code `(pos? (compare-nio-buffers-unsigned ~@emitted-args))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:> String String] [{:keys [emitted-args]}]
+(defmethod codegen-call [:> ArrowType$Utf8 ArrowType$Utf8] [{:keys [emitted-args]}]
   {:code `(pos? (compare-nio-buffers-unsigned ~@emitted-args))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(prefer-method codegen-call [:> Number Number] [:> Comparable Comparable])
-(prefer-method codegen-call [:> Date Date] [:> Comparable Comparable])
-(prefer-method codegen-call [:> Duration Duration] [:> Comparable Comparable])
-(prefer-method codegen-call [:> String String] [:> Comparable Comparable])
+(prefer-method codegen-call [:> ::types/Number ::types/Number] [:> ::types/Object ::types/Object])
+(prefer-method codegen-call [:> ArrowType$Timestamp ArrowType$Timestamp] [:> ::types/Object ::types/Object])
+(prefer-method codegen-call [:> ArrowType$Duration ArrowType$Duration] [:> ::types/Object ::types/Object])
+(prefer-method codegen-call [:> ArrowType$Utf8 ArrowType$Utf8] [:> ::types/Object ::types/Object])
 
-(defmethod codegen-call [:>= Number Number] [{:keys [emitted-args]}]
+(defmethod codegen-call [:>= ::types/Number ::types/Number] [{:keys [emitted-args]}]
   {:code `(>= ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:>= Date Date] [{:keys [emitted-args]}]
+(defmethod codegen-call [:>= ArrowType$Timestamp ArrowType$Timestamp] [{:keys [emitted-args]}]
   {:code `(>= ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:>= Duration Duration] [{:keys [emitted-args]}]
+(defmethod codegen-call [:>= ArrowType$Duration ArrowType$Duration] [{:keys [emitted-args]}]
   {:code `(>= ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:>= Comparable Comparable] [{:keys [emitted-args]}]
+(defmethod codegen-call [:>= ::types/Object ::types/Object] [{:keys [emitted-args]}]
   {:code `(not (neg? (compare ~@emitted-args)))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:>= types/byte-array-class types/byte-array-class] [{:keys [emitted-args]}]
+(defmethod codegen-call [:>= ArrowType$Binary ArrowType$Binary] [{:keys [emitted-args]}]
   {:code `(not (neg? (compare-nio-buffers-unsigned ~@emitted-args)))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:>= String String] [{:keys [emitted-args]}]
+(defmethod codegen-call [:>= ArrowType$Utf8 ArrowType$Utf8] [{:keys [emitted-args]}]
   {:code `(not (neg? (compare-nio-buffers-unsigned ~@emitted-args)))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(prefer-method codegen-call [:>= Number Number] [:>= Comparable Comparable])
-(prefer-method codegen-call [:>= Date Date] [:>= Comparable Comparable])
-(prefer-method codegen-call [:>= Duration Duration] [:>= Comparable Comparable])
-(prefer-method codegen-call [:>= String String] [:>= Comparable Comparable])
+(prefer-method codegen-call [:>= ::types/Number ::types/Number] [:>= ::types/Object ::types/Object])
+(prefer-method codegen-call [:>= ArrowType$Timestamp ArrowType$Timestamp] [:>= ::types/Object ::types/Object])
+(prefer-method codegen-call [:>= ArrowType$Duration ArrowType$Duration] [:>= ::types/Object ::types/Object])
+(prefer-method codegen-call [:>= ArrowType$Utf8 ArrowType$Utf8] [:>= ::types/Object ::types/Object])
 
-(defmethod codegen-call [:and Boolean Boolean] [{:keys [emitted-args]}]
+(defmethod codegen-call [:and ArrowType$Bool ArrowType$Bool] [{:keys [emitted-args]}]
   {:code `(and ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:or Boolean Boolean] [{:keys [emitted-args]}]
+(defmethod codegen-call [:or ArrowType$Bool ArrowType$Bool] [{:keys [emitted-args]}]
   {:code `(or ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:not Boolean] [{:keys [emitted-args]}]
+(defmethod codegen-call [:not ArrowType$Bool] [{:keys [emitted-args]}]
   {:code `(not ~@emitted-args)
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:+ Number Number] [{:keys [emitted-args], [x-type y-type] :arg-types}]
+(defmethod codegen-call [:+ ::types/Number ::types/Number] [{:keys [emitted-args arg-types]}]
   {:code `(+ ~@emitted-args)
-   :return-type (widen-numeric-types x-type y-type)})
+   :return-type (types/least-upper-bound arg-types)})
 
-(defmethod codegen-call [:- Number Number] [{:keys [emitted-args], [x-type y-type] :arg-types}]
+(defmethod codegen-call [:- ::types/Number ::types/Number] [{:keys [emitted-args arg-types]}]
   {:code `(- ~@emitted-args)
-   :return-type (widen-numeric-types x-type y-type)})
+   :return-type (types/least-upper-bound arg-types)})
 
-(defmethod codegen-call [:- Number] [{:keys [emitted-args], [x-type] :arg-types}]
+(defmethod codegen-call [:- ::types/Number] [{:keys [emitted-args], [x-type] :arg-types}]
   {:code `(- ~@emitted-args)
    :return-type x-type})
 
-(defmethod codegen-call [:* Number Number] [{:keys [emitted-args], [x-type y-type] :arg-types}]
+(defmethod codegen-call [:* ::types/Number ::types/Number] [{:keys [emitted-args arg-types]}]
   {:code `(* ~@emitted-args)
-   :return-type (widen-numeric-types x-type y-type)})
+   :return-type (types/least-upper-bound arg-types)})
 
-(defmethod codegen-call [:% Number Number] [{:keys [emitted-args], [x-type y-type] :arg-types}]
+(defmethod codegen-call [:% ::types/Number ::types/Number] [{:keys [emitted-args arg-types]}]
   {:code `(mod ~@emitted-args)
-   :return-type (widen-numeric-types x-type y-type)})
+   :return-type (types/least-upper-bound arg-types)})
 
-(defmethod codegen-call [:/ Number Number] [{:keys [emitted-args], [x-type y-type] :arg-types}]
+(defmethod codegen-call [:/ ::types/Number ::types/Number] [{:keys [emitted-args arg-types]}]
   {:code `(/ ~@emitted-args)
-   :return-type (widen-numeric-types x-type y-type)})
+   :return-type (types/least-upper-bound arg-types)})
 
-(defmethod codegen-call [:/ Long Long] [{:keys [emitted-args]}]
+(defmethod codegen-call [:/ ArrowType$Int ArrowType$Int] [{:keys [emitted-args arg-types]}]
   {:code `(quot ~@emitted-args)
-   :return-type Long})
+   :return-type (types/least-upper-bound arg-types)})
 
-(defmethod codegen-call [:like Comparable String] [{[{x :code} {:keys [literal]}] :args}]
+(defmethod codegen-call [:like ::types/Object ArrowType$Utf8] [{[{x :code} {:keys [literal]}] :args}]
   {:code `(boolean (re-find ~(re-pattern (str "^" (str/replace literal #"%" ".*") "$"))
                             (resolve-string ~x)))
-   :return-type Boolean})
+   :return-type ArrowType$Bool/INSTANCE})
 
-(defmethod codegen-call [:substr Comparable Long Long] [{[{x :code} {start :code} {length :code}] :args}]
+(defmethod codegen-call [:substr ::types/Object ArrowType$Int ArrowType$Int] [{[{x :code} {start :code} {length :code}] :args}]
   {:code `(ByteBuffer/wrap (.getBytes (subs (resolve-string ~x) (dec ~start) (+ (dec ~start) ~length))
                                       StandardCharsets/UTF_8))
-   :return-type String})
+   :return-type ArrowType$Utf8/INSTANCE})
 
-(defmethod codegen-call [:extract String Date] [{[{field :literal} {x :code}] :args}]
+(defmethod codegen-call [:extract ArrowType$Utf8 ArrowType$Timestamp] [{[{field :literal} {x :code}] :args}]
   {:code `(.get (.atOffset (Instant/ofEpochMilli ~x) ZoneOffset/UTC)
                 ~(case field
                    "YEAR" `ChronoField/YEAR
@@ -447,9 +433,9 @@
                    "DAY" `ChronoField/DAY_OF_MONTH
                    "HOUR" `ChronoField/HOUR_OF_DAY
                    "MINUTE" `ChronoField/MINUTE_OF_HOUR))
-   :return-type Long})
+   :return-type (types/->arrow-type :bigint)})
 
-(defmethod codegen-call [:date-trunc String Date] [{[{field :literal} {x :code}] :args}]
+(defmethod codegen-call [:date-trunc ArrowType$Utf8 ArrowType$Timestamp] [{[{field :literal} {x :code, date-type :return-type}] :args}]
   {:code `(.toEpochMilli (.truncatedTo (Instant/ofEpochMilli ~x)
                                        ~(case field
                                           ;; can't truncate instants to years/months
@@ -457,16 +443,21 @@
                                           "HOUR" `ChronoUnit/HOURS
                                           "MINUTE" `ChronoUnit/MINUTES
                                           "SECOND" `ChronoUnit/SECONDS)))
-   :return-type Date})
+   :return-type date-type})
+
+(def ^:private type->arrow-type
+  {Double/TYPE (types/->arrow-type :float8)
+   Long/TYPE (types/->arrow-type :bigint)
+   Boolean/TYPE ArrowType$Bool/INSTANCE})
 
 (doseq [^Method method (.getDeclaredMethods Math)
         :let [math-op (.getName method)
-              boxed-types (map type->boxed-type (.getParameterTypes method))
-              boxed-return-type (get type->boxed-type (.getReturnType method))]
-        :when (and boxed-return-type (every? some? boxed-types))]
-  (defmethod codegen-call (vec (cons (keyword math-op) boxed-types)) [{:keys [emitted-args]}]
+              param-types (map type->arrow-type (.getParameterTypes method))
+              return-type (get type->arrow-type (.getReturnType method))]
+        :when (and return-type (every? some? param-types))]
+  (defmethod codegen-call (vec (cons (keyword math-op) (map class param-types))) [{:keys [emitted-args]}]
     {:code `(~(symbol "Math" math-op) ~@emitted-args)
-     :return-type boxed-return-type}))
+     :return-type return-type}))
 
 (defn normalize-union-value [v]
   (cond
@@ -496,8 +487,8 @@
                        (util/into-linked-map
                         (util/map-entries (fn [param-k param-v]
                                             (let [arrow-type (types/class->arrow-type (class param-v))
-                                                  normalized-expr-type (class (normalize-union-value param-v))
-                                                  primitive-tag (get type->cast normalized-expr-type)]
+                                                  normalized-expr-type (normalize-union-value param-v)
+                                                  primitive-tag (get type->cast (types/class->arrow-type (class normalized-expr-type)))]
                                               (MapEntry/create (cond-> param-k
                                                                  primitive-tag (with-tag primitive-tag))
                                                                arrow-type))))))
@@ -513,67 +504,50 @@
          (map (fn [variable]
                (MapEntry/create variable (.columnReader in-rel (name variable))))))))
 
-(def ^:private return-type->type-kw
-  {Boolean :bit
-   Long :bigint
-   Double :float8
-   String :varchar
-   types/byte-array-class :varbinary
-   Date :timestamp-milli
-   Duration :duration-milli})
-
 (defmulti set-value-form
-  (fn [return-type-kw out-vec-sym idx-sym code]
-    return-type-kw))
+  (fn [arrow-type out-vec-sym idx-sym code]
+    (class arrow-type)))
 
-(defmethod set-value-form Boolean [_ out-vec-sym idx-sym code]
+(defmethod set-value-form ArrowType$Bool [_ out-vec-sym idx-sym code]
   `(.set ~out-vec-sym ~idx-sym (if ~code 1 0)))
 
-(defmethod set-value-form Long [_ out-vec-sym idx-sym code]
+(defmethod set-value-form ArrowType$Int [_ out-vec-sym idx-sym code]
   `(.set ~out-vec-sym ~idx-sym (long ~code)))
 
-(defmethod set-value-form Double [_ out-vec-sym idx-sym code]
+(defmethod set-value-form ArrowType$FloatingPoint [_ out-vec-sym idx-sym code]
   `(.set ~out-vec-sym ~idx-sym (double ~code)))
 
-(defmethod set-value-form String [_ out-vec-sym idx-sym code]
+(defmethod set-value-form ArrowType$Utf8 [_ out-vec-sym idx-sym code]
   `(let [buf# ~code]
      (.setSafe ~out-vec-sym ~idx-sym buf#
                (.position buf#) (.remaining buf#))))
 
-(defmethod set-value-form types/byte-array-class [_ out-vec-sym idx-sym code]
+(defmethod set-value-form ArrowType$Binary [_ out-vec-sym idx-sym code]
   `(let [buf# ~code]
      (.setSafe ~out-vec-sym ~idx-sym buf#
                (.position buf#) (.remaining buf#))))
 
-(defmethod set-value-form Date [_ out-vec-sym idx-sym code]
+(defmethod set-value-form ArrowType$Timestamp [_ out-vec-sym idx-sym code]
   `(.set ~out-vec-sym ~idx-sym ~code))
 
-(defmethod set-value-form Duration [_ out-vec-sym idx-sym code]
+(defmethod set-value-form ArrowType$Duration [_ out-vec-sym idx-sym code]
   `(.set ~out-vec-sym ~idx-sym ~code))
 
-(defn- generate-projection [col-name expr var-types param-types]
-  (let [codegen-opts {:var->types var-types, :param->type param-types}
+(defn- generate-projection [expr var-types param-types]
+  (let [codegen-opts {:var->type var-types, :param->type param-types}
         {:keys [code return-type]} (postwalk-expr #(codegen-expr % codegen-opts) expr)
         variables (->> (keys var-types)
                        (map #(with-tag % IColumnReader)))
 
-        allocator-sym (gensym 'allocator)
         out-vec-sym (gensym 'out-vec)]
 
-    `(fn [~allocator-sym [~@variables] [~@(keys param-types)] ^long row-count#]
-       (let [~(-> out-vec-sym
-                  (with-tag (-> return-type types/class->arrow-type types/arrow-type->vector-type)))
-             ~(if-let [type-kw (return-type->type-kw return-type)]
-                `(.createVector (types/->field ~col-name (types/->arrow-type ~type-kw) false)
-                                ~allocator-sym)
-                `(throw (UnsupportedOperationException.)))]
+    {:code `(fn [~(-> out-vec-sym
+                      (with-tag (-> return-type types/arrow-type->vector-type)))
+                 [~@variables] [~@(keys param-types)] ^long row-count#]
 
-         (.setValueCount ~out-vec-sym row-count#)
-
-         (dotimes [~idx-sym row-count#]
-           ~(set-value-form return-type out-vec-sym idx-sym code))
-
-         (rel/vec->reader ~out-vec-sym)))))
+              (dotimes [~idx-sym row-count#]
+                ~(set-value-form return-type out-vec-sym idx-sym code)))
+     :return-type return-type}))
 
 (def ^:private memo-generate-projection (memoize generate-projection))
 (def ^:private memo-eval (memoize eval))
@@ -587,18 +561,23 @@
               var-types (->> in-cols
                              (util/into-linked-map
                               (util/map-values (fn [_variable ^IColumnReader read-col]
-                                                 (rel/col->arrow-types read-col)))))
-              expr-fn (-> (memo-generate-projection col-name expr var-types param-types)
-                          (memo-eval))]
-          (expr-fn allocator (vals in-cols) (vals emitted-params) (.rowCount in-rel)))))))
+                                                 (->> (rel/col->arrow-types read-col)
+                                                      (types/least-upper-bound))))))
+              {:keys [code return-type]} (memo-generate-projection expr var-types param-types)
+              expr-fn (memo-eval code)
+              out-vec (.createVector (types/->field col-name return-type false) allocator)
+              row-count (.rowCount in-rel)]
+          (.setValueCount out-vec row-count)
+          (expr-fn out-vec (vals in-cols) (vals emitted-params) row-count)
+          (rel/vec->reader out-vec))))))
 
 (defn- generate-selection [expr var-types param-types]
-  (let [codegen-opts {:var->types var-types, :param->type param-types}
+  (let [codegen-opts {:var->type var-types, :param->type param-types}
         {:keys [code return-type]} (postwalk-expr #(codegen-expr % codegen-opts) expr)
         variables (->> (keys var-types)
                        (map #(with-tag % IColumnReader)))]
 
-    (assert (= Boolean return-type))
+    (assert (= ArrowType$Bool/INSTANCE return-type))
     `(fn [[~@variables] [~@(keys param-types)] ^long row-count#]
        (let [acc# (RoaringBitmap.)]
          (dotimes [~idx-sym row-count#]
@@ -620,7 +599,8 @@
                 var-types (->> in-cols
                                (util/into-linked-map
                                 (util/map-values (fn [_variable ^IColumnReader read-col]
-                                                   (rel/col->arrow-types read-col)))))
+                                                   (->> (rel/col->arrow-types read-col)
+                                                        (types/least-upper-bound))))))
                 expr-code (memo-generate-selection expr var-types param-types)
                 expr-fn (memo-eval expr-code)]
             (expr-fn (vals in-cols) (vals emitted-params) (.rowCount in)))
@@ -638,7 +618,8 @@
           (let [in-cols (doto (LinkedHashMap.)
                           (.put variable in-col))
                 var-types (doto (LinkedHashMap.)
-                            (.put variable (rel/col->arrow-types in-col)))
+                            (.put variable (->> (rel/col->arrow-types in-col)
+                                                (types/least-upper-bound))))
                 expr-code (memo-generate-selection expr var-types param-types)
                 expr-fn (memo-eval expr-code)]
             (expr-fn (vals in-cols) (vals emitted-params) (.getValueCount in-col)))

--- a/core2/core/src/core2/expression/comparator.clj
+++ b/core2/core/src/core2/expression/comparator.clj
@@ -1,9 +1,7 @@
 (ns core2.expression.comparator
   (:require [core2.expression :as expr]
             [core2.types :as types])
-  (:import core2.relation.IColumnReader
-           java.util.Date
-           org.apache.arrow.vector.types.pojo.ArrowType))
+  (:import [org.apache.arrow.vector.types.pojo ArrowType ArrowType$Binary ArrowType$Bool ArrowType$Int ArrowType$Timestamp ArrowType$Utf8]))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -11,54 +9,52 @@
   (^int compareIdx [^org.apache.arrow.vector.ValueVector left-vec, ^int left-idx,
                     ^org.apache.arrow.vector.ValueVector right-vec, ^int right-idx]))
 
-(defmethod expr/codegen-call [:compare Long Long] [{:keys [emitted-args]}]
+(defmethod expr/codegen-call [:compare ArrowType$Int ArrowType$Int] [{:keys [emitted-args]}]
   {:code `(Long/compare ~@emitted-args)
-   :return-type Long})
+   :return-type (types/->arrow-type :bigint)})
 
-(defmethod expr/codegen-call [:compare Double Double] [{:keys [emitted-args]}]
+(defmethod expr/codegen-call [:compare ::types/Number ::types/Number] [{:keys [emitted-args]}]
   {:code `(Double/compare ~@emitted-args)
-   :return-type Long})
+   :return-type (types/->arrow-type :bigint)})
 
-(defmethod expr/codegen-call [:compare Number Number] [{:keys [emitted-args]}]
-  {:code `(Double/compare ~@emitted-args)
-   :return-type Long})
-
-(defmethod expr/codegen-call [:compare Date Date] [{:keys [emitted-args]}]
+(defmethod expr/codegen-call [:compare ArrowType$Timestamp ArrowType$Timestamp] [{:keys [emitted-args]}]
   {:code `(Long/compare ~@emitted-args)
-   :return-type Long})
+   :return-type (types/->arrow-type :bigint)})
 
-(defmethod expr/codegen-call [:compare types/byte-array-class types/byte-array-class] [{:keys [emitted-args]}]
+(defmethod expr/codegen-call [:compare ArrowType$Binary ArrowType$Binary] [{:keys [emitted-args]}]
   {:code `(expr/compare-nio-buffers-unsigned ~@emitted-args)
-   :return-type Long})
+   :return-type (types/->arrow-type :bigint)})
 
-(defmethod expr/codegen-call [:compare Boolean Boolean] [{:keys [emitted-args]}]
+(defmethod expr/codegen-call [:compare ArrowType$Bool ArrowType$Bool] [{:keys [emitted-args]}]
   {:code `(Boolean/compare ~@emitted-args)
-   :return-type Long})
+   :return-type (types/->arrow-type :bigint)})
 
-(defmethod expr/codegen-call [:compare Comparable Comparable] [{:keys [emitted-args]}]
+(defmethod expr/codegen-call [:compare ::types/Object ::types/Object] [{:keys [emitted-args]}]
   {:code `(.compareTo ~@emitted-args)
-   :return-type Long})
+   :return-type (types/->arrow-type :bigint)})
 
-(defmethod expr/codegen-call [:compare String String] [{:keys [emitted-args]}]
+(defmethod expr/codegen-call [:compare ArrowType$Utf8 ArrowType$Utf8] [{:keys [emitted-args]}]
   {:code `(expr/compare-nio-buffers-unsigned ~@emitted-args)
-   :return-type Long})
+   :return-type (types/->arrow-type :bigint)})
 
-(prefer-method expr/codegen-call [:compare Date Date] [:compare Comparable Comparable])
-(prefer-method expr/codegen-call [:compare Number Number] [:compare Comparable Comparable])
-(prefer-method expr/codegen-call [:compare String String] [:compare Comparable Comparable])
+(prefer-method expr/codegen-call [:compare ArrowType$Timestamp ArrowType$Timestamp] [:compare ::types/Object ::types/Object])
+(prefer-method expr/codegen-call [:compare ::types/Number ::types/Number] [:compare ::types/Object ::types/Object])
+(prefer-method expr/codegen-call [:compare ArrowType$Utf8 ArrowType$Utf8] [:compare ::types/Object ::types/Object])
 
 (defn- comparator-code [^ArrowType arrow-type]
   (let [left-vec-sym (gensym 'left-vec)
         left-idx-sym (gensym 'left-idx)
         right-vec-sym (gensym 'right-vec)
         right-idx-sym (gensym 'right-idx)
-        el-type (get types/arrow-type->java-type arrow-type Comparable)]
+        vec-type (types/arrow-type->vector-type arrow-type)]
     `(reify ColumnComparator
        (compareIdx [_# ~left-vec-sym ~left-idx-sym ~right-vec-sym ~right-idx-sym]
-         ~(:code (expr/codegen-call {:f :compare
-                                     :arg-types [el-type el-type]
-                                     :emitted-args [(expr/get-value-form arrow-type left-vec-sym left-idx-sym)
-                                                    (expr/get-value-form arrow-type right-vec-sym right-idx-sym)]}))))))
+         (let [~(-> left-vec-sym (expr/with-tag vec-type)) ~left-vec-sym
+               ~(-> right-vec-sym (expr/with-tag vec-type)) ~right-vec-sym]
+           ~(:code (expr/codegen-call {:f :compare
+                                       :arg-types [arrow-type arrow-type]
+                                       :emitted-args [(expr/get-value-form arrow-type left-vec-sym left-idx-sym)
+                                                      (expr/get-value-form arrow-type right-vec-sym right-idx-sym)]})))))))
 
 (def ^:private memo-comparator-code (memoize comparator-code))
 (def ^:private memo-eval (memoize eval))

--- a/core2/core/test/core2/indexer_test.clj
+++ b/core2/core/test/core2/indexer_test.clj
@@ -8,21 +8,18 @@
             [core2.buffer-pool :as bp]
             [core2.indexer :as idx]
             [core2.json :as c2-json]
-            [core2.metadata :as meta]
             [core2.local-node :as node]
             [core2.object-store :as os]
             [core2.temporal :as temporal]
             [core2.temporal.kd-tree :as kd]
             [core2.test-util :as tu]
             [core2.ts-devices :as ts]
-            [core2.tx :as tx]
             [core2.types :as ty]
             [core2.util :as util])
   (:import core2.api.TransactionInstant
            [core2.buffer_pool BufferPool IBufferPool]
            core2.local_node.Node
            core2.indexer.IChunkManager
-           core2.metadata.IMetadataManager
            core2.object_store.ObjectStore
            core2.temporal.TemporalManager
            java.nio.file.Files


### PR DESCRIPTION
Smallest increment I could make such that the expression engine uses ArrowTypes rather than classes (affectionately known as 'step 1.5').

* There's quite a few places still that assume (as Core2 does more generally) that integer/float types can only be 64 bits, and Timestamp/Duration types can only be millis - these will get ironed out as part of the next block of work.
* The expression engine still doesn't particularly handle the case where a column has multiple types (e.g. some ints, some floats).
* Previously we used Java's inheritance hierarchy so that Long and Double are considered sub-types of Number - I've used a custom multimethod hierarchy to achieve this with `ArrowType`s, because `ArrowType$Int` and `ArrowType$FloatingPoint` (obviously) don't have a common super-type.