### PR TITLE
WIP: Add preliminary theta join support

### DIFF
--- a/core/src/core2/operator/join.clj
+++ b/core/src/core2/operator/join.clj
@@ -6,16 +6,17 @@
             [core2.util :as util]
             [core2.vector.indirect :as iv]
             [core2.vector.writer :as vw])
-  (:import core2.expression.map.IRelationMap
-           core2.ICursor
-           core2.types.LegType
-           [core2.vector IIndirectRelation IIndirectVector IRelationWriter IRowCopier IVectorWriter]
-           [java.util ArrayList Iterator List]
-           java.util.function.Consumer
-           java.util.stream.IntStream
-           org.apache.arrow.memory.BufferAllocator
-           [org.roaringbitmap IntConsumer RoaringBitmap]
-           org.roaringbitmap.buffer.MutableRoaringBitmap))
+  (:import (core2 ICursor)
+           (core2.expression.map IRelationMap)
+           (core2.operator IRelationSelector)
+           (core2.vector IIndirectRelation IIndirectVector IRelationWriter IRowCopier)
+           (java.util ArrayList Iterator List)
+           (java.util.function Consumer)
+           (java.util.stream IntStream)
+           (org.apache.arrow.memory BufferAllocator)
+           (org.roaringbitmap IntConsumer RoaringBitmap)
+           (org.roaringbitmap.buffer MutableRoaringBitmap)
+           [org.apache.arrow.vector NullVector]))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -49,23 +50,23 @@
                            (.add left-rels (iv/copy left-rel allocator)))))
 
     (boolean
-     (when-let [right-rel (or (when (and left-rel-iterator (.hasNext left-rel-iterator))
-                                right-rel)
-                              (do
-                                (when right-rel
-                                  (.close right-rel)
-                                  (set! (.right-rel this) nil))
-                                (when (.tryAdvance right-cursor
-                                                   (reify Consumer
-                                                     (accept [_ right-rel]
-                                                       (set! (.right-rel this) (iv/copy right-rel allocator))
-                                                       (set! (.left-rel-iterator this) (.iterator left-rels)))))
-                                  (.right-rel this))))]
+      (when-let [right-rel (or (when (and left-rel-iterator (.hasNext left-rel-iterator))
+                                 right-rel)
+                               (do
+                                 (when right-rel
+                                   (.close right-rel)
+                                   (set! (.right-rel this) nil))
+                                 (when (.tryAdvance right-cursor
+                                                    (reify Consumer
+                                                      (accept [_ right-rel]
+                                                        (set! (.right-rel this) (iv/copy right-rel allocator))
+                                                        (set! (.left-rel-iterator this) (.iterator left-rels)))))
+                                   (.right-rel this))))]
 
-       (when-let [left-rel (when (.hasNext left-rel-iterator)
-                             (.next left-rel-iterator))]
-         (.accept c (cross-product left-rel right-rel))
-         true))))
+        (when-let [left-rel (when (.hasNext left-rel-iterator)
+                              (.next left-rel-iterator))]
+          (.accept c (cross-product left-rel right-rel))
+          true))))
 
   (close [_]
     (when left-rels
@@ -94,76 +95,178 @@
         (dotimes [build-idx (.rowCount build-rel)]
           (.add pushdown-bloom ^ints (bloom/bloom-hashes internal-vec (.getIndex build-col build-idx))))))))
 
-(defn- ->nullable-row-copier ^core2.vector.IRowCopier [^IIndirectVector in-col, ^IRelationWriter out-rel, join-type]
-  (let [col-name (.getName in-col)
-        writer (.writerForName out-rel col-name)
-        row-copier (vw/->row-copier writer in-col)
-        null-copier (when (contains? #{:full-outer :left-outer} join-type)
-                      (vw/->null-row-copier writer))]
-    (reify IRowCopier
-      (copyRow [_ idx]
-        (if (neg? idx)
-          (.copyRow null-copier idx)
-          (.copyRow row-copier idx))))))
+#_{:clj-kondo/ignore [:unused-binding]}
+(defmulti ^core2.vector.IIndirectRelation probe-phase
+  (fn [join-type allocator probe-rel rel-map probe-column-names matched-build-idxs theta-selector]
+    join-type))
 
-(defn- probe-phase ^core2.vector.IIndirectRelation [^IRelationWriter rel-writer
-                                                    ^IIndirectRelation probe-rel
-                                                    ^IRelationMap rel-map
-                                                    probe-column-names
-                                                    ^RoaringBitmap matched-build-idxs
-                                                    join-type]
-  (when (pos? (.rowCount probe-rel))
-    (let [semi-join? (contains? #{:semi :anti-semi} join-type)
-          anti-join? (= :anti-semi join-type)
-          outer-join? (contains? #{:full-outer :left-outer} join-type)
-          matching-build-idxs (IntStream/builder)
-          matching-probe-idxs (IntStream/builder)
-          rel-map-prober (.probeFromRelation rel-map probe-rel)]
+(defn- probe-inner-join-select
+  "Returns a pair of selections [probe-sel, build-sel].
 
-      (dotimes [probe-idx (.rowCount probe-rel)]
-        (let [match? (if semi-join?
-                       (not (neg? (.indexOf rel-map-prober probe-idx)))
-                       (when-let [build-idxs (.getAll rel-map-prober probe-idx)]
-                         (.forEach build-idxs
-                                   (reify IntConsumer
-                                     (accept [_ build-idx]
-                                       (when matched-build-idxs
-                                         (.add matched-build-idxs build-idx))
-                                       (.add matching-build-idxs build-idx)
-                                       (.add matching-probe-idxs probe-idx))))
-                         true))]
-          (cond
-            outer-join? (when-not match?
-                          (.add matching-probe-idxs probe-idx)
-                          (.add matching-build-idxs -1))
-            anti-join? (when-not match?
-                         (.add matching-probe-idxs probe-idx))
-            semi-join? (when match?
-                         (.add matching-probe-idxs probe-idx)))))
+  The selections represent matched rows in both underlying relations.
 
-      (let [probe-column-names-set (set probe-column-names)
-            copy-rel (fn copy-rel [^IIndirectRelation in-rel, ^ints idxs]
-                       (doseq [^IIndirectVector in-col in-rel
-                               :when (or (= in-rel probe-rel)
-                                         (not (contains? probe-column-names-set (.getName in-col))))
-                               :let [row-copier (->nullable-row-copier in-col rel-writer join-type)]]
-                         (dotimes [idx (alength idxs)]
-                           (.copyRow row-copier (aget idxs idx)))))]
+  The selections will have the same size."
+  [^IIndirectRelation probe-rel ^IRelationMap rel-map ]
+  (let [rel-map-prober (.probeFromRelation rel-map probe-rel)
+        matching-build-idxs (IntStream/builder)
+        matching-probe-idxs (IntStream/builder)]
 
-        (when-not semi-join?
-          (copy-rel (.getBuiltRelation rel-map)
-                    (.toArray (.build matching-build-idxs))))
+    (dotimes [probe-idx (.rowCount probe-rel)]
+      (when-let [build-idxs (.getAll rel-map-prober probe-idx)]
+        (.forEach build-idxs
+                  (reify IntConsumer
+                    (accept [_ build-idx]
+                      (.add matching-build-idxs build-idx)
+                      (.add matching-probe-idxs probe-idx))))))
 
-        (copy-rel probe-rel (.toArray (.build matching-probe-idxs)))))))
+    [(.toArray (.build matching-probe-idxs)) (.toArray (.build matching-build-idxs))]))
+
+(defn- join-rels
+  "Takes a relation (probe-rel) and its mapped relation (via rel-map) and returns a relation with the columns of both."
+  [^IIndirectRelation probe-rel
+   ^IRelationMap rel-map
+   [probe-sel build-sel :as _selection-pair]]
+  (let [built-rel (.getBuiltRelation rel-map)]
+    (iv/->indirect-rel (concat (iv/select built-rel build-sel)
+                               (iv/select probe-rel probe-sel)))))
+
+(defn- probe-semi-join-select-fast-path
+  "Do not call me directly, use probe-semi-join-select. Only works for semi-join without theta predicates."
+  ^ints [^IIndirectRelation probe-rel
+         ^IRelationMap rel-map]
+  (let [rel-map-prober (.probeFromRelation rel-map probe-rel)
+        matching-probe-idxs (IntStream/builder)]
+    (dotimes [probe-idx (.rowCount probe-rel)]
+      (when (<= 0 (.indexOf rel-map-prober probe-idx))
+        (.add matching-probe-idxs probe-idx)))
+    (.toArray (.build matching-probe-idxs))))
+
+(defn- distinct-selection [^ints sel]
+  (.toArray (RoaringBitmap/bitmapOf sel)))
+
+(defn- probe-semi-join-select
+  "Returns a single selection of the probe relation, that represents matches for a semi-join."
+  ^ints [^IIndirectRelation probe-rel
+         ^IRelationMap rel-map
+         ^BufferAllocator allocator
+         ^IRelationSelector theta-selector]
+  (if (nil? theta-selector)
+    (probe-semi-join-select-fast-path probe-rel rel-map)
+    (let [probe-semi-sel (probe-semi-join-select-fast-path probe-rel rel-map)
+          probe-filtered-rel (iv/select probe-rel probe-semi-sel)
+          selection-pair (probe-inner-join-select probe-filtered-rel rel-map)
+
+          theta-base-rel (join-rels probe-filtered-rel rel-map selection-pair)
+          theta-sel (.select theta-selector allocator theta-base-rel)]
+      (-> (iv/compose-selection probe-semi-sel theta-sel)
+          (distinct-selection)))))
+
+(defmethod probe-phase ::inner-join
+  [_join-type
+   ^BufferAllocator allocator
+   ^IIndirectRelation probe-rel
+   ^IRelationMap rel-map
+   _probe-column-names
+   _matched-build-idxs
+   ^IRelationSelector theta-selector]
+  (let [joined-rel (join-rels probe-rel rel-map (probe-inner-join-select probe-rel rel-map))
+        theta-sel (when theta-selector (.select theta-selector allocator joined-rel))]
+    (cond-> joined-rel theta-sel (iv/select theta-sel))))
+
+(defmethod probe-phase ::semi-join
+  [_join-type
+   ^BufferAllocator allocator
+   ^IIndirectRelation probe-rel
+   ^IRelationMap rel-map
+   _probe-column-names
+   _matched-build-idxs
+   ^IRelationSelector theta-selector]
+  (iv/select probe-rel (probe-semi-join-select probe-rel rel-map allocator theta-selector)))
+
+(defmethod probe-phase ::anti-semi-join
+  [_join-type
+   ^BufferAllocator allocator
+   ^IIndirectRelation probe-rel
+   ^IRelationMap rel-map
+   _probe-column-names
+   _matched-build-idxs
+   ^IRelationSelector theta-selector]
+
+  (let [anti-stream (IntStream/builder)
+        semi-bitmap (doto (MutableRoaringBitmap.) (.add (probe-semi-join-select probe-rel rel-map allocator theta-selector)))
+        anti-sel (do (dotimes [idx (.rowCount ^IIndirectRelation probe-rel)]
+                       (when-not (.contains semi-bitmap idx)
+                         (.add anti-stream idx)))
+                     (.toArray (.build anti-stream)))]
+    (iv/select probe-rel anti-sel)))
+
+(derive ::full-outer-join ::outer-join)
+(derive ::left-outer-join ::outer-join)
+
+(defn- int-array-concat
+  ^ints [^ints arr1 ^ints arr2]
+  (let [ret-arr (int-array (+ (alength arr1) (alength arr2)))]
+    (System/arraycopy arr1 0 ret-arr 0 (alength arr1))
+    (System/arraycopy arr2 0 ret-arr (alength arr1) (alength arr2))
+    ret-arr))
+
+(defn- probe-outer-join-select [probe-rel rel-map ^BufferAllocator allocator ^RoaringBitmap matched-build-idxs ^IRelationSelector theta-selector]
+  (let [[probe-sel build-sel :as selection-pair] (probe-inner-join-select probe-rel rel-map)
+        inner-join-rel (join-rels probe-rel rel-map selection-pair)
+
+        theta-sel (when theta-selector (.select theta-selector allocator inner-join-rel))
+        ^ints theta-probe-sel (cond-> probe-sel theta-sel (iv/compose-selection theta-sel))
+        ^ints theta-build-sel (cond-> build-sel theta-sel (iv/compose-selection theta-sel))
+
+        _ (when matched-build-idxs (.add matched-build-idxs ^ints theta-build-sel))
+
+        probe-bm (RoaringBitmap/bitmapOf theta-probe-sel)
+        probe-int-stream (IntStream/builder)
+        build-int-stream (IntStream/builder)
+
+        _ (dotimes [idx (.rowCount probe-rel)]
+            (when-not (.contains probe-bm idx)
+              (.add probe-int-stream idx)
+              ;; position 0 represents the row we added to the build-rel using `add-nil-row!`.
+              ;; sorry for the hack, cheapest thing to do now.
+              (.add build-int-stream 0)))
+
+        extra-probe-sel (.toArray (.build probe-int-stream))
+        extra-build-sel (.toArray (.build build-int-stream))
+
+        full-probe-sel (int-array-concat theta-probe-sel extra-probe-sel)
+        full-build-sel (int-array-concat theta-build-sel extra-build-sel)]
+
+    [full-probe-sel full-build-sel]))
+
+(defmethod probe-phase ::outer-join
+  [_join-type
+   ^BufferAllocator allocator
+   ^IIndirectRelation probe-rel
+   ^IRelationMap rel-map
+   _probe-column-names
+   ^RoaringBitmap matched-build-idxs
+   ^IRelationSelector theta-selector]
+  (->> (probe-outer-join-select probe-rel rel-map allocator matched-build-idxs theta-selector)
+       (join-rels probe-rel rel-map)))
+
+(defn- ->nil-rel
+  "Returns a single row relation where all columns are nil. (Useful for outer joins)."
+  [col-names]
+  (iv/->indirect-rel (for [col-name col-names]
+                       (iv/->direct-vec (doto (NullVector. (name col-name))
+                                          (.setValueCount 1))))))
+
+(def ^:private nil-row-idx 0)
 
 (deftype JoinCursor [^BufferAllocator allocator
                      ^ICursor build-cursor, build-key-column-names, build-column-names
                      ^ICursor probe-cursor, probe-key-column-names, probe-column-names
-                     ^IRelationWriter rel-writer
                      ^IRelationMap rel-map
                      ^RoaringBitmap matched-build-idxs
                      pushdown-blooms
-                     join-type]
+                     join-type
+                     ^IRelationSelector theta-selector]
   ICursor
   (tryAdvance [_ c]
     (.forEachRemaining build-cursor
@@ -171,128 +274,125 @@
                          (accept [_ build-rel]
                            (build-phase build-rel build-key-column-names rel-map pushdown-blooms))))
 
-    (let [yield-missing? (contains? #{:anti-semi :left-outer :full-outer} join-type)]
+    (let [yield-missing? (contains? #{::anti-semi-join ::left-outer-join ::full-outer-join} join-type)]
       (boolean
-       (or (let [advanced? (boolean-array 1)]
-             (binding [scan/*column->pushdown-bloom*
-                       (if yield-missing?
-                         scan/*column->pushdown-bloom*
-                         (conj scan/*column->pushdown-bloom* (zipmap probe-key-column-names pushdown-blooms)))]
-               (while (and (not (aget advanced? 0))
-                           (.tryAdvance probe-cursor
-                                        (reify Consumer
-                                          (accept [_ probe-rel]
-                                            (probe-phase rel-writer probe-rel rel-map probe-key-column-names matched-build-idxs join-type)
+        (or (let [advanced? (boolean-array 1)]
+              (binding [scan/*column->pushdown-bloom*
+                        (if yield-missing?
+                          scan/*column->pushdown-bloom*
+                          (conj scan/*column->pushdown-bloom* (zipmap probe-key-column-names pushdown-blooms)))]
+                (while (and (not (aget advanced? 0))
+                            (.tryAdvance probe-cursor
+                                         (reify Consumer
+                                           (accept [_ probe-rel]
+                                             (when (pos? (.rowCount ^IIndirectRelation probe-rel))
+                                               (with-open [out-rel (-> (probe-phase join-type allocator probe-rel rel-map probe-column-names matched-build-idxs theta-selector)
+                                                                       (iv/copy allocator))]
+                                                 (when (pos? (.rowCount out-rel))
+                                                   (aset advanced? 0 true)
+                                                   (.accept c out-rel))))))))))
+              (aget advanced? 0))
 
-                                            (with-open [out-rel (vw/rel-writer->reader rel-writer)]
-                                              (try
-                                                (when (pos? (.rowCount out-rel))
-                                                  (aset advanced? 0 true)
-                                                  (.accept c out-rel))
-                                                (finally
-                                                  (vw/clear-rel rel-writer))))))))))
-             (aget advanced? 0))
+            (when (= ::full-outer-join join-type)
+              (let [build-rel (.getBuiltRelation rel-map)
+                    build-row-count (long (.rowCount build-rel))
+                    unmatched-build-idxs (RoaringBitmap/flip matched-build-idxs 0 build-row-count)]
+                (.remove unmatched-build-idxs nil-row-idx)
 
-           (when (= :full-outer join-type)
-             (let [build-rel (.getBuiltRelation rel-map)
-                   build-row-count (long (.rowCount build-rel))
-                   unmatched-build-idxs (RoaringBitmap/flip matched-build-idxs 0 build-row-count)]
-               (when-not (.isEmpty unmatched-build-idxs)
-                 (.add matched-build-idxs 0 build-row-count)
+                (when-not (.isEmpty unmatched-build-idxs)
+                  ;; this means .isEmpty will be true on the next iteration (we flip the bitmap)
+                  (.add matched-build-idxs 0 build-row-count)
 
-                 (doseq [^IRowCopier row-copier (concat (for [col-name (map name build-column-names)]
-                                                          (vw/->row-copier (.writerForName rel-writer col-name) (.vectorForName build-rel col-name)))
-
-                                                        (for [probe-col-name (map name (set/difference probe-column-names build-column-names))]
-                                                          (vw/->null-row-copier (.writerForName rel-writer probe-col-name))))]
-
-                   (.forEach unmatched-build-idxs
-                             (reify IntConsumer
-                               (accept [_ build-idx]
-                                 (.copyRow row-copier build-idx)))))
-
-                 (with-open [out-rel (vw/rel-writer->reader rel-writer)]
-                   (.accept c out-rel)
-                   true))))))))
+                  (let [nil-rel (->nil-rel probe-column-names)
+                        build-sel (.toArray unmatched-build-idxs)
+                        probe-sel (int-array (alength build-sel))]
+                    (.accept c (join-rels nil-rel rel-map [probe-sel build-sel]))
+                    true))))))))
 
   (close [_]
     (run! #(.clear ^MutableRoaringBitmap %) pushdown-blooms)
-    (util/try-close rel-writer)
     (util/try-close rel-map)
     (util/try-close build-cursor)
     (util/try-close probe-cursor)))
 
-(defn- vrepeatedly
-  "Like clojure.core/repeatedly, but returns a vector."
-  [n f]
-  (let [n (int n)
-        oarr (object-array n)]
-    (loop [i (int 0)]
-      (if (< i n)
-        (do (aset oarr i (f)) (recur (unchecked-inc-int i)))
-        (vec oarr)))))
-
 (defn ->equi-join-cursor ^core2.ICursor [^BufferAllocator allocator,
                                          ^ICursor left-cursor, left-key-column-names, left-column-names
-                                         ^ICursor right-cursor, right-key-column-names, right-column-names]
+                                         ^ICursor right-cursor, right-key-column-names, right-column-names
+                                         theta-selector]
   (JoinCursor. allocator
                left-cursor left-key-column-names left-column-names
                right-cursor right-key-column-names right-column-names
-               (vw/->rel-writer allocator)
                (emap/->relation-map allocator {:build-key-col-names left-key-column-names
                                                :probe-key-col-names right-key-column-names})
                nil
-               (vrepeatedly (count right-key-column-names) #(MutableRoaringBitmap.))
-               :inner))
+               (vec (repeatedly (count right-key-column-names) #(MutableRoaringBitmap.)))
+               ::inner-join
+               theta-selector))
 
 (defn ->left-semi-equi-join-cursor ^core2.ICursor [^BufferAllocator allocator,
                                                    ^ICursor left-cursor, left-key-column-names, left-column-names
-                                                   ^ICursor right-cursor, right-key-column-names, right-column-names]
+                                                   ^ICursor right-cursor, right-key-column-names, right-column-names
+                                                   theta-selector]
   (JoinCursor. allocator
                right-cursor right-key-column-names right-column-names
                left-cursor left-key-column-names left-column-names
-               (vw/->rel-writer allocator)
                (emap/->relation-map allocator {:build-key-col-names right-key-column-names
                                                :probe-key-col-names left-key-column-names})
                nil
-               (vrepeatedly (count right-key-column-names) #(MutableRoaringBitmap.))
-               :semi))
+               (vec (repeatedly (count right-key-column-names) #(MutableRoaringBitmap.)))
+               ::semi-join
+               theta-selector))
+
+(defn- add-nil-row!
+  "Due to lack of no-copy append support for vectors / relations, we take advantage of the fact we are already
+  copying into our rel-map to add a nil-row, that can be used with selections of the build-rel for outer-joins."
+  [^IRelationMap rel-map col-names]
+
+  (doto (.buildFromRelation rel-map (->nil-rel col-names))
+    (.add nil-row-idx))
+
+  rel-map)
 
 (defn ->left-outer-equi-join-cursor ^core2.ICursor [^BufferAllocator allocator,
                                                     ^ICursor left-cursor, left-key-column-names, left-column-names
-                                                    ^ICursor right-cursor, right-key-column-names, right-column-names]
+                                                    ^ICursor right-cursor, right-key-column-names, right-column-names
+                                                    theta-selector]
   (JoinCursor. allocator
                right-cursor right-key-column-names right-column-names
                left-cursor left-key-column-names left-column-names
-               (vw/->rel-writer allocator)
-               (emap/->relation-map allocator {:build-key-col-names right-key-column-names
-                                               :probe-key-col-names left-key-column-names})
+               (doto (emap/->relation-map allocator {:build-key-col-names right-key-column-names
+                                                     :probe-key-col-names left-key-column-names})
+                 (add-nil-row! right-column-names))
                nil
-               (vrepeatedly (count right-key-column-names) #(MutableRoaringBitmap.))
-               :left-outer))
+               (vec (repeatedly (count right-key-column-names) #(MutableRoaringBitmap.)))
+               ::left-outer-join
+               theta-selector))
 
 (defn ->full-outer-equi-join-cursor ^core2.ICursor [^BufferAllocator allocator,
                                                     ^ICursor left-cursor, left-key-column-names, left-column-names
-                                                    ^ICursor right-cursor, right-key-column-names, right-column-names]
+                                                    ^ICursor right-cursor, right-key-column-names, right-column-names
+                                                    theta-selector]
   (JoinCursor. allocator
                left-cursor left-key-column-names left-column-names
                right-cursor right-key-column-names right-column-names
-               (vw/->rel-writer allocator)
-               (emap/->relation-map allocator {:build-key-col-names left-key-column-names
-                                               :probe-key-col-names right-key-column-names})
+               (doto (emap/->relation-map allocator {:build-key-col-names left-key-column-names
+                                                     :probe-key-col-names right-key-column-names})
+                 (add-nil-row! left-column-names))
                (RoaringBitmap.)
-               (vrepeatedly (count right-key-column-names) #(MutableRoaringBitmap.))
-               :full-outer))
+               (vec (repeatedly (count right-key-column-names) #(MutableRoaringBitmap.)))
+               ::full-outer-join
+               theta-selector))
 
 (defn ->left-anti-semi-equi-join-cursor ^core2.ICursor [^BufferAllocator allocator,
                                                         ^ICursor left-cursor, left-key-column-names, left-column-names
-                                                        ^ICursor right-cursor, right-key-column-names, right-column-names]
+                                                        ^ICursor right-cursor, right-key-column-names, right-column-names
+                                                        theta-selector]
   (JoinCursor. allocator
                right-cursor right-key-column-names right-column-names
                left-cursor left-key-column-names left-column-names
-               (vw/->rel-writer allocator)
                (emap/->relation-map allocator {:build-key-col-names right-key-column-names
                                                :probe-key-col-names left-key-column-names})
                nil
-               (vrepeatedly (count right-key-column-names) #(MutableRoaringBitmap.))
-               :anti-semi))
+               (vec (repeatedly (count right-key-column-names) #(MutableRoaringBitmap.)))
+               ::anti-semi-join
+               theta-selector))


### PR DESCRIPTION
# Theta joins

Closes xtdb/xtdb#2061

## Problem 

We would like to be able to specify predicate conditions for joins beyond equality.

## Solution

Add the ability to specify expressions in the condition list of the `:join` operator in the logical plan. e.g 

`[:join [{x y}] left right]` 

The `[{x y}]` is the join condition vector, in this case containing a single equi-join clause.

To add a theta condition, we could add an expression to the join condition vector:

`[:join [{x y} (= z 42)] left right]`

You can mix-and-match as many theta expressions into the condition list as you might like.

__important__
The initial spec for theta will disallow join conditions only consisting of theta specs (e.g no equi join portion), a bit more work will need to be done to make this possible - but until we are using indexes, there are few advantages over using a `:select` on a cross join in the plan instead.

## Semi / Anti joins

Along side inner/outer joins, support for theta is extended to semi & anti-join although an argument can be made to remove those options as we do not yet leverage indexes as part of theta join execution.