### PR TITLE
Show: add basic composite-structure exprs to the expression engine

### DIFF
--- a/core/src/core2/expression/walk.clj
+++ b/core/src/core2/expression/walk.clj
@@ -1,15 +1,23 @@
-(ns core2.expression.walk)
+(ns core2.expression.walk
+  (:import clojure.lang.MapEntry))
 
 (defmulti direct-child-exprs
   (fn [{:keys [op] :as expr}]
     op)
   :default ::default)
 
-(defmethod direct-child-exprs ::default [_] #{})
-(defmethod direct-child-exprs :if [{:keys [pred then else]}] [pred then else])
-(defmethod direct-child-exprs :if-some [{:keys [local expr then else]}] [expr then else])
-(defmethod direct-child-exprs :let [{:keys [expr body]}] [expr body])
-(defmethod direct-child-exprs :call [{:keys [args]}] args)
+(defmethod direct-child-exprs ::default [_])
+
+(defmethod direct-child-exprs :if [e] (map e [:pred :then :else]))
+(defmethod direct-child-exprs :if-some [e] (map e [:expr :then :else]))
+(defmethod direct-child-exprs :let [e] (map e [:expr :body]))
+(defmethod direct-child-exprs :call [e] (:args e))
+(defmethod direct-child-exprs :struct [e] (vals (:entries e)))
+(defmethod direct-child-exprs :dot-const-field [e] (map e [:struct-expr]))
+(defmethod direct-child-exprs :dot [e] (map e [:struct-expr :field-expr]))
+(defmethod direct-child-exprs :list [e] (:elements e))
+(defmethod direct-child-exprs :nth-const-idx [e] (map e [:coll-expr]))
+(defmethod direct-child-exprs :nth [e] (map e (map e [:coll-expr :idx-expr])))
 
 (defn expr-seq [expr]
   (lazy-seq
@@ -24,28 +32,38 @@
   (outer expr))
 
 (defmethod walk-expr :if [inner outer {:keys [pred then else]}]
-  (outer {:op :if
-          :pred (inner pred)
-          :then (inner then)
-          :else (inner else)}))
+  (outer {:op :if, :pred (inner pred), :then (inner then), :else (inner else)}))
 
 (defmethod walk-expr :if-some [inner outer {:keys [local expr then else]}]
-  (outer {:op :if-some
-          :local local
-          :expr (inner expr)
-          :then (inner then)
-          :else (inner else)}))
+  (outer {:op :if-some, :local local, :expr (inner expr)
+          :then (inner then), :else (inner else)}))
 
 (defmethod walk-expr :let [inner outer {:keys [local expr body]}]
-  (outer {:op :let
-          :local local
-          :expr (inner expr)
-          :body (inner body)}))
+  (outer {:op :let, :local local, :expr (inner expr), :body (inner body)}))
 
 (defmethod walk-expr :call [inner outer {expr-f :f, :keys [args]}]
-  (outer {:op :call
-          :f expr-f
-          :args (mapv inner args)}))
+  (outer {:op :call, :f expr-f, :args (mapv inner args)}))
+
+(defmethod walk-expr :struct [inner outer {:keys [entries]}]
+  (outer {:op :struct
+          :entries (->> (for [[k expr] entries]
+                          (MapEntry/create k (inner expr)))
+                        (into {}))}))
+
+(defmethod walk-expr :dot-const-field [inner outer {:keys [struct-expr field]}]
+  (outer {:op :dot-const-field, :struct-expr (inner struct-expr), :field field}))
+
+(defmethod walk-expr :dot [inner outer {:keys [struct-expr field-expr]}]
+  (outer {:op :dot, :struct-expr (inner struct-expr), :field-expr (inner field-expr)}))
+
+(defmethod walk-expr :list [inner outer {:keys [elements]}]
+  (outer {:op :list, :elements (mapv inner elements)}))
+
+(defmethod walk-expr :nth-const-idx [inner outer {:keys [coll-expr idx]}]
+  (outer {:op :nth-const-idx, :coll-expr (inner coll-expr), :idx idx}))
+
+(defmethod walk-expr :nth [inner outer {:keys [coll-expr idx-expr]}]
+  (outer {:op :nth, :coll-expr (inner coll-expr), :idx-expr (inner idx-expr)}))
 
 ;; from clojure.walk
 (defn postwalk-expr [f expr]

--- a/core/test/core2/align_test.clj
+++ b/core/test/core2/align_test.clj
@@ -24,9 +24,11 @@
                           (VectorSchemaRoot. vecs))]
 
     (let [row-ids (doto (align/->row-id-bitmap (.select (expr/->expression-relation-selector '(<= age 30) {})
+                                                        tu/*allocator*
                                                         (iv/->indirect-rel [(iv/->direct-vec age-vec)]))
                                                age-row-id-vec)
                     (.and (align/->row-id-bitmap (.select (expr/->expression-relation-selector '(<= name "Frank") {})
+                                                          tu/*allocator*
                                                           (iv/->indirect-rel [(iv/->direct-vec name-vec)]))
                                                  name-row-id-vec)))
           roots [name-root age-root]]

--- a/core/test/core2/operator/select_test.clj
+++ b/core/test/core2/operator/select_test.clj
@@ -20,7 +20,7 @@
                                      [{:a 83, :b 100}]])
                 select-cursor (select/->select-cursor tu/*allocator* cursor
                                                       (reify IRelationSelector
-                                                        (select [_ in-rel]
+                                                        (select [_ _al in-rel]
                                                           (let [idxs (RoaringBitmap.)
                                                                 ^BigIntVector a-vec (.getVector (.vectorForName in-rel "a"))
                                                                 ^BigIntVector b-vec (.getVector (.vectorForName in-rel "b"))]


### PR DESCRIPTION
This PR adds early support for composite structures to the expression engine:

* Struct/list literal expressions
* `(. a b)` - get `b` field from `a` struct
* `(nth coll 4)`
* see [tests](https://github.com/xtdb/core2/pull/72/files#diff-a7330d2ab2b39d09b7abb95b927644884ab7a07efc69c5680be3da04ac0f5ff9R461-R500)

Still to do (later commits, out of scope here):
* Handle polymorphic lists/structs
* Handle fields possibly being in different legs of a DUV (a field might be present in many keysets)

Notes:
* In a similar vein to MonetDB's [X100](http://cs.brown.edu/courses/cs227/archives/2008/Papers/ColumnStores/MonetDB.pdf) engine, we split expressions into non-primitive and primitive expressions. Non-primitive expressions take some vectors and return a vector (e.g. `(. (. a b) c)` will first get `a` into a vector, then create a vector of all the `b` values, then create a vector of all the `c` values) - no codegen here. Primitive expressions `(+ x (* y z))` will combine multiple sub-exprs into one so that we don't need to create intermediate vectors for primitive values - we get `x`, `y` and `z` vectors, and then compile a Clojure expression that creates an output vector in one step.
* We currently eagerly copy the intermediate vectors in the non-primitive exprs - we could probably avoid copying here in various places - I might be tempted to have these return indirect vectors instead so that we can pass variables straight through from the input relation.
* Probably plenty of other improvements too