### PR TITLE
Add multi-column handling to join operator

### DIFF
--- a/core/src/core2/logical_plan.clj
+++ b/core/src/core2/logical_plan.clj
@@ -137,35 +137,43 @@
          :left ::ra-expression
          :right ::ra-expression))
 
-(s/def ::equi-join-columns (s/map-of ::column ::column :conform-keys true :count 1))
+(s/def ::equi-join-columns
+  (s/and
+    (s/or :map-seq-form (s/coll-of (s/map-of ::column ::column :conform-keys true :count 1) :kind vector? :min-count 1)
+          :legacy-single-map-form (s/map-of ::column ::column :conform-keys true :count 1))
+    (s/conformer
+      (fn [[tag val]]
+        (case tag
+          :map-seq-form (mapcat identity val)
+          :legacy-single-map-form val)))))
 
 (defmethod ra-expr :join [_]
   (s/cat :op #{:⋈ :join}
-         :columns ::equi-join-columns
+         :key-columns ::equi-join-columns
          :left ::ra-expression
          :right ::ra-expression))
 
 (defmethod ra-expr :left-outer-join [_]
   (s/cat :op #{:⟕ :left-outer-join}
-         :columns ::equi-join-columns
+         :key-columns ::equi-join-columns
          :left ::ra-expression
          :right ::ra-expression))
 
 (defmethod ra-expr :full-outer-join [_]
   (s/cat :op #{:⟗ :full-outer-join}
-         :columns ::equi-join-columns
+         :key-columns ::equi-join-columns
          :left ::ra-expression
          :right ::ra-expression))
 
 (defmethod ra-expr :semi-join [_]
   (s/cat :op #{:⋉ :semi-join}
-         :columns ::equi-join-columns
+         :key-columns ::equi-join-columns
          :left ::ra-expression
          :right ::ra-expression))
 
 (defmethod ra-expr :anti-join [_]
   (s/cat :op #{:▷ :anti-join}
-         :columns ::equi-join-columns
+         :key-columns ::equi-join-columns
          :left ::ra-expression
          :right ::ra-expression))
 

--- a/core/src/core2/operator.clj
+++ b/core/src/core2/operator.clj
@@ -232,16 +232,16 @@
          [:semi-join join/->left-semi-equi-join-cursor (fn [l _r] l)]
          [:anti-join join/->left-anti-semi-equi-join-cursor (fn [l _r] l)]]]
 
-  (defmethod emit-op join-op-k [{:keys [columns left right]} srcs]
-    (let [[left-col] (keys columns)
-          [right-col] (vals columns)]
+  (defmethod emit-op join-op-k [{:keys [key-columns left right]} srcs]
+    (let [left-key-cols (map first key-columns)
+          right-key-cols (map second key-columns)]
       (binary-op left right srcs
                  (fn [left-col-names right-col-names]
                    {:col-names (->col-names left-col-names right-col-names)
                     :->cursor (fn [{:keys [allocator]} left right]
                                 (->join-cursor allocator
-                                               left (name left-col) left-col-names
-                                               right (name right-col) right-col-names))})))))
+                                               left (map name left-key-cols) left-col-names
+                                               right (map name right-key-cols) right-col-names))})))))
 
 (defmethod emit-op :group-by [{:keys [columns relation]} srcs]
   (let [{group-cols :group-by, aggs :aggregate} (group-by first columns)

--- a/test/core2/operator/join_test.clj
+++ b/test/core2/operator/join_test.clj
@@ -11,23 +11,27 @@
 (def ^:private a-field (ty/->field "a" ty/bigint-type false))
 (def ^:private b-field (ty/->field "b" ty/bigint-type false))
 (def ^:private c-field (ty/->field "c" ty/bigint-type false))
+(def ^:private d-field (ty/->field "d" ty/bigint-type false))
+(def ^:private e-field (ty/->field "e" ty/bigint-type false))
 
 (defn- run-join-test
   ([join-op left-blocks right-blocks]
    (run-join-test join-op left-blocks right-blocks {}))
 
   ([->join-cursor left-blocks right-blocks
-    {:keys [left-fields right-fields left-join-col right-join-col]
+    {:keys [left-fields right-fields
+            left-join-cols
+            right-join-cols]
      :or {left-fields [a-field], right-fields [b-field]
-          left-join-col "a", right-join-col "b"}}]
+          left-join-cols ["a"], right-join-cols ["b"]}}]
 
    (let [left-col-names (->> left-fields (into #{} (map (comp symbol #(.getName ^Field %)))))
          right-col-names (->> right-fields (into #{} (map (comp symbol #(.getName ^Field %)))))]
      (with-open [left-cursor (tu/->cursor (Schema. left-fields) left-blocks)
                  right-cursor (tu/->cursor (Schema. right-fields) right-blocks)
                  ^ICursor join-cursor (->join-cursor tu/*allocator*
-                                                     left-cursor left-join-col left-col-names
-                                                     right-cursor right-join-col right-col-names)]
+                                                     left-cursor left-join-cols left-col-names
+                                                     right-cursor right-join-cols right-col-names)]
 
        (vec (tu/<-cursor join-cursor))))))
 
@@ -74,7 +78,7 @@
                                [[{:a 12}, {:a 2}]
                                 [{:a 100} {:a 0}]]
                                {:left-fields [a-field], :right-fields [a-field]
-                                :left-join-col "a", :right-join-col "a"})
+                                :left-join-cols ["a"], :right-join-cols ["a"]})
                 (mapv frequencies)))
         "same column name")
 
@@ -90,6 +94,26 @@
                                [[{:b 10 :c 1}, {:b 15 :c 2}]
                                 [{:b 83 :c 3}]]))
         "empty output"))
+
+(t/deftest test-equi-join-multi-col
+  (->> "multi column"
+       (t/is (= [{{:a 12, :b 42, :c 12, :d 42, :e 0} 2}
+                 {{:a 12, :b 42, :c 12, :d 42, :e 0} 4
+                  {:a 12, :b 42, :c 12, :d 42, :e 1} 2}]
+                (->> (run-join-test join/->equi-join-cursor
+                                    [[{:a 12, :b 42}
+                                      {:a 12, :b 42}
+                                      {:a 11, :b 44}
+                                      {:a 10, :b 42}]]
+                                    [[{:c 12, :d 42, :e 0}
+                                      {:c 12, :d 43, :e 0}
+                                      {:c 11, :d 42, :e 0}]
+                                     [{:c 12, :d 42, :e 0}
+                                      {:c 12, :d 42, :e 0}
+                                      {:c 12, :d 42, :e 1}]]
+                                    {:left-fields [a-field b-field], :right-fields [c-field d-field e-field]
+                                     :left-join-cols ["a" "b"], :right-join-cols ["c" "d"]})
+                     (mapv frequencies))))))
 
 (t/deftest test-semi-equi-join
   (t/is (= [{{:a 12} 2} {{:a 100} 1}]
@@ -123,6 +147,24 @@
                                 [{:b 83 :c 3}]]))
         "empty output"))
 
+(t/deftest test-semi-equi-join-multi-col
+  (->> "multi column semi"
+       (t/is (= [{{:a 12, :b 42} 2}]
+                (->> (run-join-test join/->left-semi-equi-join-cursor
+                                    [[{:a 12, :b 42}
+                                      {:a 12, :b 42}
+                                      {:a 11, :b 44}
+                                      {:a 10, :b 42}]]
+                                    [[{:c 12, :d 42, :e 0}
+                                      {:c 12, :d 43, :e 0}
+                                      {:c 11, :d 42, :e 0}]
+                                     [{:c 12, :d 42, :e 0}
+                                      {:c 12, :d 42, :e 0}
+                                      {:c 12, :d 42, :e 1}]]
+                                    {:left-fields [a-field b-field], :right-fields [c-field d-field]
+                                     :left-join-cols ["a" "b"], :right-join-cols ["c" "d"]})
+                     (mapv frequencies))))))
+
 (t/deftest test-left-equi-join
   (t/is (= [{{:a 12, :b 12, :c 2} 1, {:a 12, :b 12, :c 0} 1, {:a 0, :b nil, :c nil} 1}
             {{:a 12, :b 12, :c 2} 1, {:a 100, :b 100, :c 3} 1, {:a 12, :b 12, :c 0} 1}]
@@ -155,6 +197,27 @@
                                   [{:a 100}]]
                                  [[]])
                   (mapv set))))))
+
+(t/deftest test-left-equi-join-multi-col
+  (->> "multi column left"
+       (t/is (= [{{:a 11, :b 44, :c nil, :d nil, :e nil} 1
+                  {:a 10, :b 42, :c nil, :d nil, :e nil} 1
+                  {:a 12, :b 42, :c 12, :d 42, :e 0} 6
+                  {:a 12, :b 42, :c 12, :d 42, :e 1} 2}]
+                (->> (run-join-test join/->left-outer-equi-join-cursor
+                                    [[{:a 12, :b 42}
+                                      {:a 12, :b 42}
+                                      {:a 11, :b 44}
+                                      {:a 10, :b 42}]]
+                                    [[{:c 12, :d 42, :e 0}
+                                      {:c 12, :d 43, :e 0}
+                                      {:c 11, :d 42, :e 0}]
+                                     [{:c 12, :d 42, :e 0}
+                                      {:c 12, :d 42, :e 0}
+                                      {:c 12, :d 42, :e 1}]]
+                                    {:left-fields [a-field b-field], :right-fields [c-field d-field e-field]
+                                     :left-join-cols ["a" "b"], :right-join-cols ["c" "d"]})
+                     (mapv frequencies))))))
 
 (t/deftest test-full-outer-join
   (t/testing "missing on both sides"
@@ -217,6 +280,30 @@
                                   [{:b 100} {:b 0}]])
                   (mapv frequencies))))))
 
+(t/deftest test-full-outer-equi-join-multi-col
+  (->> "multi column full outer"
+       (t/is (= [{{:a 12 :b 42 :c 12 :d 42 :e 0} 2
+                  {:a nil :b nil :c 11 :d 42 :e 0} 1
+                  {:a nil :b nil :c 12 :d 43 :e 0} 1}
+                 {{:a 12 :b 42 :c 12 :d 42 :e 0} 4
+                  {:a 12 :b 42 :c 12 :d 42 :e 1} 2}
+                 {{:a 10 :b 42 :c nil :d nil :e nil} 1
+                  {:a 11 :b 44 :c nil :d nil :e nil} 1}]
+                (->> (run-join-test join/->full-outer-equi-join-cursor
+                                    [[{:a 12, :b 42}
+                                      {:a 12, :b 42}
+                                      {:a 11, :b 44}
+                                      {:a 10, :b 42}]]
+                                    [[{:c 12, :d 42, :e 0}
+                                      {:c 12, :d 43, :e 0}
+                                      {:c 11, :d 42, :e 0}]
+                                     [{:c 12, :d 42, :e 0}
+                                      {:c 12, :d 42, :e 0}
+                                      {:c 12, :d 42, :e 1}]]
+                                    {:left-fields [a-field b-field], :right-fields [c-field d-field e-field]
+                                     :left-join-cols ["a" "b"], :right-join-cols ["c" "d"]})
+                     (mapv frequencies))))))
+
 (t/deftest test-anti-equi-join
   (t/is (= [{{:a 0} 2}]
            (->> (run-join-test join/->left-anti-semi-equi-join-cursor
@@ -246,3 +333,22 @@
                                [[{:b 12}, {:b 2}]
                                 [{:b 100}]]))
         "empty output"))
+
+(t/deftest test-anti-equi-join-multi-col
+  (->> "multi column anti"
+       (t/is (= [{{:a 10 :b 42} 1
+                  {:a 11 :b 44} 1}]
+                (->> (run-join-test join/->left-anti-semi-equi-join-cursor
+                                    [[{:a 12, :b 42}
+                                      {:a 12, :b 42}
+                                      {:a 11, :b 44}
+                                      {:a 10, :b 42}]]
+                                    [[{:c 12, :d 42, :e 0}
+                                      {:c 12, :d 43, :e 0}
+                                      {:c 11, :d 42, :e 0}]
+                                     [{:c 12, :d 42, :e 0}
+                                      {:c 12, :d 42, :e 0}
+                                      {:c 12, :d 42, :e 1}]]
+                                    {:left-fields [a-field b-field], :right-fields [c-field d-field e-field]
+                                     :left-join-cols ["a" "b"], :right-join-cols ["c" "d"]})
+                     (mapv frequencies))))))

--- a/test/core2/operator_test.clj
+++ b/test/core2/operator_test.clj
@@ -221,7 +221,7 @@
              (op/query-ra '[:fixpoint Path
                             [:table $table]
                             [:project [x y]
-                             [:join {z z}
+                             [:join [{z z}]
                               [:rename {y z} Path]
                               [:rename {x z} Path]]]]
                           {'$table [{:x "a" :y "b"}
@@ -234,14 +234,14 @@
   (t/is (= [{:a 1 :b 1}]
            (op/query-ra '[:assign [X [:table $x]
                                    Y [:table $y]]
-                          [:join {a b} X Y]]
+                          [:join [{a b}] X Y]]
                         '{$x [{:a 1}]
                           $y [{:b 1}]})))
 
   (t/testing "can see earlier assignments"
     (t/is (= [{:a 1 :b 1}]
              (op/query-ra '[:assign [X [:table $x]
-                                     Y [:join {a b} X [:table $y]]
+                                     Y [:join [{a b}] X [:table $y]]
                                      X Y]
                             X]
                           '{$x [{:a 1}]


### PR DESCRIPTION
Extends the join operator to accept multiple column (equi) joins.

This is a pre-cursor to full theta, it allows you to say:

`[:join '[{a b}, {c d}] left right]`  (for `from left inner join right on a = b and c = d`)

A spec conformer is used for compatibility, so the old single map form continues to work, we may decide to to port old tests and code to the preferred form at some later date.

Support is extended to the family of joins as implemented (inner, left outer, full outer, semi, anti).

n.b the spec requires _at least one_ pair of columns, if you want a cross join, you have to use the cross join operator.
