### PR TITLE
Expression engine deals with the different timestamp/duration units

### DIFF
--- a/core2/core/src/core2/types.clj
+++ b/core2/core/src/core2/types.clj
@@ -189,7 +189,10 @@
     (let [^ArrowType$Timestamp arrow-type arrow-type]
       (if (.getTimezone arrow-type)
         (case (.name (.getUnit arrow-type))
-          "MICROSECOND" TimeStampMicroTZVector)
+          "SECOND" TimeStampSecTZVector
+          "MILLISECOND" TimeStampMilliTZVector
+          "MICROSECOND" TimeStampMicroTZVector
+          "NANOSECOND" TimeStampNanoTZVector)
         (throw (UnsupportedOperationException.)))))
 
   ArrowType$Duration (arrow-type->vector-type [_] DurationVector))

--- a/core2/core/test/core2/test_util.clj
+++ b/core2/core/test/core2/test_util.clj
@@ -129,7 +129,7 @@
 
 (defn <-column [^IIndirectVector col]
   (mapv (fn [idx]
-          (.getObject (.getVector col) (.getIndex col idx)))
+          (ty/get-object (.getVector col) (.getIndex col idx)))
         (range (.getValueCount col))))
 
 (defn <-cursor [^ICursor cursor]


### PR DESCRIPTION
Even though we might only translate timestamps/durations into micros, this PR handles timestamp/duration operations in any time unit - used when users give us their own Arrow files to query. Like the numerics, we use the most specific precision of the input arguments, and throw on overflow.

Test is `test-mixing-timestamp-types`