### PR TITLE
[show] Metadata manager keeps track of the field for each column, #134

### DIFF
--- a/core/src/core2/expression.clj
+++ b/core/src/core2/expression.clj
@@ -1701,10 +1701,6 @@
     op)
   :default ::default)
 
-(defn field-with-name ^org.apache.arrow.vector.types.pojo.Field [^Field field, ^String col-name]
-  (apply types/->field col-name (.getType field) (.isNullable field)
-         (.getChildren field)))
-
 (defmethod emit-expr :struct [{:keys [entries]} col-name opts]
   (let [entries (vec (for [[k v] entries]
                        (emit-expr v (name k) opts)))]
@@ -1769,7 +1765,7 @@
 (defmethod emit-expr :variable [{:keys [variable]} col-name {:keys [var-fields]}]
   (let [^Field out-field (-> (or (get var-fields variable)
                                  (throw (IllegalArgumentException. (str "missing variable: " variable ", available " (pr-str (set (keys var-fields)))))))
-                             (field-with-name col-name))]
+                             (types/field-with-name col-name))]
     (fn [^IIndirectRelation in-rel al _params]
       (let [in-vec (.vectorForName in-rel (name variable))
             out-vec (.createVector out-field al)]

--- a/core/src/core2/expression/temporal.clj
+++ b/core/src/core2/expression/temporal.clj
@@ -1,6 +1,5 @@
 (ns core2.expression.temporal
-  (:require [clojure.walk :as w]
-            [core2.expression :as expr]
+  (:require [core2.expression :as expr]
             [core2.expression.macro :as emacro]
             [core2.expression.metadata :as expr.meta]
             [core2.expression.walk :as ewalk]
@@ -8,7 +7,7 @@
             [core2.types :as types]
             [core2.util :as util])
   (:import java.time.Instant
-           [org.apache.arrow.vector.types.pojo ArrowType$Duration ArrowType$Int ArrowType$Timestamp ArrowType$Interval ArrowType$Date ArrowType ArrowType$Null]
+           [org.apache.arrow.vector.types.pojo ArrowType$Duration ArrowType$Int ArrowType$Timestamp ArrowType$Interval ArrowType$Date]
            org.apache.arrow.vector.types.TimeUnit
            [java.time LocalDate Period Duration]
            [org.apache.arrow.vector PeriodDuration]

--- a/core/src/core2/vector/extensions/XtExtensionType.java
+++ b/core/src/core2/vector/extensions/XtExtensionType.java
@@ -34,7 +34,7 @@ public abstract class XtExtensionType extends ArrowType.ExtensionType {
     @Override
     public ArrowType deserialize(ArrowType storageType, String serializedData) {
         if (!storageType.equals(this.storageType)) {
-            throw new UnsupportedOperationException("Cannot construct XtExtensionType from underlying type " + storageType);
+            throw new UnsupportedOperationException(String.format("Cannot construct '%s' from underlying type %s", getClass().getSimpleName(), storageType));
         } else {
             return deserialize(serializedData);
         }

--- a/test-resources/can-build-chunk-as-arrow-ipc-file-format/metadata-0000000000000000.arrow.json
+++ b/test-resources/can-build-chunk-as-arrow-ipc-file-format/metadata-0000000000000000.arrow.json
@@ -136,6 +136,9 @@
         "metadata" : [{
           "value" : "TIMESTAMPMICROTZ",
           "key" : "minor-type"
+        },{
+          "value" : "UTC",
+          "key" : "tz"
         }]
       }]
     },{

--- a/test-resources/can-handle-dynamic-cols-in-same-block/metadata-0000000000000000.arrow.json
+++ b/test-resources/can-handle-dynamic-cols-in-same-block/metadata-0000000000000000.arrow.json
@@ -136,6 +136,9 @@
         "metadata" : [{
           "value" : "TIMESTAMPMICROTZ",
           "key" : "minor-type"
+        },{
+          "value" : "UTC",
+          "key" : "tz"
         }]
       },{
         "name" : "list",

--- a/test-resources/multi-block-metadata/metadata-0000000000000000.arrow.json
+++ b/test-resources/multi-block-metadata/metadata-0000000000000000.arrow.json
@@ -109,6 +109,9 @@
         "metadata" : [{
           "value" : "TIMESTAMPMICROTZ",
           "key" : "minor-type"
+        },{
+          "value" : "UTC",
+          "key" : "tz"
         }]
       },{
         "name" : "float8",


### PR DESCRIPTION
Following on from xtdb/core2#184 in the xtdb/xtdb#2097 quest, the metadata-manager now keeps track of the widest-possible `Field` for each column as we go.

This is done in two parts:
* For each chunk's metadata, we can decode the `Field` for each column (`->column-field`). For lists/structs, this is a recursive process.
* Given the current `Field` for each column, and a new chunk's metadata, we can merge the new type information into our running state (`types/merge-fields`). If we now have differing types for a field, we introduce a union. Likewise, for lists/structs, this is a recursive process. See `test-merge-fields` for more examples.

At startup, we play through all of the metadata chunks to rebuild this `Field` cache. 

Next:
* Getting the scan operator to transform its input vectors in each batch into this `Field`. We may need to take the watermark into account too.
* On with each operator.