### PR TITLE
DML accepts `:app-time-as-of-now?` flag through `submit-tx`, #383

### DIFF
--- a/http-server/src/core2/server.clj
+++ b/http-server/src/core2/server.clj
@@ -53,7 +53,9 @@
                                (inst? s) s
                                (string? s) (inst/read-instant-date s)))}))
 
-(s/def ::opts (s/keys :opt-un [::sys-time]))
+(s/def ::app-time-as-of-now? boolean?)
+
+(s/def ::opts (s/keys :opt-un [::sys-time ::app-time-as-of-now?]))
 
 (defmethod route-handler :status [_]
   {:get (fn [{:keys [node] :as _req}]

--- a/test-resources/can-build-chunk-as-arrow-ipc-file-format/log-0000000000000000.arrow.json
+++ b/test-resources/can-build-chunk-as-arrow-ipc-file-format/log-0000000000000000.arrow.json
@@ -83,7 +83,7 @@
       "name" : "tx-id",
       "count" : 2,
       "VALIDITY" : [1,1],
-      "DATA" : ["0","8333"]
+      "DATA" : ["0","8469"]
     },{
       "name" : "system-time",
       "count" : 2,

--- a/test-resources/can-write-tx-to-arrow-ipc-streaming-format.json
+++ b/test-resources/can-write-tx-to-arrow-ipc-streaming-format.json
@@ -603,6 +603,13 @@
         "timezone" : "UTC"
       },
       "children" : [ ]
+    },{
+      "name" : "application-time-as-of-now?",
+      "nullable" : false,
+      "type" : {
+        "name" : "bool"
+      },
+      "children" : [ ]
     }]
   },
   "batches" : [{
@@ -1021,6 +1028,11 @@
       "count" : 1,
       "VALIDITY" : [1],
       "DATA" : [1609459200000000]
+    },{
+      "name" : "application-time-as-of-now?",
+      "count" : 1,
+      "VALIDITY" : [1],
+      "DATA" : [1]
     }]
   }]
 }

--- a/test-resources/multi-block-metadata/log-0000000000000000.arrow.json
+++ b/test-resources/multi-block-metadata/log-0000000000000000.arrow.json
@@ -132,7 +132,7 @@
       "name" : "tx-id",
       "count" : 1,
       "VALIDITY" : [1],
-      "DATA" : ["6109"]
+      "DATA" : ["6245"]
     },{
       "name" : "system-time",
       "count" : 1,

--- a/test-resources/writes-log-file/log-0000000000000000.arrow.json
+++ b/test-resources/writes-log-file/log-0000000000000000.arrow.json
@@ -83,7 +83,7 @@
       "name" : "tx-id",
       "count" : 2,
       "VALIDITY" : [1,1],
-      "DATA" : ["0","3125"]
+      "DATA" : ["0","3261"]
     },{
       "name" : "system-time",
       "count" : 2,

--- a/test/core2/indexer_test.clj
+++ b/test/core2/indexer_test.clj
@@ -72,7 +72,7 @@
 
 (t/deftest can-build-chunk-as-arrow-ipc-file-format
   (let [node-dir (util/->path "target/can-build-chunk-as-arrow-ipc-file-format")
-        last-tx-key (c2/map->TransactionInstant {:tx-id 8333, :sys-time (util/->instant #inst "2020-01-02")})
+        last-tx-key (c2/map->TransactionInstant {:tx-id 8469, :sys-time (util/->instant #inst "2020-01-02")})
         total-number-of-ops (count (for [tx-ops txs
                                          op tx-ops]
                                      op))]
@@ -297,7 +297,7 @@
 
 (t/deftest can-stop-node-without-writing-chunks
   (let [node-dir (util/->path "target/can-stop-node-without-writing-chunks")
-        last-tx-key (c2/map->TransactionInstant {:tx-id 8333, :sys-time (util/->instant #inst "2020-01-02")})]
+        last-tx-key (c2/map->TransactionInstant {:tx-id 8469, :sys-time (util/->instant #inst "2020-01-02")})]
     (util/delete-dir node-dir)
 
     (with-open [node (tu/->local-node {:node-dir node-dir})]

--- a/test/core2/tx_producer_test.clj
+++ b/test/core2/tx_producer_test.clj
@@ -51,7 +51,8 @@
                    [:sql "DELETE FROM foo FOR PORTION OF APP_TIME FROM DATE '2023' TO DATE '2025' WHERE foo.id = ?"
                     [[1]]]]
 
-                  {:sys-time (util/->instant #inst "2021")})
+                  {:sys-time (util/->instant #inst "2021")
+                   :app-time-as-of-now? true})
 
                  (c2-json/arrow-streaming->json)
                  #_(doto (->> (spit expected-file)))


### PR DESCRIPTION
resolves #383. see #337 for semantics.

* We pass the flag over the tx-log - the flag is per-client (and likely per-session, but that's then up to the client).
* Adds an `*opts*` dynamic var in the planner - we'd need to take this into account if we were to cache the plan at this level.
* There are a few zero-length time ranges in the test output - I'll check these are intended but they're ~correct. More integration testing required, regardless.