### PR TITLE
SQL 2011 (Temporal) Spike

### DIFF
--- a/core/resources/core2/sql/parser/SQL2011.edn
+++ b/core/resources/core2/sql/parser/SQL2011.edn
@@ -750,11 +750,6 @@
   :parsers
   ({:tag :nt, :keyword :left_paren, :hide true}
    {:tag :nt, :keyword :right_paren, :hide true})},
- :overlaps_predicate_part_2
- {:tag :cat,
-  :parsers
-  ({:tag :string, :string "OVERLAPS"}
-   {:tag :nt, :keyword :row_value_predicand_2})},
  :general_logarithm_base
  {:tag :nt,
   :keyword :numeric_value_expression,
@@ -830,7 +825,7 @@
  :period_predicand
  {:tag :alt,
   :parsers
-  ({:tag :nt, :keyword :period_reference}
+  ({:tag :nt, :keyword :column_reference}
    {:tag :cat,
     :parsers
     ({:tag :string, :string "PERIOD"}
@@ -884,8 +879,7 @@
    {:tag :nt, :keyword :octet_like_predicate_part_2}
    {:tag :nt, :keyword :regex_like_predicate_part_2}
    {:tag :nt, :keyword :null_predicate_part_2}
-   {:tag :nt, :keyword :quantified_comparison_predicate_part_2}
-   {:tag :nt, :keyword :overlaps_predicate_part_2}),
+   {:tag :nt, :keyword :quantified_comparison_predicate_part_2}),
   :red {:reduction-type :raw}},
  :basic_identifier_chain
  {:tag :nt, :keyword :identifier_chain, :red {:reduction-type :raw}},
@@ -1152,10 +1146,6 @@
  {:tag :nt,
   :keyword :character_value_expression,
   :red {:reduction-type :raw}},
- :row_value_predicand_2
- {:tag :nt,
-  :keyword :row_value_predicand,
-  :red {:reduction-type :raw}},
  :column_reference {:tag :nt, :keyword :basic_identifier_chain},
  :trim_array_function
  {:tag :cat,
@@ -1281,10 +1271,6 @@
    {:tag :nt, :keyword :direct_select_statement__multiple_rows}
    {:tag :nt, :keyword :insert_statement}
    {:tag :nt, :keyword :update_statement__searched}),
-  :red {:reduction-type :raw}},
- :overlaps_predicate_part_1
- {:tag :nt,
-  :keyword :row_value_predicand_1,
   :red {:reduction-type :raw}},
  :array_primary
  {:tag :alt,
@@ -1584,10 +1570,6 @@
  :binary_factor
  {:tag :nt, :keyword :binary_primary, :red {:reduction-type :raw}},
  :greater_than_or_equals_operator {:tag :string, :string ">="},
- :row_value_predicand_1
- {:tag :nt,
-  :keyword :row_value_predicand,
-  :red {:reduction-type :raw}},
  :interval_fractional_seconds_precision
  {:tag :nt, :keyword :unsigned_integer, :red {:reduction-type :raw}},
  :all {:tag :string, :string "ALL"},
@@ -1985,11 +1967,7 @@
  {:tag :nt, :keyword :datetime_value, :red {:reduction-type :raw}},
  :seconds_fraction
  {:tag :nt, :keyword :unsigned_integer, :red {:reduction-type :raw}},
- :case_operand
- {:tag :alt,
-  :parsers
-  ({:tag :nt, :keyword :row_value_predicand}
-   {:tag :nt, :keyword :overlaps_predicate_part_1})},
+ :case_operand {:tag :nt, :keyword :row_value_predicand},
  :join_condition
  {:tag :cat,
   :parsers
@@ -2776,7 +2754,6 @@
    {:tag :nt, :keyword :null_predicate}
    {:tag :nt, :keyword :quantified_comparison_predicate}
    {:tag :nt, :keyword :exists_predicate}
-   {:tag :nt, :keyword :overlaps_predicate}
    {:tag :nt, :keyword :period_predicate}),
   :red {:reduction-type :raw}},
  :escape_octet
@@ -2933,11 +2910,6 @@
   :red {:reduction-type :raw}},
  :left_bracket_trigraph
  {:tag :string, :string "??(", :red {:reduction-type :raw}},
- :overlaps_predicate
- {:tag :cat,
-  :parsers
-  ({:tag :nt, :keyword :overlaps_predicate_part_1}
-   {:tag :nt, :keyword :overlaps_predicate_part_2})},
  :boolean_value_expression
  {:tag :alt,
   :parsers

--- a/test/core2/sql/temporal_test.clj
+++ b/test/core2/sql/temporal_test.clj
@@ -1,0 +1,115 @@
+(ns core2.sql.temporal-test
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [clojure.string :as str]
+            [core2.sql.plan-test :as pt]
+            [core2.api :as c2]
+            [core2.operator :as op]
+            [core2.snapshot :as snap]
+            [core2.test-util :as tu]))
+
+(use-fixtures :each tu/with-node)
+
+
+(deftest system-time-as-of
+  (let [snapshot-factory (tu/component ::snap/snapshot-factory)
+
+        !tx1 (c2/submit-tx tu/*node* [[:put {:_id :my-doc, :last_updated "tx1"}]])
+        tx1-system-time (str/replace (str/replace (str (:tx-time @!tx1)) "T" " ") "Z" "")
+        one-second-before-tx1-system-time (str/replace (str/replace (str (.minusSeconds (:tx-time @!tx1) 1)) "T" " ") "Z" "")]
+
+    (is (= []
+           (op/query-ra (pt/plan-sql (str "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME AS OF TIMESTAMP '" one-second-before-tx1-system-time "'"))
+                        (snap/snapshot snapshot-factory !tx1))))
+
+    (is (= [{:last_updated "tx1"}]
+           (op/query-ra (pt/plan-sql (str "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME AS OF TIMESTAMP '" tx1-system-time "'"))
+                        (snap/snapshot snapshot-factory !tx1))))))
+
+(deftest app-time-period-predicates
+
+  (testing "OVERLAPS"
+    (let [snapshot-factory (tu/component ::snap/snapshot-factory)
+
+          !tx1 (c2/submit-tx tu/*node* [[:put {:_id :my-doc, :last_updated "2000"}
+                                         {:_valid-time-start #inst "2000"}]
+                                        [:put {:_id :my-doc, :last_updated "3000"}
+                                         {:_valid-time-start #inst "3000"}]
+                                        [:put {:_id :some-other-doc, :last_updated "4000"}
+                                         {:_valid-time-start #inst "4000"
+                                          :_valid-time-end #inst "4001"}]])
+          db (snap/snapshot snapshot-factory !tx1)]
+
+
+      (is (= [{:last_updated "2000"}]
+             (op/query-ra (pt/plan-sql "SELECT foo.last_updated FROM foo WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')")
+                          db)))
+
+      (is (= [{:last_updated "3000"}]
+             (op/query-ra (pt/plan-sql "SELECT foo.last_updated FROM foo WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '3000-01-01 00:00:00', TIMESTAMP '3001-01-01 00:00:00')")
+                          db)))
+
+      (is (= [{:last_updated "3000"} {:last_updated "4000"}]
+             (op/query-ra (pt/plan-sql "SELECT foo.last_updated FROM foo WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '4000-01-01 00:00:00', TIMESTAMP '4001-01-01 00:00:00')")
+                          db)))
+
+      (is (= [{:last_updated "3000"}]
+             (op/query-ra (pt/plan-sql "SELECT foo.last_updated FROM foo WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '4002-01-01 00:00:00', TIMESTAMP '9999-01-01 00:00:00')")
+                          db))))))
+
+(deftest app-time-multiple-tables
+  (let [snapshot-factory (tu/component ::snap/snapshot-factory)
+
+        !tx1 (c2/submit-tx tu/*node* [[:put {:_id :foo-doc, :last_updated "2001"}
+                                       {:_valid-time-start #inst "2000"
+                                        :_valid-time-end #inst "2001"}]
+                                      [:put {:_id :bar-doc, :l_updated "2003"}
+                                       {:_valid-time-start #inst "2002"
+                                        :_valid-time-end #inst "2003"}]])
+        db (snap/snapshot snapshot-factory !tx1)]
+
+    (is (= [{:last_updated "2001"}]
+           (op/query-ra (pt/plan-sql "SELECT foo.last_updated FROM foo
+                                     WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '1999-01-01 00:00:00', TIMESTAMP '2002-01-01 00:00:00')") db)))
+
+    (is (= [{:l_updated "2003"}]
+           (op/query-ra (pt/plan-sql "SELECT bar.l_updated FROM bar
+                                     WHERE bar.APP_TIME OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00', TIMESTAMP '2003-01-01 00:00:00')") db)))
+
+    (is (= []
+           (op/query-ra (pt/plan-sql "SELECT foo.last_updated, bar.l_updated FROM foo, bar
+                                     WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '1999-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')
+                                     AND
+                                     bar.APP_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')") db)))
+
+    (is (= [{:last_updated "2001", :l_updated "2003"}]
+           (op/query-ra (pt/plan-sql "SELECT foo.last_updated, bar.l_updated FROM foo, bar
+                                     WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')
+                                     AND
+                                     bar.APP_TIME OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00', TIMESTAMP '2003-01-01 00:00:00')") db)))
+    (is (= []
+           (op/query-ra (pt/plan-sql "SELECT foo.last_updated, bar.name FROM foo, bar
+                                     WHERE foo.APP_TIME OVERLAPS bar.APP_TIME") db)))))
+
+(deftest app-time-joins
+  (let [snapshot-factory (tu/component ::snap/snapshot-factory)
+
+        !tx1 (c2/submit-tx tu/*node* [[:put {:_id :bill, :name "Bill"}
+                                       {:_valid-time-start #inst "2016"
+                                        :_valid-time-end #inst "2019"}]
+                                      [:put {:_id :jeff, :also_name "Jeff"}
+                                       {:_valid-time-start #inst "2018"
+                                        :_valid-time-end #inst "2020"}]])
+        db (snap/snapshot snapshot-factory !tx1)]
+
+    (is (= []
+           (op/query-ra (pt/plan-sql "SELECT foo.name, bar.also_name
+                                     FROM foo, bar
+                                     WHERE foo.APP_TIME SUCCEEDS bar.APP_TIME") db)))
+
+    (is (= [{:name "Bill" :also_name "Jeff"}]
+           (op/query-ra (pt/plan-sql "SELECT foo.name, bar.also_name
+                                     FROM foo, bar
+                                     WHERE foo.APP_TIME OVERLAPS bar.APP_TIME") db)))))
+
+
+


### PR DESCRIPTION
Adds Initial spike of temporal SQL, adding both SYSTEM_TIME and app time queries.

Concessions/Considerations:

- PR opts to parse period_references as column_references. This is almost certainly incorrect periods are distinct from cols and should be resolved differently. However a lot of our analysis code relies on column_references, I think they could be duplicated to work for period_references, or perhaps moved down to work on basic_identifier_chains, but this seemed like a rabbit hole without much immediate benefit. We should revisit this when we have time. 

- PR also comments out overlaps_predicate this is an older pre SQL 2011 predicate, its functionality seems mostly superseded by period_predicate_overlaps, however it does offer the ability to combine a datetime + interval to build a "period" of sorts. Main reason for this is during parsing we mistake period predicates for these when having app_time on both sides. Previous concession might not be helping here, but I think it has more to do with not being able to detect/enforce that either side of the overlaps pred must be made up 2 elements. Again we should go back and add this, but seems a lower priority than other features.

> The degrees of <row value predicand 1> and <row value predicand 2> shall both be 2.

Remaining work is fleshing out the sys/app time predicates/clauses and full support for all datetime literals.