### PR TITLE
Return null if promotable-agg-factory receives only nulls or empty rel

### DIFF
--- a/core/src/core2/DenseUnionUtil.java
+++ b/core/src/core2/DenseUnionUtil.java
@@ -59,4 +59,17 @@ public class DenseUnionUtil {
 
         return offset;
     }
+
+    public static boolean isNull (DenseUnionVector duv, int idx) {
+        while (true) {
+          var subVec = duv.getVectorByType(duv.getTypeId(idx));
+          var subVecIdx = duv.getOffset(idx);
+          if (subVec instanceof DenseUnionVector) {
+             duv = (DenseUnionVector)subVec;
+             idx = subVecIdx;
+          } else {
+              return subVec.isNull(subVecIdx);
+          }
+        }
+    }
 }

--- a/core/src/core2/operator/group_by.clj
+++ b/core/src/core2/operator/group_by.clj
@@ -233,7 +233,7 @@
             (getFromColumnName [_] from-name)
 
             (aggregate [_ in-vec group-mapping]
-              (when (pos? (.getValueCount in-vec))
+              (when (not (.isAllNull in-vec))
                 (let [from-val-types (expr/field->value-types (.getField (.getVector in-vec)))
                       out-vec (.maybePromote out-pvec from-val-types)
                       acc-type (.getType (.getField out-vec))

--- a/core/src/core2/vector/IIndirectVector.java
+++ b/core/src/core2/vector/IIndirectVector.java
@@ -18,6 +18,8 @@ public interface IIndirectVector<V extends ValueVector> extends AutoCloseable {
 
     int getValueCount();
 
+    boolean isAllNull();
+
     IIndirectVector<V> withName(String colName);
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
The solution presented involves asking the question 'is every element null' on (potentially indirect) vectors as they arrive to aggregate, and if so, skipping the aggregation.

This is similar to the previous check of `(pos? (.getValueCount in-vec))` in spirit.

Because such a function requires a different implementation when you a selection present (IndirectVector) we have opted to add an interface method to IIndirectVector to allow us private access to the index array in that case. 

By implementing the check on input-vector we avoid a crash in `.maybePromote` due to least upper bound requiring us to see at least one numeric type in the input vector.  maybePromote is responsible for determining the type of the initial accumulator value, which currently requires at least one numeric input. An alternative solution could involve revisiting the promotion of null vectors (to ensure the acc type remains null) and fix a few aggregate implementations emit-init steps.

An additional complication with changing `.maybePromote` is that you may receive monomorphic vectors with nulls in the validity bitmap, which again would mess with accumulator init values. You really do need to know if all elements are null, or once visited by the agg have been observed to be null - not just the types.

The code in this PR includes a DenseUnionUtil function for determining the nullness of (potentially nested) DUV elements. We can avoid this function if we disallow nested DenseUnion legs (say by throwing an exception).

Fixes xtdb/xtdb#2125 
