### PR TITLE
Temporal casting in the backend

### DIFF
--- a/core/src/core2/expression.clj
+++ b/core/src/core2/expression.clj
@@ -15,7 +15,7 @@
            core2.vector.PolyValueBox
            (java.nio ByteBuffer)
            (java.nio.charset StandardCharsets)
-           (java.time Clock Duration Instant LocalDate LocalDateTime OffsetDateTime Period ZoneOffset ZonedDateTime)
+           (java.time Clock Duration Instant LocalDate LocalDateTime LocalTime OffsetDateTime Period ZoneOffset ZonedDateTime)
            (java.util Arrays Date HashMap LinkedList)
            (java.util.function IntUnaryOperator)
            (java.util.regex Pattern)
@@ -211,7 +211,7 @@
 (defmethod write-value-code :null [_ & args] `(.writeNull ~@args))
 
 (doseq [[k sym] '{:bool Boolean, :i8 Byte, :i16 Short, :i32 Int, :i64 Long, :f32 Float, :f64 Double
-                  :date Int, :time Long, :timestamp-tz Long, :timestamp-local Long, :duration Long, :interval Object
+                  :date Int, :time-local Long, :timestamp-tz Long, :timestamp-local Long, :duration Long, :interval Object
                   :utf8 Buffer, :varbinary Buffer}]
   (defmethod read-value-code k [_ & args] `(~(symbol (str ".read" sym)) ~@args))
   (defmethod write-value-code k [_ & args] `(~(symbol (str ".write" sym)) ~@args)))
@@ -235,6 +235,7 @@
 (defmethod emit-value ZonedDateTime [_ code] `(util/instant->micros (util/->instant ~code)))
 (defmethod emit-value OffsetDateTime [_ code] `(util/instant->micros (util/->instant ~code)))
 (defmethod emit-value LocalDateTime [_ code] `(util/instant->micros (.toInstant ~code ZoneOffset/UTC)))
+(defmethod emit-value LocalTime [_ code] `(.toNanoOfDay ~code))
 (defmethod emit-value Duration [_ code] `(quot (.toNanos ~code) 1000))
 
 ;; consider whether a bound hash map for literal parameters would be better

--- a/core/src/core2/metadata.clj
+++ b/core/src/core2/metadata.clj
@@ -158,7 +158,7 @@
                                (pos? (.applyAsInt max-comparator values-idx types-vec-idx))))
                   (.copyFromSafe max-vec values-idx types-vec-idx content-vec))))))))))
 
-(doseq [type-head #{:int :float :utf8 :varbinary :timestamp-tz :timestamp-local :date :interval :time}]
+(doseq [type-head #{:int :float :utf8 :varbinary :timestamp-tz :timestamp-local :date :interval :time-local}]
   (defmethod type->metadata-writer type-head [_write-col-meta! metadata-root col-type] (->min-max-type-handler metadata-root col-type)))
 
 (defmethod col-type->type-metadata :fixed-size-binary [[type-head byte-width]]
@@ -185,10 +185,10 @@
 (defmethod type-metadata->col-type :date [type-metadata]
   [(get type-metadata "type-head"), (keyword (get type-metadata "date-unit"))])
 
-(defmethod col-type->type-metadata :time [[type-head time-unit]]
+(defmethod col-type->type-metadata :time-local [[type-head time-unit]]
   {"type-head" (name type-head), "time-unit" (name time-unit)})
 
-(defmethod type-metadata->col-type :time [type-metadata]
+(defmethod type-metadata->col-type :time-local [type-metadata]
   [(get type-metadata "type-head"), (keyword (get type-metadata "time-unit"))])
 
 (defmethod col-type->type-metadata :interval [[type-head interval-unit]]

--- a/core/src/core2/operator/group_by.clj
+++ b/core/src/core2/operator/group_by.clj
@@ -261,7 +261,7 @@
                      (types/least-upper-bound))]
     (reducing-agg-factory (into agg-opts
                                 {:to-type to-type
-                                 :val-expr {:op :call, :f :cast, :cast-type to-type
+                                 :val-expr {:op :call, :f :cast, :target-type to-type
                                             :args [{:op :variable, :variable from-name}]}
                                  :step-expr {:op :call, :f :+,
                                              :args [{:op :local, :local acc-local}
@@ -396,7 +396,7 @@
                      (types/least-upper-bound))]
     (reducing-agg-factory (into agg-opts
                                 {:to-type to-type
-                                 :val-expr {:op :call, :f :cast, :cast-type to-type
+                                 :val-expr {:op :call, :f :cast, :target-type to-type
                                             :args [{:op :variable, :variable from-name}]}
                                  :step-expr {:op :if,
                                              :pred {:op :call, :f compare-kw,

--- a/core/src/core2/types.clj
+++ b/core/src/core2/types.clj
@@ -111,7 +111,7 @@
     (.setSafe ^DateDayVector (.getVector writer) (.getPosition writer) (.toEpochDay v)))
 
   LocalTime
-  (value->col-type [_] [:time :nano])
+  (value->col-type [_] [:time-local :nano])
   (write-value! [v ^IVectorWriter writer]
     (.setSafe ^TimeNanoVector (.getVector writer) (.getPosition writer) (.toNanoOfDay v)))
 
@@ -435,7 +435,7 @@
       (derive :num :any)
 
       (derive :timestamp-tz :any) (derive :timestamp-local :any)
-      (derive :date :any) (derive :time :any) (derive :interval :any) (derive :duration :any)
+      (derive :date :any) (derive :time-local :any) (derive :interval :any) (derive :duration :any)
       (derive :varbinary :any) (derive :utf8 :any)
       (derive :extension-type :any)))
 
@@ -663,17 +663,17 @@
 
 ;;; time
 
-(defmethod col-type->field-name :time [[type-head time-unit]]
+(defmethod col-type->field-name :time-local [[type-head time-unit]]
   (str (name type-head) "-" (name time-unit)))
 
-(defmethod col-type->field* :time [col-name nullable? [_type-head time-unit]]
+(defmethod col-type->field* :time-local [col-name nullable? [_type-head time-unit]]
   (->field col-name
            (ArrowType$Time. (kw->time-unit time-unit)
                             (case time-unit (:second :milli) 32, (:micro :nano) 64))
            nullable?))
 
 (defmethod arrow-type->col-type ArrowType$Time [^ArrowType$Time arrow-type]
-  [:time (time-unit->kw (.getUnit arrow-type))])
+  [:time-local (time-unit->kw (.getUnit arrow-type))])
 
 ;;; duration
 

--- a/core/src/core2/util.clj
+++ b/core/src/core2/util.clj
@@ -96,16 +96,23 @@
    To do this for LocalDate and LocalDateTime, the provided SQL session time zone is assumed to be the implied time zone of the date/time."
   ^Instant [temporal ^ZoneId session-zone]
   (condp instance? temporal
-    LocalDate (sql-temporal->instant (.atTime ^LocalDate temporal (LocalTime/of 0 0)) session-zone)
+    LocalDate (sql-temporal->instant (.atTime ^LocalDate temporal LocalTime/MIDNIGHT) session-zone)
     LocalDateTime (.toInstant (.atZone ^LocalDateTime temporal session-zone))
     (->instant temporal)))
 
 (defn instant->micros ^long [^Instant inst]
-  (-> (Math/multiplyExact (.getEpochSecond inst) 1000000)
+  (-> (Math/multiplyExact (.getEpochSecond inst) #=(long 1e6))
       (Math/addExact (quot (.getNano inst) 1000))))
+
+(defn instant->nanos ^long [^Instant inst]
+  (-> (Math/multiplyExact (.getEpochSecond inst) #=(long 1e9))
+      (Math/addExact (long (.getNano inst)))))
 
 (defn micros->instant ^java.time.Instant [^long μs]
   (.plus Instant/EPOCH μs ChronoUnit/MICROS))
+
+(defn nanos->instant ^java.time.Instant [^long ns]
+  (.plus Instant/EPOCH ns ChronoUnit/NANOS))
 
 (def ^java.time.Instant end-of-time
   (Instant/parse "9999-12-31T23:59:59.999999Z"))

--- a/test/core2/expression/temporal_test.clj
+++ b/test/core2/expression/temporal_test.clj
@@ -37,83 +37,132 @@
     false #time/offset-date-time "2021-08-09T15:43:23+02:00" #time/date-time "2021-08-09T15:43:23" "+03:00"))
 
 (t/deftest test-cast-temporal
-  (letfn [(test-cast
-            ([src-value tgt-type] (test-cast src-value tgt-type {}))
-            ([src-value tgt-type {:keys [default-tz], :or {default-tz ZoneOffset/UTC}}]
-             (-> (tu/query-ra [:project [{'res `(~'cast ~'arg ~tgt-type)}]
-                               [:table [{}]]]
-                              {:default-tz default-tz
-                               :params {'arg src-value}})
-                 first :res)))]
+  (let [current-time #time/instant "2022-08-16T20:04:14.423452Z"]
+    (letfn [(test-cast
+              ([src-value tgt-type] (test-cast src-value tgt-type {}))
+              ([src-value tgt-type {:keys [default-tz], :or {default-tz ZoneOffset/UTC}}]
+               (-> (tu/query-ra [:project [{'res `(~'cast ~'arg ~tgt-type)}]
+                                 [:table [{}]]]
+                                {:current-time current-time
+                                 :default-tz default-tz
+                                 :params {'arg src-value}})
+                   first :res)))]
 
-    (t/testing "date ->"
-      (t/testing "date"
-        (t/is (= #time/date "2022-08-01"
-                 (test-cast #time/date "2022-08-01"
-                            [:date :milli]))))
+      (t/testing "date ->"
+        (t/testing "date"
+          (t/is (= #time/date "2022-08-01"
+                   (test-cast #time/date "2022-08-01"
+                              [:date :milli]))))
 
-      (t/testing "ts"
-        (t/is (= #time/date-time "2022-08-01T00:00:00"
-                 (test-cast #time/date "2022-08-01"
-                            [:timestamp-local :milli]))))
+        (t/testing "ts"
+          (t/is (= #time/date-time "2022-08-01T00:00:00"
+                   (test-cast #time/date "2022-08-01"
+                              [:timestamp-local :milli]))))
 
-      (t/testing "tstz"
-        (t/is (= #time/zoned-date-time "2022-07-31T16:00-07:00[America/Los_Angeles]"
-                 (test-cast #time/date "2022-08-01"
-                            [:timestamp-tz :nano "America/Los_Angeles"]
-                            {:default-tz (ZoneId/of "Europe/London")})))))
+        (t/testing "tstz"
+          (t/is (= #time/zoned-date-time "2022-07-31T16:00-07:00[America/Los_Angeles]"
+                   (test-cast #time/date "2022-08-01"
+                              [:timestamp-tz :nano "America/Los_Angeles"]
+                              {:default-tz (ZoneId/of "Europe/London")})))))
 
-    (t/testing "tstz ->"
-      (t/testing "date"
-        (t/is (= #time/date "2022-07-31"
-                 (test-cast #time/zoned-date-time "2022-08-01T05:34:56.789+01:00[Europe/London]"
-                            [:date :day]
-                            {:default-tz (ZoneId/of "America/Los_Angeles")}))))
+      (t/testing "tstz ->"
+        (t/testing "date"
+          (t/is (= #time/date "2022-07-31"
+                   (test-cast #time/zoned-date-time "2022-08-01T05:34:56.789+01:00[Europe/London]"
+                              [:date :day]
+                              {:default-tz (ZoneId/of "America/Los_Angeles")}))))
 
-      (t/testing "ts"
-        (t/is (= #time/date-time "2022-08-01T12:34:56"
-                 (test-cast #time/zoned-date-time "2022-08-01T12:34:56.789Z"
-                            [:timestamp-local :second])))
+        (t/testing "time"
+          (t/is (= #time/time "12:34:56"
+                   (test-cast #time/zoned-date-time "2022-08-01T12:34:56.789Z"
+                              [:time-local :second])))
 
-        (t/is (= #time/date-time "2022-08-01T13:34:56"
-                 (test-cast #time/zoned-date-time "2022-08-01T12:34:56.789Z"
-                            [:timestamp-local :second]
-                            {:default-tz (ZoneId/of "Europe/London")})))
+          (t/is (= #time/time "13:34:56"
+                   (test-cast #time/zoned-date-time "2022-08-01T12:34:56.789Z"
+                              [:time-local :second]
+                              {:default-tz (ZoneId/of "Europe/London")})))
 
-        (t/is (= #time/date-time "2022-08-01T05:34:56"
-                 (test-cast #time/zoned-date-time "2022-08-01T13:34:56.789+01:00[Europe/London]"
-                            [:timestamp-local :second]
-                            {:default-tz (ZoneId/of "America/Los_Angeles")}))))
+          (t/is (= #time/time "05:34:56"
+                   (test-cast #time/zoned-date-time "2022-08-01T13:34:56.789+01:00[Europe/London]"
+                              [:time-local :second]
+                              {:default-tz (ZoneId/of "America/Los_Angeles")}))))
 
-      (t/testing "tstz"
-        (t/is (= #time/zoned-date-time "2022-08-01T13:34:56+01:00[Europe/London]"
-                 (test-cast #time/zoned-date-time "2022-08-01T12:34:56.789012Z"
-                            [:timestamp-tz :second "Europe/London"])))
+        (t/testing "ts"
+          (t/is (= #time/date-time "2022-08-01T12:34:56"
+                   (test-cast #time/zoned-date-time "2022-08-01T12:34:56.789Z"
+                              [:timestamp-local :second])))
 
-        (t/is (= #time/zoned-date-time "2022-08-01T13:34:56+01:00[Europe/London]"
-                 (test-cast #time/zoned-date-time "2022-08-01T12:34:56Z"
-                            [:timestamp-tz :nano "Europe/London"])))))
+          (t/is (= #time/date-time "2022-08-01T13:34:56"
+                   (test-cast #time/zoned-date-time "2022-08-01T12:34:56.789Z"
+                              [:timestamp-local :second]
+                              {:default-tz (ZoneId/of "Europe/London")})))
 
-    (t/testing "ts ->"
-      (t/testing "date"
-        (t/is (= #time/date "2022-08-01"
-                 (test-cast #time/date-time "2022-08-01T05:34:56.789"
-                            [:date :day]
-                            {:default-tz (ZoneId/of "America/Los_Angeles")}))))
+          (t/is (= #time/date-time "2022-08-01T05:34:56"
+                   (test-cast #time/zoned-date-time "2022-08-01T13:34:56.789+01:00[Europe/London]"
+                              [:timestamp-local :second]
+                              {:default-tz (ZoneId/of "America/Los_Angeles")}))))
 
-      (t/testing "ts"
-        (t/is (= #time/date-time "2022-08-01T05:34:56"
-                 (test-cast #time/date-time "2022-08-01T05:34:56.789"
-                            [:timestamp-local :second "America/Los_Angeles"]
-                            {:default-tz (ZoneId/of "America/Los_Angeles")}))))
+        (t/testing "tstz"
+          (t/is (= #time/zoned-date-time "2022-08-01T13:34:56+01:00[Europe/London]"
+                   (test-cast #time/zoned-date-time "2022-08-01T12:34:56.789012Z"
+                              [:timestamp-tz :second "Europe/London"])))
 
-      (t/testing "tstz"
-        (t/is (= #time/zoned-date-time "2022-08-01T05:34:56-07:00[America/Los_Angeles]"
-                 (test-cast #time/date-time "2022-08-01T05:34:56.789"
-                            [:timestamp-tz :second "America/Los_Angeles"]
-                            {:default-tz (ZoneId/of "America/Los_Angeles")})))
+          (t/is (= #time/zoned-date-time "2022-08-01T13:34:56+01:00[Europe/London]"
+                   (test-cast #time/zoned-date-time "2022-08-01T12:34:56Z"
+                              [:timestamp-tz :nano "Europe/London"])))))
 
-        (t/is (= #time/zoned-date-time "2022-08-01T04:34:56-07:00[America/Los_Angeles]"
-                 (test-cast #time/date-time "2022-08-01T12:34:56.789"
-                            [:timestamp-tz :second "America/Los_Angeles"]
-                            {:default-tz (ZoneId/of "Europe/London")})))))))
+      (t/testing "ts ->"
+        (t/testing "date"
+          (t/is (= #time/date "2022-08-01"
+                   (test-cast #time/date-time "2022-08-01T05:34:56.789"
+                              [:date :day]
+                              {:default-tz (ZoneId/of "America/Los_Angeles")}))))
+
+        (t/testing "time"
+          (t/is (= #time/time "05:34:56.789012"
+                   (test-cast #time/date-time "2022-08-01T05:34:56.789012345"
+                              [:time-local :micro]
+                              {:default-tz (ZoneId/of "America/Los_Angeles")}))))
+
+        (t/testing "ts"
+          (t/is (= #time/date-time "2022-08-01T05:34:56"
+                   (test-cast #time/date-time "2022-08-01T05:34:56.789"
+                              [:timestamp-local :second "America/Los_Angeles"]
+                              {:default-tz (ZoneId/of "America/Los_Angeles")}))))
+
+        (t/testing "tstz"
+          (t/is (= #time/zoned-date-time "2022-08-01T05:34:56-07:00[America/Los_Angeles]"
+                   (test-cast #time/date-time "2022-08-01T05:34:56.789"
+                              [:timestamp-tz :second "America/Los_Angeles"]
+                              {:default-tz (ZoneId/of "America/Los_Angeles")})))
+
+          (t/is (= #time/zoned-date-time "2022-08-01T04:34:56-07:00[America/Los_Angeles]"
+                   (test-cast #time/date-time "2022-08-01T12:34:56.789"
+                              [:timestamp-tz :second "America/Los_Angeles"]
+                              {:default-tz (ZoneId/of "Europe/London")})))))
+
+      (t/testing "time ->"
+        (t/testing "date"
+          (t/is (thrown? IllegalArgumentException
+                         (test-cast #time/time "12:34:56.789012345" [:date :day]))))
+
+        (t/testing "time"
+          (t/is (= #time/time "12:34:56.789"
+                   (test-cast #time/time "12:34:56.789012345"
+                              [:time-local :milli]))))
+
+        (t/testing "ts"
+          (t/is (= #time/date-time "2022-08-16T12:34:56"
+                   (test-cast #time/time "12:34:56.789012345"
+                              [:timestamp-local :second]))))
+
+        (t/testing "tstz"
+          (t/is (= #time/zoned-date-time "2022-08-16T12:34:56-07:00[America/Los_Angeles]"
+                   (test-cast #time/time "12:34:56.789012345"
+                              [:timestamp-tz :second "America/Los_Angeles"]
+                              {:default-tz (ZoneId/of "America/Los_Angeles")})))
+
+          (t/is (= #time/zoned-date-time "2022-08-16T04:34:56.789012-07:00[America/Los_Angeles]"
+                   (test-cast #time/time "12:34:56.789012345"
+                              [:timestamp-tz :micro "America/Los_Angeles"]
+                              {:default-tz (ZoneId/of "Europe/London")}))))))))

--- a/test/core2/expression/temporal_test.clj
+++ b/test/core2/expression/temporal_test.clj
@@ -1,0 +1,119 @@
+(ns core2.expression.temporal-test
+  (:require [clojure.test :as t]
+            [core2.test-util :as tu])
+  (:import (java.time Instant ZoneId ZoneOffset)))
+
+(t/use-fixtures :each tu/with-allocator)
+
+;; the goal of this test is simply to demonstrate clock affects the computation
+;; equality may well remain incorrect for now, it is not the goal
+(t/deftest clock-influences-equality-of-ambiguous-datetimes-test
+  (t/are [expected a b zone-id]
+      (= expected (-> (tu/query-ra [:project [{'res '(= ?a ?b)}]
+                                    [:table [{}]]]
+                                   {:params {'?a a, '?b b}
+                                    :current-time Instant/EPOCH
+                                    :default-tz (ZoneOffset/of zone-id)})
+                      first :res))
+    ;; identity
+    true #time/date-time "2021-08-09T15:43:23" #time/date-time "2021-08-09T15:43:23" "Z"
+
+    ;; obvious inequality
+    false #time/date-time "2022-08-09T15:43:23" #time/date-time "2021-08-09T15:43:23" "Z"
+
+    ;; added fraction
+    false #time/date-time "2021-08-09T15:43:23" #time/date-time "2021-08-09T15:43:23.3" "Z"
+
+    ;; trailing zero ok
+    true #time/date-time "2021-08-09T15:43:23" #time/date-time "2021-08-09T15:43:23.0" "Z"
+
+    ;; equality preserved across tz
+    true #time/date-time "2021-08-09T15:43:23" #time/date-time "2021-08-09T15:43:23" "+02:00"
+
+    ;; offset equiv
+    true #time/offset-date-time "2021-08-09T15:43:23+02:00" #time/date-time "2021-08-09T15:43:23" "+02:00"
+
+    ;; offset inequality
+    false #time/offset-date-time "2021-08-09T15:43:23+02:00" #time/date-time "2021-08-09T15:43:23" "+03:00"))
+
+(t/deftest test-cast-temporal
+  (letfn [(test-cast
+            ([src-value tgt-type] (test-cast src-value tgt-type {}))
+            ([src-value tgt-type {:keys [default-tz], :or {default-tz ZoneOffset/UTC}}]
+             (-> (tu/query-ra [:project [{'res `(~'cast ~'arg ~tgt-type)}]
+                               [:table [{}]]]
+                              {:default-tz default-tz
+                               :params {'arg src-value}})
+                 first :res)))]
+
+    (t/testing "date ->"
+      (t/testing "date"
+        (t/is (= #time/date "2022-08-01"
+                 (test-cast #time/date "2022-08-01"
+                            [:date :milli]))))
+
+      (t/testing "ts"
+        (t/is (= #time/date-time "2022-08-01T00:00:00"
+                 (test-cast #time/date "2022-08-01"
+                            [:timestamp-local :milli]))))
+
+      (t/testing "tstz"
+        (t/is (= #time/zoned-date-time "2022-07-31T16:00-07:00[America/Los_Angeles]"
+                 (test-cast #time/date "2022-08-01"
+                            [:timestamp-tz :nano "America/Los_Angeles"]
+                            {:default-tz (ZoneId/of "Europe/London")})))))
+
+    (t/testing "tstz ->"
+      (t/testing "date"
+        (t/is (= #time/date "2022-07-31"
+                 (test-cast #time/zoned-date-time "2022-08-01T05:34:56.789+01:00[Europe/London]"
+                            [:date :day]
+                            {:default-tz (ZoneId/of "America/Los_Angeles")}))))
+
+      (t/testing "ts"
+        (t/is (= #time/date-time "2022-08-01T12:34:56"
+                 (test-cast #time/zoned-date-time "2022-08-01T12:34:56.789Z"
+                            [:timestamp-local :second])))
+
+        (t/is (= #time/date-time "2022-08-01T13:34:56"
+                 (test-cast #time/zoned-date-time "2022-08-01T12:34:56.789Z"
+                            [:timestamp-local :second]
+                            {:default-tz (ZoneId/of "Europe/London")})))
+
+        (t/is (= #time/date-time "2022-08-01T05:34:56"
+                 (test-cast #time/zoned-date-time "2022-08-01T13:34:56.789+01:00[Europe/London]"
+                            [:timestamp-local :second]
+                            {:default-tz (ZoneId/of "America/Los_Angeles")}))))
+
+      (t/testing "tstz"
+        (t/is (= #time/zoned-date-time "2022-08-01T13:34:56+01:00[Europe/London]"
+                 (test-cast #time/zoned-date-time "2022-08-01T12:34:56.789012Z"
+                            [:timestamp-tz :second "Europe/London"])))
+
+        (t/is (= #time/zoned-date-time "2022-08-01T13:34:56+01:00[Europe/London]"
+                 (test-cast #time/zoned-date-time "2022-08-01T12:34:56Z"
+                            [:timestamp-tz :nano "Europe/London"])))))
+
+    (t/testing "ts ->"
+      (t/testing "date"
+        (t/is (= #time/date "2022-08-01"
+                 (test-cast #time/date-time "2022-08-01T05:34:56.789"
+                            [:date :day]
+                            {:default-tz (ZoneId/of "America/Los_Angeles")}))))
+
+      (t/testing "ts"
+        (t/is (= #time/date-time "2022-08-01T05:34:56"
+                 (test-cast #time/date-time "2022-08-01T05:34:56.789"
+                            [:timestamp-local :second "America/Los_Angeles"]
+                            {:default-tz (ZoneId/of "America/Los_Angeles")}))))
+
+      (t/testing "tstz"
+        (t/is (= #time/zoned-date-time "2022-08-01T05:34:56-07:00[America/Los_Angeles]"
+                 (test-cast #time/date-time "2022-08-01T05:34:56.789"
+                            [:timestamp-tz :second "America/Los_Angeles"]
+                            {:default-tz (ZoneId/of "America/Los_Angeles")})))
+
+        (t/is (= #time/zoned-date-time "2022-08-01T04:34:56-07:00[America/Los_Angeles]"
+                 (test-cast #time/date-time "2022-08-01T12:34:56.789"
+                            [:timestamp-tz :second "America/Los_Angeles"]
+                            {:default-tz (ZoneId/of "Europe/London")})))))))

--- a/test/core2/expression_test.clj
+++ b/test/core2/expression_test.clj
@@ -1476,12 +1476,12 @@
                 "current-date")
 
           (t/is (= {:res [(.toLocalTime utc-zdt-micros)]
-                    :res-type [:time :micro]}
+                    :res-type [:time-local :micro]}
                    (project-fn '(current-time)))
                 "current-time")
 
           (t/is (= {:res [(.toLocalTime utc-zdt-micros)]
-                    :res-type [:time :micro]}
+                    :res-type [:time-local :micro]}
                    (project-fn '(local-time)))
                 "local-time")
 
@@ -1505,12 +1505,12 @@
                 "current-date")
 
           (t/is (= {:res [(.toLocalTime utc-zdt-micros)]
-                    :res-type [:time :micro]}
+                    :res-type [:time-local :micro]}
                    (project-fn '(current-time)))
                 "current-time")
 
           (t/is (= {:res [(.toLocalTime la-zdt-micros)]
-                    :res-type [:time :micro]}
+                    :res-type [:time-local :micro]}
                    (project-fn '(local-time)))
                 "local-time")
 
@@ -1533,12 +1533,12 @@
 
         (t/testing "time precision"
           (t/is (= {:res [(-> utc-zdt (.truncatedTo ChronoUnit/MILLIS) (.toLocalTime))]
-                    :res-type [:time :milli]}
+                    :res-type [:time-local :milli]}
                    (project-fn '(current-time 3)))
                 "current-time")
 
           (t/is (= {:res [(-> la-zdt (.truncatedTo ChronoUnit/MILLIS) (.minusNanos 8e6) (.toLocalTime))]
-                    :res-type [:time :milli]}
+                    :res-type [:time-local :milli]}
                    (project-fn '(local-time 2)))
                 "local-time"))))))
 

--- a/test/core2/expression_test.clj
+++ b/test/core2/expression_test.clj
@@ -1914,51 +1914,24 @@
 (t/deftest test-trim-array-offset-over-trim-exception
   (t/is (thrown-with-msg? IllegalArgumentException #"Data exception - array element error\." (project1 '(trim-array [1 2 3] 4) {}))))
 
-(t/deftest test-cast
-  (t/are [expected expr variables]
-    (= expected (project1 expr variables))
+(t/deftest test-cast-numerics
+  (letfn [(test-cast
+            ([src tgt-type] (test-cast src tgt-type {}))
+            ([src tgt-type params] (project1 (list 'cast src tgt-type) params)))]
+    (t/is (= nil (test-cast nil :i32)))
 
-    nil (list 'cast nil :i32) {}
-    nil (list 'cast nil :i64) {}
-    nil (list 'cast nil :i16) {}
-    nil (list 'cast nil :f32) {}
-    nil (list 'cast nil :f64) {}
+    (t/is (= nil (test-cast nil :i64)))
+    (t/is (= nil (test-cast nil :i16)))
+    (t/is (= nil (test-cast nil :f32)))
+    (t/is (= nil (test-cast nil :f64)))
 
-    42 (list 'cast 42 :i32) {}
+    (t/is (= 42 (test-cast 42 :i32)))
 
-    42 (list 'cast 42.0 :i32) {}
-    42 (list 'cast 42.0 :i16) {}
-    42 (list 'cast 42.0 :i64) {}
+    (t/is (= 42 (test-cast 42.0 :i32)))
+    (t/is (= 42 (test-cast 42.0 :i16)))
+    (t/is (= 42 (test-cast 42.0 :i64)))
 
-    42.0 (list 'cast 42 :f32) {}
-    42.0 (list 'cast 42 :f64) {}
+    (t/is (= 42.0 (test-cast 42 :f32)))
+    (t/is (= 42.0 (test-cast 42 :f64)))
 
-    42 (list 'cast 'a :i32) {:a 42.0}))
-
-(defn- ldt ^LocalDateTime [s] (LocalDateTime/parse s))
-
-;; the goal of this test is simply to demonstrate clock affects the computation
-;; equality may well remain incorrect for now, it is not the goal
-(t/deftest clock-influences-equality-of-ambiguous-datetimes-test
-  (t/are [expected a b clock]
-    (= expected (binding [expr/*clock* (Clock/fixed Instant/EPOCH (ZoneId/of clock))] (project1 '(= sa sb) {:sa a, :sb b})))
-    ;; identity
-    true (ldt "2021-08-09T15:43:23") (ldt "2021-08-09T15:43:23") "UTC"
-
-    ;; obvious inequality
-    false (ldt "2022-08-09T15:43:23") (ldt "2021-08-09T15:43:23") "UTC"
-
-    ;; added fraction
-    false (ldt "2021-08-09T15:43:23") (ldt "2021-08-09T15:43:23.3") "UTC"
-
-    ;; trailing zero ok
-    true (ldt "2021-08-09T15:43:23") (ldt "2021-08-09T15:43:23.0") "UTC"
-
-    ;; equality preserved across tz
-    true (ldt "2021-08-09T15:43:23") (ldt "2021-08-09T15:43:23") "UTC+2"
-
-    ;; offset equiv
-    true #time/offset-date-time "2021-08-09T15:43:23+02:00" (ldt "2021-08-09T15:43:23") "UTC+2"
-
-    ;; offset inequality
-    false #time/offset-date-time "2021-08-09T15:43:23+02:00" (ldt "2021-08-09T15:43:23") "UTC+3"))
+    (t/is (= 42 (test-cast 'a :i32 {:a 42.0})))))

--- a/test/core2/types_test.clj
+++ b/test/core2/types_test.clj
@@ -104,21 +104,21 @@
                   (test-round-trip all))))
 
     (->> "LocalTime can be read from SECOND time vectors"
-         (t/is (= secs (:vs (test-read (constantly [:time :second])
+         (t/is (= secs (:vs (test-read (constantly [:time-local :second])
                                        (fn [^IVectorWriter w, ^LocalTime v]
                                          (.setSafe ^TimeSecVector (.getVector w) (.getPosition w) (.toSecondOfDay v)))
                                        secs)))))
 
     (let [millis+ (concat millis secs)]
       (->> "LocalTime can be read from MILLI time vectors"
-           (t/is (= millis+ (:vs (test-read (constantly [:time :milli])
+           (t/is (= millis+ (:vs (test-read (constantly [:time-local :milli])
                                             (fn [^IVectorWriter w, ^LocalTime v]
                                               (.setSafe ^TimeMilliVector (.getVector w) (.getPosition w) (int (quot (.toNanoOfDay v) 1e6))))
                                             millis+))))))
 
     (let [micros+ (concat micros millis secs)]
       (->> "LocalTime can be read from MICRO time vectors"
-           (t/is (= micros+ (:vs (test-read (constantly [:time :micro])
+           (t/is (= micros+ (:vs (test-read (constantly [:time-local :micro])
                                             (fn [^IVectorWriter w, ^LocalTime v]
                                               (.setSafe ^TimeMicroVector (.getVector w) (.getPosition w) (long (quot (.toNanoOfDay v) 1e3))))
                                             micros+))))))))


### PR DESCRIPTION
... for the first part of #294 - this commit implements `CAST` in the backend for `#{date ts ts-tz} × #{date ts ts-tz}`, and then uses cast in the existing impls of `=` for tstz/ts.

NB:
* As @wotbrew alludes to [here](https://github.com/xtdb/core2/issues/105#issuecomment-1216360263), there isn't a perfect mapping between SQL and Arrow/C2 types - particularly, SQL ts-tz values keep the TZ offset with every value; Arrow requires a single TZ per column (although we can use union types if required).
* I've changed `emit-value` for `LocalDateTime` - AFAICT we shouldn't convert this using the session TZ for the runtime representation. Let's say we're in LA, we have an LDT for 05:00 and we want to put it straight into a timestamp vector:
  * we want it to output 05:00 rather than 13:00, as it would do if it was converted to UTC for the runtime representation
  * if we're (e.g.) extracting the hour value from the timestamp-local, we want 5 rather than 13
  * but this seems like I'm not aware of all the nuances, so could use another pair of eyes (@wotbrew, probably).

Still to come for #294:
* introducing time/time-tz (IIRC there's no support for this at all), adding casts for these to all the other types
* using the casts in boolean comparisons