### PR TITLE
[show] Polymorphic cols in the expression engine, #63

### DIFF
--- a/core/src/core2/types.clj
+++ b/core/src/core2/types.clj
@@ -19,6 +19,7 @@
 
 (set! *unchecked-math* :warn-on-boxed)
 
+(def bool-type (.getType Types$MinorType/BIT))
 (def bigint-type (.getType Types$MinorType/BIGINT))
 (def float8-type (.getType Types$MinorType/FLOAT8))
 (def varchar-type (.getType Types$MinorType/VARCHAR))


### PR DESCRIPTION
Previously, the expression engine could only handle columns containing a single type-vector - this PR adds support for polymorphic columns. Resolves xtdb/xtdb#2047.

Particularly, we wanted to ensure that primitives pass through the expression engine unboxed. Even where an input variable can be either an int or a float (or, later, null), we still don't want to box up each value in order to pass dynamic type information through.

## Inversion of Control (IoC) in `codegen-expr`

Biggest change here is that there's now an IoC in the `codegen-expr` multimethod - it now returns a set of return-types and a continuation (details in docstring). The reason for this IoC is that, for a variable that's either an int or a float, we want to generate (pseudo-)code like this:

```clojure
(case (type-of x idx)
  Int (handle-int (get-int x idx))
  Float (handle-float (get-float x idx)))
```

If we were to get a highlighter out:
* the `case` part and the `get-int`/`get-float` are the domain of the variable emitter - i.e. how to figure out which type it is, and then how to get that type out of the union.
* the `handle-int`/`handle-float` code is the domain of the caller.

So that's why we have the continuation passed from the caller - the variable emitter becomes:

```clojure
`(case (type-of x idx)
   Int ~(f Int `(get-int x idx))
   Float ~(f Float `(get-float x idx)))
```

and then `f` can decide how to handle int/float, and how to use the actual value (i.e. where to use the value in its own expression).

### Alternatives considered

For comparison, I initially went with a Arrow Java holder-like pattern (elsewhere called 'indicator variables', IIUC), which generated (pseudo-)code like this:

```clojure
(let [int-box (IntBox.)
      float-box (FloatBox.)]
  (dotimes [idx row-count]
    (let [x-box (case (type-of x idx)
                  Int (doto int-box (.setInt (get-int x idx)))
                  Float (doto float-box (.setFloat (get-float x idx))))]
      (case x-box
        int-box (handle-int (.getInt int-box))
        float-box (handle-float (.getFloat float-box))))))
```

In that case, the `(case (type-of ...) ...)` expr is entirely the domain of the variable emission, the surrounding call entirely the caller, and no callbacks required - so the compiler code was simpler, but the generated code was more complex with more overhead.

### `(defmethod codegen-expr :call ...)`

This one was fun. We have an arbitrary number of argument expressions to emit (each of which could be polymorphic), so we have to call each continuation in turn before making the call itself:

```clojure
;; 0 args:
(fn [f]
  ((continue-call-for []) f []))

;; 1 arg:
(fn [f]
  ((:continue x-arg)
   (fn [x-type x-code]
     ((continue-call-for [x-type]) f [x-code]))))

;; 2 args:
(fn [f]
  ((:continue x-arg)
   (fn [x-type x-code]
     ((:continue y-arg)
      (fn [y-type y-code]
        ((continue-call-for [x-type y-type]) f [x-code y-code]))))))

;; ... etc
```

(this chain of functions is only within the compiler - the emitted code is flat and inlined)

In the general case, we build up this chain 'inside-out', [using `reduce`](https://github.com/xtdb/core2/pull/71/files#diff-2b5d7d9ed48ba1eed2575e349fe2ab11cdd05ee1e6bc152af8ce72527a493d1aR332-R347) - the innermost function (the init value) has all of the types and the emitted args available, and makes the call; each step then wraps the inner function with another emitted arg.

## Next up

xtdb/xtdb#2046 (ternary logic) to come next. This will also handle external Arrow containing nullable vectors - the vectors we generate all have null as a leg in the union.