### PR TITLE
Standardising on ZDTs for TSTZs, #332

### DIFF
--- a/core/src/core2/sql/plan.clj
+++ b/core/src/core2/sql/plan.clj
@@ -224,9 +224,8 @@
     (throw (IllegalArgumentException. (str "Cannot build expression for: "  (pr-str (r/node z)))))))
 
 (defn seconds-fraction->nanos [seconds-fraction]
-  (* (* (Long/parseLong seconds-fraction)
-        (Math/pow 10 (- (count seconds-fraction))))
-     (Math/pow 10 9)))
+  (* (Long/parseLong seconds-fraction)
+     (long (Math/pow 10 (- 9 (count seconds-fraction))))))
 
 (defn create-offset-date-time
   [year month day hours minutes seconds seconds-fraction offset-hours offset-minutes]

--- a/test-resources/core2/sql/plan_test_expectations/system-time-as-of.edn
+++ b/test-resources/core2/sql/plan_test_expectations/system-time-as-of.edn
@@ -8,8 +8,8 @@
     [{system_time_start
       (<=
        system_time_start
-       #time/offset-date-time "2999-01-01T00:00Z")}
+       #time/zoned-date-time "2999-01-01T00:00Z")}
      {system_time_end
-      (> system_time_end #time/offset-date-time "2999-01-01T00:00Z")}
+      (> system_time_end #time/zoned-date-time "2999-01-01T00:00Z")}
      bar
      {_table (= _table "foo")}]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/system-time-between-a-and-b-ts-ts.edn
+++ b/test-resources/core2/sql/plan_test_expectations/system-time-between-a-and-b-ts-ts.edn
@@ -8,8 +8,8 @@
     [{system_time_start
       (<=
        system_time_start
-       #time/offset-date-time "3000-01-01T00:00Z")}
+       #time/zoned-date-time "3000-01-01T00:00Z")}
      {system_time_end
-      (> system_time_end #time/offset-date-time "2999-01-01T00:00Z")}
+      (> system_time_end #time/zoned-date-time "2999-01-01T00:00Z")}
      bar
      {_table (= _table "foo")}]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/system-time-between-a-and-b-when-a-equal-b.edn
+++ b/test-resources/core2/sql/plan_test_expectations/system-time-between-a-and-b-when-a-equal-b.edn
@@ -8,7 +8,7 @@
     [{system_time_start
       (<=
        system_time_start
-       #time/offset-date-time "3000-01-01T00:00Z")}
+       #time/zoned-date-time "3000-01-01T00:00Z")}
      {system_time_end (> system_time_end #time/date "3000-01-01")}
      bar
      {_table (= _table "foo")}]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/system-time-from-a-to-b-date-ts.edn
+++ b/test-resources/core2/sql/plan_test_expectations/system-time-from-a-to-b-date-ts.edn
@@ -6,7 +6,7 @@
    {system_time_start x1, system_time_end x2, bar x3, _table x4}
    [:scan
     [{system_time_start
-      (< system_time_start #time/offset-date-time "3000-01-01T00:00Z")}
+      (< system_time_start #time/zoned-date-time "3000-01-01T00:00Z")}
      {system_time_end (> system_time_end #time/date "2999-01-01")}
      bar
      {_table (= _table "foo")}]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/system-time-from-a-to-b-ts-ts.edn
+++ b/test-resources/core2/sql/plan_test_expectations/system-time-from-a-to-b-ts-ts.edn
@@ -6,8 +6,8 @@
    {system_time_start x1, system_time_end x2, bar x3, _table x4}
    [:scan
     [{system_time_start
-      (< system_time_start #time/offset-date-time "3000-01-01T00:00Z")}
+      (< system_time_start #time/zoned-date-time "3000-01-01T00:00Z")}
      {system_time_end
-      (> system_time_end #time/offset-date-time "2999-01-01T00:00Z")}
+      (> system_time_end #time/zoned-date-time "2999-01-01T00:00Z")}
      bar
      {_table (= _table "foo")}]]]]]

--- a/test/core2/api_test.clj
+++ b/test/core2/api_test.clj
@@ -108,7 +108,7 @@
 (t/deftest round-trips-temporal
   (let [vs {:dt #time/date "2022-08-01"
             :ts #time/date-time "2022-08-01T14:34"
-            :tstz #time/zoned-date-time "2022-08-01T14:34+01:00[Europe/London]"
+            :tstz #time/zoned-date-time "2022-08-01T14:34+01:00"
             :tm #time/time "13:21:14.932254"
             ;; :tmtz #time/offset-time "11:21:14.932254-08:00" ; TODO #323
             }
@@ -122,10 +122,12 @@
 
     (let [lits [[:dt "DATE '2022-08-01'"]
                 [:ts "TIMESTAMP '2022-08-01 14:34:00'"]
-                #_ ; FIXME #332 returns an ODT, test expects ZDT (test may be wrong)
-                [tstz "TIMESTAMP '2022-08-01 14:34:00+01:00'"]
+                [:tstz "TIMESTAMP '2022-08-01 14:34:00+01:00'"]
                 #_ ; FIXME #333 tries to return `OffsetTime` and fails (it should return `LocalTime`)
-                [:tm "TIME '13:21:14.932254'"]]
+                [:tm "TIME '13:21:14.932254'"]
+
+                #_ ; FIXME #323
+                [:tmtz "TIME '11:21:14.932254-08:00'"]]
           !tx (c2/submit-tx *node* (vec (for [[t lit] lits]
                                           [:sql (format "INSERT INTO bar (id, v) VALUES (?, %s)" lit)
                                            [[(name t)]]])))]

--- a/test/core2/expression/temporal_test.clj
+++ b/test/core2/expression/temporal_test.clj
@@ -34,10 +34,10 @@
     true #time/date-time "2021-08-09T15:43:23" #time/date-time "2021-08-09T15:43:23" "+02:00"
 
     ;; offset equiv
-    true #time/offset-date-time "2021-08-09T15:43:23+02:00" #time/date-time "2021-08-09T15:43:23" "+02:00"
+    true #time/zoned-date-time "2021-08-09T15:43:23+02:00" #time/date-time "2021-08-09T15:43:23" "+02:00"
 
     ;; offset inequality
-    false #time/offset-date-time "2021-08-09T15:43:23+02:00" #time/date-time "2021-08-09T15:43:23" "+03:00"))
+    false #time/zoned-date-time "2021-08-09T15:43:23+02:00" #time/date-time "2021-08-09T15:43:23" "+03:00"))
 
 (t/deftest test-cast-temporal
   (let [current-time #time/instant "2022-08-16T20:04:14.423452Z"]

--- a/test/core2/sql/plan_test.clj
+++ b/test/core2/sql/plan_test.clj
@@ -768,11 +768,11 @@
     "TIMESTAMP '3000-03-15 20:40:31.11'" (ldt "3000-03-15T20:40:31.11")
     "TIMESTAMP '3000-03-15 20:40:31.2222'" (ldt "3000-03-15T20:40:31.2222")
     "TIMESTAMP '3000-03-15 20:40:31.44444444'" (ldt "3000-03-15T20:40:31.44444444")
-    "TIMESTAMP '3000-03-15 20:40:31+03:44'" #time/offset-date-time "3000-03-15T20:40:31+03:44"
-    "TIMESTAMP '3000-03-15 20:40:31.12345678+13:12'" #time/offset-date-time "3000-03-15T20:40:31.123456780+13:12"
-    "TIMESTAMP '3000-03-15 20:40:31.12345678-14:00'" #time/offset-date-time"3000-03-15T20:40:31.123456780-14:00"
-    "TIMESTAMP '3000-03-15 20:40:31.12345678+14:00'" #time/offset-date-time"3000-03-15T20:40:31.123456780+14:00"
-    "TIMESTAMP '3000-03-15 20:40:31-11:44'" #time/offset-date-time "3000-03-15T20:40:31-11:44"))
+    "TIMESTAMP '3000-03-15 20:40:31+03:44'" #time/zoned-date-time "3000-03-15T20:40:31+03:44"
+    "TIMESTAMP '3000-03-15 20:40:31.12345678+13:12'" #time/zoned-date-time "3000-03-15T20:40:31.123456780+13:12"
+    "TIMESTAMP '3000-03-15 20:40:31.12345678-14:00'" #time/zoned-date-time"3000-03-15T20:40:31.123456780-14:00"
+    "TIMESTAMP '3000-03-15 20:40:31.12345678+14:00'" #time/zoned-date-time"3000-03-15T20:40:31.123456780+14:00"
+    "TIMESTAMP '3000-03-15 20:40:31-11:44'" #time/zoned-date-time "3000-03-15T20:40:31-11:44"))
 
 (deftest test-time-literal
   (t/are
@@ -793,18 +793,18 @@
     "localdate localdate")
 
   (t/is
-    (= [#time/offset-date-time "3000-03-15T00:00:00Z" #time/offset-date-time "3000-03-15T20:40:31Z"]
-       (plan/coerce-points-in-time #time/date "3000-03-15" #time/offset-date-time "3000-03-15T20:40:31Z"))
+    (= [#time/zoned-date-time "3000-03-15T00:00:00Z" #time/zoned-date-time "3000-03-15T20:40:31Z"]
+       (plan/coerce-points-in-time #time/date "3000-03-15" #time/zoned-date-time "3000-03-15T20:40:31Z"))
     "localdate offsetdate")
 
   (t/is
-    (= [#time/offset-date-time "3000-03-15T20:40:31Z" #time/offset-date-time "3000-03-15T00:00:00Z"]
-       (plan/coerce-points-in-time #time/offset-date-time "3000-03-15T20:40:31Z" #time/date "3000-03-15"))
+    (= [#time/zoned-date-time "3000-03-15T20:40:31Z" #time/zoned-date-time "3000-03-15T00:00:00Z"]
+       (plan/coerce-points-in-time #time/zoned-date-time "3000-03-15T20:40:31Z" #time/date "3000-03-15"))
     "localdate offsetdate")
 
   (t/is
-    (= [#time/offset-date-time "2000-03-15T20:40:31Z" #time/offset-date-time "3000-03-15T20:40:31Z"]
-       (plan/coerce-points-in-time #time/offset-date-time "2000-03-15T20:40:31Z" #time/offset-date-time "3000-03-15T20:40:31Z"))
+    (= [#time/zoned-date-time "2000-03-15T20:40:31Z" #time/zoned-date-time "3000-03-15T20:40:31Z"]
+       (plan/coerce-points-in-time #time/zoned-date-time "2000-03-15T20:40:31Z" #time/zoned-date-time "3000-03-15T20:40:31Z"))
     "offsetdate offsetdate"))
 
 (deftest test-system-time-queries
@@ -907,13 +907,13 @@
     (= expected (plan-expr sql))
     "foo.APP_TIME CONTAINS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
     '(and
-      (<= x1 #time/offset-date-time "2000-01-01T00:00Z")
-      (>= x2 #time/offset-date-time "2001-01-01T00:00Z"))
+      (<= x1 #time/zoned-date-time "2000-01-01T00:00Z")
+      (>= x2 #time/zoned-date-time "2001-01-01T00:00Z"))
 
     "foo.APP_TIME CONTAINS TIMESTAMP '2000-01-01 00:00:00+00:00'"
     '(and
-      (<= x1 #time/offset-date-time "2000-01-01T00:00Z")
-      (>= x2 #time/offset-date-time "2000-01-01T00:00Z"))))
+      (<= x1 #time/zoned-date-time "2000-01-01T00:00Z")
+      (>= x2 #time/zoned-date-time "2000-01-01T00:00Z"))))
 
 (deftest test-period-overlaps-predicate
   ;; also testing all period-predicate permutations
@@ -922,8 +922,8 @@
     (= expected (plan-expr sql))
     "foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
     '(and
-       (< x1 #time/offset-date-time "2001-01-01T00:00Z")
-       (> x2 #time/offset-date-time "2000-01-01T00:00Z"))
+       (< x1 #time/zoned-date-time "2001-01-01T00:00Z")
+       (> x2 #time/zoned-date-time "2000-01-01T00:00Z"))
 
     "foo.APP_TIME OVERLAPS foo.APP_TIME"
     '(and
@@ -932,8 +932,8 @@
     "PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')
     OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00+00:00', TIMESTAMP '2003-01-01 00:00:00+00:00')"
     '(and
-       (< #time/offset-date-time "2000-01-01T00:00Z" #time/offset-date-time "2003-01-01T00:00Z")
-       (> #time/offset-date-time "2001-01-01T00:00Z" #time/offset-date-time "2002-01-01T00:00Z"))))
+       (< #time/zoned-date-time "2000-01-01T00:00Z" #time/zoned-date-time "2003-01-01T00:00Z")
+       (> #time/zoned-date-time "2001-01-01T00:00Z" #time/zoned-date-time "2002-01-01T00:00Z"))))
 
 (deftest test-period-equals-predicate
   (t/are
@@ -941,36 +941,36 @@
     (= expected (plan-expr sql))
     "foo.APP_TIME EQUALS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
     '(and
-       (= x1 #time/offset-date-time "2000-01-01T00:00Z")
-       (= x2 #time/offset-date-time "2001-01-01T00:00Z"))))
+       (= x1 #time/zoned-date-time "2000-01-01T00:00Z")
+       (= x2 #time/zoned-date-time "2001-01-01T00:00Z"))))
 
 (deftest test-period-precedes-predicate
   (t/are
     [sql expected]
     (= expected (plan-expr sql))
     "foo.APP_TIME PRECEDES PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
-    '(<= x2 #time/offset-date-time "2000-01-01T00:00Z")))
+    '(<= x2 #time/zoned-date-time "2000-01-01T00:00Z")))
 
 (deftest test-period-succeeds-predicate
   (t/are
     [sql expected]
     (= expected (plan-expr sql))
     "foo.APP_TIME SUCCEEDS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
-    '(>= x1 #time/offset-date-time "2001-01-01T00:00Z")))
+    '(>= x1 #time/zoned-date-time "2001-01-01T00:00Z")))
 
 (deftest test-period-immediately-precedes-predicate
   (t/are
     [sql expected]
     (= expected (plan-expr sql))
     "foo.APP_TIME IMMEDIATELY PRECEDES PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
-    '(= x2 #time/offset-date-time "2000-01-01T00:00Z")))
+    '(= x2 #time/zoned-date-time "2000-01-01T00:00Z")))
 
 (deftest test-period-immediately-succeeds-predicate
   (t/are
     [sql expected]
     (= expected (plan-expr sql))
     "foo.APP_TIME IMMEDIATELY SUCCEEDS PERIOD (TIMESTAMP '2000-01-01 00:00:00+00:00', TIMESTAMP '2001-01-01 00:00:00+00:00')"
-    '(= x1 #time/offset-date-time "2001-01-01T00:00Z")))
+    '(= x1 #time/zoned-date-time "2001-01-01T00:00Z")))
 
 (deftest test-multiple-references-to-temporal-cols
   (t/is

--- a/test/core2/sql/plan_test.clj
+++ b/test/core2/sql/plan_test.clj
@@ -780,6 +780,7 @@
     (= expected (plan-expr sql))
     "TIME '20:40:31'" #time/offset-time "20:40:31Z"
     "TIME '20:40:31.467'" #time/offset-time "20:40:31.467Z"
+    "TIME '20:40:31.932254'" #time/offset-time "20:40:31.932254Z"
     "TIME '20:40:31-03:44'" #time/offset-time "20:40:31-03:44"
     "TIME '20:40:31+03:44'" #time/offset-time "20:40:31+03:44"
     "TIME '20:40:31.467+14:00'" #time/offset-time "20:40:31.467+14:00"))


### PR DESCRIPTION
... because ZDT also supports ZoneOffsets (as a subtype of ZoneId) and preserves zone info if we have it (e.g. from Arrow). resolves #332.

e.g. `#time/zoned-date-time "2022-08-23T14:45:32+01:00"` is a valid ZDT, and behaves like the equivalent ODT (i.e. preserving the distinction between `+01:00` and `+01:00[Europe/London]`)

Aware of both 0246067fca534ae92febe874004ea0262a7d5bcb and 3ba6fe2570ccb356fff9610fbbf200fbf7246c21 - worth a chat.