### PR TITLE
Real SQL on the wire, #297

### DIFF
--- a/core/src/core2/tx_producer.clj
+++ b/core/src/core2/tx_producer.clj
@@ -45,7 +45,7 @@
 
 (defmethod tx-op-spec :sql [_]
   (s/cat :op #{:sql}
-         :plan vector?
+         :query string?
          :param-rows (s/? (s/coll-of (s/coll-of any? :kind sequential?) :kind sequential?))))
 
 (s/def ::tx-op
@@ -148,12 +148,12 @@
 
 (defn- ->sql-writer [^IDenseUnionWriter tx-ops-writer]
   (let [sql-writer (.asStruct (.writerForTypeId tx-ops-writer 3))
-        plan-writer (.writerForName sql-writer "query")
+        query-writer (.writerForName sql-writer "query")
         param-rows-writer (.writerForName sql-writer "param-rows")]
-    (fn write-sql! [{:keys [plan param-rows]}]
+    (fn write-sql! [{:keys [query param-rows]}]
       (.startValue sql-writer)
 
-      (types/write-value! (pr-str plan) plan-writer)
+      (types/write-value! query query-writer)
       (types/write-value! (vec (for [param-row param-rows]
                                  (zipmap (map #(keyword (str "?_" %)) (range)) param-row)))
                           param-rows-writer)

--- a/test-resources/can-write-tx-to-arrow-ipc-streaming-format.json
+++ b/test-resources/can-write-tx-to-arrow-ipc-streaming-format.json
@@ -435,7 +435,7 @@
               "type" : {
                 "name" : "union",
                 "mode" : "Dense",
-                "typeIds" : [0]
+                "typeIds" : [0,1]
               },
               "children" : [{
                 "name" : "struct0",
@@ -501,6 +501,31 @@
                     },
                     "children" : [ ]
                   },{
+                    "name" : "i64",
+                    "nullable" : false,
+                    "type" : {
+                      "name" : "int",
+                      "bitWidth" : 64,
+                      "isSigned" : true
+                    },
+                    "children" : [ ]
+                  }]
+                }]
+              },{
+                "name" : "struct1",
+                "nullable" : false,
+                "type" : {
+                  "name" : "struct"
+                },
+                "children" : [{
+                  "name" : "?_0",
+                  "nullable" : false,
+                  "type" : {
+                    "name" : "union",
+                    "mode" : "Dense",
+                    "typeIds" : [0]
+                  },
+                  "children" : [{
                     "name" : "i64",
                     "nullable" : false,
                     "type" : {
@@ -824,18 +849,18 @@
             "name" : "query",
             "count" : 3,
             "VALIDITY" : [1,1,1],
-            "OFFSET" : [0,66,528,957],
-            "DATA" : ["[:insert {:table \"foo\"} [:table [{:foo ?_0, :bar ?_1, :baz ?_2}]]]","[:update {:table \"foo\"} [:project [_iid _row-id id {bar \"world\"} {application_time_start (max application_time_start #inst \"2021-01-01T00:00:00.000-00:00\")} {application_time_end (min application_time_end #inst \"2024-01-01T00:00:00.000-00:00\")}] [:scan [_iid _row-id {id (= id 1)} {application_time_start (<= application_time_start #inst \"2024-01-01T00:00:00.000-00:00\")} {application_time_end (>= application_time_end #inst \"2021-01-01T00:00:00.000-00:00\")}]]]]","[:delete {:table \"foo\"} [:project [_iid {application_time_start (max application_time_start #inst \"2021-01-01T00:00:00.000-00:00\")} {application_time_end (min application_time_end #inst \"2024-01-01T00:00:00.000-00:00\")}] [:scan [_iid {id (= id 1)} {application_time_start (<= application_time_start #inst \"2024-01-01T00:00:00.000-00:00\")} {application_time_end (>= application_time_end #inst \"2021-01-01T00:00:00.000-00:00\")}]]]]"]
+            "OFFSET" : [0,48,161,249],
+            "DATA" : ["INSERT INTO foo (foo, bar, baz) VALUES (?, ?, ?)","UPDATE foo FOR PORTION OF APP_TIME FROM DATE '2021-01-01' TO DATE '2024-01-01' SET bar = 'world' WHERE foo.id = ?","DELETE FROM foo FOR PORTION OF APP_TIME FROM DATE '2023' TO DATE '2025' WHERE foo.id = ?"]
           },{
             "name" : "param-rows",
             "count" : 3,
             "VALIDITY" : [1,1,1],
-            "OFFSET" : [0,2,2,2],
+            "OFFSET" : [0,2,3,4],
             "children" : [{
               "name" : "$data$",
-              "count" : 2,
-              "TYPE_ID" : [0,0],
-              "OFFSET" : [0,1],
+              "count" : 4,
+              "TYPE_ID" : [0,0,1,1],
+              "OFFSET" : [0,1,0,1],
               "children" : [{
                 "name" : "struct0",
                 "count" : 2,
@@ -881,6 +906,22 @@
                     "count" : 1,
                     "VALIDITY" : [1],
                     "DATA" : ["12"]
+                  }]
+                }]
+              },{
+                "name" : "struct1",
+                "count" : 2,
+                "VALIDITY" : [1,1],
+                "children" : [{
+                  "name" : "?_0",
+                  "count" : 2,
+                  "TYPE_ID" : [0,0],
+                  "OFFSET" : [0,1],
+                  "children" : [{
+                    "name" : "i64",
+                    "count" : 2,
+                    "VALIDITY" : [1,1],
+                    "DATA" : ["1","1"]
                   }]
                 }]
               }]

--- a/test/core2/indexer_test.clj
+++ b/test/core2/indexer_test.clj
@@ -596,8 +596,7 @@
 
         (let [last-tx-key (c2/map->TransactionInstant {:tx-id 0, :sys-time (util/->instant #inst "2020-01-01")})]
           (t/is (= last-tx-key
-                   @(c2/submit-tx node [[:sql '[:insert {:table "table"}
-                                                [:table [{:id ?_0, :foo ?_1, :bar ?_2, :baz ?_3}]]]
+                   @(c2/submit-tx node [[:sql "INSERT INTO table (id, foo, bar, baz) VALUES (?, ?, ?, ?)"
                                          '[[0, 2, "hello", 12]
                                            [1, 1, "world", 3.3]]]])))
 

--- a/test/core2/metadata_test.clj
+++ b/test/core2/metadata_test.clj
@@ -44,7 +44,7 @@
 
 (t/deftest test-param-metadata-error-310
   (let [!tx1 (c2/submit-tx tu/*node*
-                           [[:sql (pt/plan-sql "INSERT INTO users (id, name, application_time_start) VALUES (?, ?, ?)")
+                           [[:sql "INSERT INTO users (id, name, application_time_start) VALUES (?, ?, ?)"
                              [["dave", "Dave", #inst "2018"]
                               ["claire", "Claire", #inst "2019"]]]])]
 

--- a/test/core2/tx_producer_test.clj
+++ b/test/core2/tx_producer_test.clj
@@ -33,24 +33,13 @@
                           :cpu-avg-1min 24.81,
                           :mem-free 4.10011078E8,
                           :mem-used 5.89988922E8}]
-                   [:sql '[:insert {:table "foo"}
-                           [:table [{:foo ?_0, :bar ?_1, :baz ?_2}]]]
+                   [:sql "INSERT INTO foo (foo, bar, baz) VALUES (?, ?, ?)"
                     [[1 nil 3.3]
                      [2 "hello" 12]]]
-                   [:sql '[:update {:table "foo"}
-                           [:project [_iid _row-id id {bar "world"}
-                                      {application_time_start (max application_time_start #inst "2021")}
-                                      {application_time_end (min application_time_end #inst "2024")}]
-                            [:scan [_iid _row-id {id (= id 1)}
-                                    {application_time_start (<= application_time_start #inst "2024")}
-                                    {application_time_end (>= application_time_end #inst "2021")}]]]]]
-                   [:sql '[:delete {:table "foo"}
-                           [:project [_iid
-                                      {application_time_start (max application_time_start #inst "2021")}
-                                      {application_time_end (min application_time_end #inst "2024")}]
-                            [:scan [_iid {id (= id 1)}
-                                    {application_time_start (<= application_time_start #inst "2024")}
-                                    {application_time_end (>= application_time_end #inst "2021")}]]]]]]
+                   [:sql "UPDATE foo FOR PORTION OF APP_TIME FROM DATE '2021-01-01' TO DATE '2024-01-01' SET bar = 'world' WHERE foo.id = ?"
+                    [[1]]]
+                   [:sql "DELETE FROM foo FOR PORTION OF APP_TIME FROM DATE '2023' TO DATE '2025' WHERE foo.id = ?"
+                    [[1]]]]
                   {:sys-time (util/->instant #inst "2021")
                    :current-time (util/->instant #inst "2021")})
                  (c2-json/arrow-streaming->json)


### PR DESCRIPTION
Based on PR #308 (this PR includes both commits - filter it just to the #297 one to see this change in isolation), resolves #297.

We've now got real SQL on the wire, no more user-visible DML plans :champagne: see [this API test](https://github.com/jarohen/xtdb-core2/blob/sql-on-the-wire-297/test/core2/api_test.clj#L150-L192) for a usage example.

* I've still not included support for aborting transactions as yet (tracked in #127) - if you submit incorrect DML, it'll just blow up.