### PR TITLE
Implicitly expand Periods into their underlying cols in all-column-re…

### DIFF
--- a/test-resources/core2/sql/plan_test_expectations/test-app-time-correlated-subquery-projection.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-app-time-correlated-subquery-projection.edn
@@ -1,0 +1,22 @@
+[:rename
+ {x9 $column_1$}
+ [:project
+  [x9]
+  [:apply
+   :cross-join
+   {x1 ?x10, x2 ?x11}
+   [:rename
+    {application_time_start x1, application_time_end x2, _table x3}
+    [:scan
+     [application_time_start
+      application_time_end
+      {_table (= _table "bar")}]]]
+   [:max-1-row
+    [:project
+     [{x9 (and (< x5 ?x11) (> x6 ?x10))}]
+     [:rename
+      {application_time_start x5, application_time_end x6, _table x7}
+      [:scan
+       [application_time_start
+        application_time_end
+        {_table (= _table "foo")}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-app-time-correlated-subquery-where.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-app-time-correlated-subquery-where.edn
@@ -1,0 +1,26 @@
+[:rename
+ {x5 name}
+ [:project
+  [x5]
+  [:apply
+   :cross-join
+   {x1 ?x10, x2 ?x11}
+   [:rename
+    {application_time_start x1, application_time_end x2, _table x3}
+    [:scan
+     [application_time_start
+      application_time_end
+      {_table (= _table "bar")}]]]
+   [:max-1-row
+    [:project
+     [x5]
+     [:rename
+      {name x5,
+       application_time_start x6,
+       application_time_end x7,
+       _table x8}
+      [:scan
+       [name
+        {application_time_start (< application_time_start ?x11)}
+        {application_time_end (> application_time_end ?x10)}
+        {_table (= _table "foo")}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
@@ -1,0 +1,24 @@
+[:update
+ {:table "foo"}
+ [:rename
+  {x3 _iid,
+   x4 _row-id,
+   x2 bar,
+   x5 application_time_start,
+   x6 application_time_end}
+  [:project
+   [x3 x4 x2 x5 x6]
+   [:rename
+    {_table x1,
+     baz x2,
+     _iid x3,
+     _row-id x4,
+     application_time_start x5,
+     application_time_end x6}
+    [:scan
+     [{_table (= _table "foo")}
+      baz
+      _iid
+      _row-id
+      application_time_start
+      application_time_end]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
@@ -1,0 +1,26 @@
+[:update
+ {:table "foo"}
+ [:rename
+  {x6 _iid,
+   x7 _row-id,
+   x9 bar,
+   x4 application_time_start,
+   x5 application_time_end}
+  [:project
+   [x6 x7 {x9 (and (< x2 x5) (> x3 x4))} x4 x5]
+   [:rename
+    {_table x1,
+     system_time_start x2,
+     system_time_end x3,
+     application_time_start x4,
+     application_time_end x5,
+     _iid x6,
+     _row-id x7}
+    [:scan
+     [{_table (= _table "foo")}
+      system_time_start
+      system_time_end
+      application_time_start
+      application_time_end
+      _iid
+      _row-id]]]]]]

--- a/test/core2/sql/analyze_test.clj
+++ b/test/core2/sql/analyze_test.clj
@@ -420,7 +420,10 @@ SELECT t1.d-t1.e AS a, SUM(t1.a) AS b
     FROM foo
     WHERE foo.SYSTEM_TIME = 20")
 
-)
+(invalid?
+    #"References to periods may only appear within period predicates: foo.SYSTEM_TIME"
+    "UPDATE foo SET bar = foo.SYSTEM_TIME"))
+
 (t/deftest test-projection
   (t/is (= [[{:index 0, :identifier "b"}]
             [{:index 0, :identifier "b", :qualified-column ["t1" "b"]}]


### PR DESCRIPTION
…fs, fixes #376


Options for how to fix this, and more generally on where period refs should be split into their underlying col refs, PR implements option 2

1. column-reference when called on periods will return the underlying cols, however this is fn is only called during analysis or when you are planning expressions where even without this work its easy enough to expand out the underlying cols in the case you know you have a period pred.
2. all-column-refs (or a similar fn) returns the underlying start/end cols instead of the period cols, this is the what most everything calls when it wants to know what cols are being referenced (for example when wanting to know what cols to project out). Anyone calling this would have the expansion handled for them opaquely. (perhaps this should become all-expanded-column-refs, for clarity? although there would be no callers of the original currently.)
3. handle expanding out the underlying cols everywhere that calls into column-reference or all-column-references. This is the most flexible but also fragile in that if you add a new call site/location in which it would be valid to reference a period, you have to remember to expand out the underlying cols.