### PR TITLE
Return the different types of intervals as different concrete classes

### DIFF
--- a/api/src/core2/transit.clj
+++ b/api/src/core2/transit.clj
@@ -2,9 +2,11 @@
   "This namespace additionally requires a project dependency on `time-literals`, provided by HTTP server + HTTP client"
   (:require [cognitect.transit :as transit]
             [core2.api :as c2]
+            [core2.edn :as c2-edn]
             [core2.error :as err]
             [time-literals.read-write :as time-literals.rw])
   (:import core2.api.TransactionInstant
+           (core2.types IntervalDayTime IntervalMonthDayNano IntervalYearMonth)
            [java.time DayOfWeek Duration Instant LocalDate LocalDateTime LocalTime Month MonthDay OffsetDateTime OffsetTime Period Year YearMonth ZoneId ZonedDateTime]))
 
 (def tj-read-handlers
@@ -13,7 +15,11 @@
              (update-vals transit/read-handler))
          {"core2/tx-key" (transit/read-handler c2/map->TransactionInstant)
           "core2/illegal-arg" (transit/read-handler err/-iae-reader)
-          "core2/runtime-err" (transit/read-handler err/-runtime-err-reader)}))
+          "core2/runtime-err" (transit/read-handler err/-runtime-err-reader)
+          "core2/period-duration" c2-edn/period-duration-reader
+          "core2.interval/year-month" c2-edn/interval-ym-reader
+          "core2.interval/day-time" c2-edn/interval-dt-reader
+          "core2.interval/month-day-nano" c2-edn/interval-mdn-reader}))
 
 (def tj-write-handlers
   (merge (-> {Period "time/period"
@@ -34,4 +40,14 @@
              (update-vals #(transit/write-handler % str)))
          {TransactionInstant (transit/write-handler "core2/tx-key" #(select-keys % [:tx-id :sys-time]))
           core2.IllegalArgumentException (transit/write-handler "core2/illegal-arg" ex-data)
-          core2.RuntimeException (transit/write-handler "core2/runtime-err" ex-data)}))
+          core2.RuntimeException (transit/write-handler "core2/runtime-err" ex-data)
+
+          IntervalYearMonth (transit/write-handler "core2.interval/year-month" #(str (.-period ^IntervalYearMonth %)))
+
+          IntervalDayTime (transit/write-handler "core2.interval/day-time"
+                                                 #(vector (str (.-period ^IntervalDayTime %))
+                                                          (str (.-duration ^IntervalDayTime %))))
+
+          IntervalMonthDayNano (transit/write-handler "core2.interval/month-day-nano"
+                                                      #(vector (str (.-period ^IntervalMonthDayNano %))
+                                                               (str (.-duration ^IntervalMonthDayNano %))))}))

--- a/api/src/core2/types/IntervalDayTime.java
+++ b/api/src/core2/types/IntervalDayTime.java
@@ -1,0 +1,33 @@
+package core2.types;
+
+import java.time.Duration;
+import java.time.Period;
+import java.util.Objects;
+
+public final class IntervalDayTime {
+    public final Period period;
+    public final Duration duration;
+
+    public IntervalDayTime(Period period, Duration duration) {
+        this.period = period;
+        this.duration = duration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IntervalDayTime that = (IntervalDayTime) o;
+        return period.equals(that.period) && duration.equals(that.duration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(period, duration);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("(IntervalDayTime %s %s)", period, duration);
+    }
+}

--- a/api/src/core2/types/IntervalMonthDayNano.java
+++ b/api/src/core2/types/IntervalMonthDayNano.java
@@ -1,0 +1,33 @@
+package core2.types;
+
+import java.time.Duration;
+import java.time.Period;
+import java.util.Objects;
+
+public final class IntervalMonthDayNano {
+    public final Period period;
+    public final Duration duration;
+
+    public IntervalMonthDayNano(Period period, Duration duration) {
+        this.period = period;
+        this.duration = duration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IntervalMonthDayNano that = (IntervalMonthDayNano) o;
+        return period.equals(that.period) && duration.equals(that.duration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(period, duration);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("(IntervalMonthDayNano %s %s)", period, duration);
+    }
+}

--- a/api/src/core2/types/IntervalYearMonth.java
+++ b/api/src/core2/types/IntervalYearMonth.java
@@ -1,0 +1,30 @@
+package core2.types;
+
+import java.time.Period;
+import java.util.Objects;
+
+public final class IntervalYearMonth {
+    public final Period period;
+
+    public IntervalYearMonth(Period period) {
+        this.period = period;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IntervalYearMonth that = (IntervalYearMonth) o;
+        return period.equals(that.period);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(period);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("(IntervalYearMonth %s)", period);
+    }
+}

--- a/api/src/data_readers.clj
+++ b/api/src/data_readers.clj
@@ -1,3 +1,8 @@
 {c2/tx-key core2.api/map->TransactionInstant
  c2/illegal-arg core2.error/-iae-reader
- c2/runtime-err core2.error/-runtime-err-reader}
+ c2/runtime-err core2.error/-runtime-err-reader
+
+ c2/period-duration core2.edn/period-duration-reader
+ c2.interval/year-month core2.edn/interval-ym-reader
+ c2.interval/day-time core2.edn/interval-dt-reader
+ c2.interval/month-day-nano core2.edn/interval-mdn-reader}

--- a/core/src/core2/edn.clj
+++ b/core/src/core2/edn.clj
@@ -1,19 +1,42 @@
 (ns ^{:clojure.tools.namespace.repl/load false}
   core2.edn
-  (:require [clojure.string :as str])
-  (:import java.io.Writer
+  (:import (core2.types IntervalDayTime IntervalMonthDayNano IntervalYearMonth)
+           java.io.Writer
            [java.time Duration Period]
            [org.apache.arrow.vector PeriodDuration]))
 
-(defn period-duration-reader [pd]
-  (let [[p d] (str/split pd #" ")]
-    (PeriodDuration. (Period/parse p) (Duration/parse d))))
+(defn period-duration-reader [[p d]]
+  (PeriodDuration. (Period/parse p) (Duration/parse d)))
 
-(defn- print-time-to-string [t o]
-  (str "#time/" t " \"" (str o) "\""))
-
-(defmethod print-dup PeriodDuration [c ^Writer w]
-  (.write w ^String (print-time-to-string "period-duration" c)))
+(defmethod print-dup PeriodDuration [^PeriodDuration pd ^Writer w]
+  (.write w (format "#c2/period-duration %s" (pr-str [(str (.getPeriod pd)) (str (.getDuration pd))]))))
 
 (defmethod print-method PeriodDuration [c ^Writer w]
   (print-dup c w))
+
+(defn interval-ym-reader [p]
+  (IntervalYearMonth. (Period/parse p)))
+
+(defmethod print-dup IntervalYearMonth [^IntervalYearMonth i, ^Writer w]
+  (.write w (format "#c2.interval/year-month %s" (pr-str (str (.-period i))))))
+
+(defmethod print-method IntervalYearMonth [i ^Writer w]
+  (print-dup i w))
+
+(defn interval-dt-reader [[p d]]
+  (IntervalDayTime. (Period/parse p) (Duration/parse d)))
+
+(defmethod print-dup IntervalDayTime [^IntervalDayTime i, ^Writer w]
+  (.write w (format "#c2.interval/day-time %s" (pr-str [(str (.-period i)) (str (.-duration i))]))))
+
+(defmethod print-method IntervalDayTime [i ^Writer w]
+  (print-dup i w))
+
+(defn interval-mdn-reader [[p d]]
+  (IntervalMonthDayNano. (Period/parse p) (Duration/parse d)))
+
+(defmethod print-dup IntervalMonthDayNano [^IntervalMonthDayNano i, ^Writer w]
+  (.write w (format "#c2.interval/month-day-nano %s" (pr-str [(str (.-period i)) (str (.-duration i))]))))
+
+(defmethod print-method IntervalMonthDayNano [i ^Writer w]
+  (print-dup i w))

--- a/core/src/core2/expression/temporal.clj
+++ b/core/src/core2/expression/temporal.clj
@@ -4,7 +4,6 @@
             [core2.expression.metadata :as expr.meta]
             [core2.expression.walk :as ewalk]
             [core2.temporal :as temporal]
-            [core2.types :as types]
             [core2.util :as util]
             [core2.error :as err])
   (:import (java.time Duration Instant LocalDate LocalDateTime LocalTime Period ZoneId ZoneOffset ZonedDateTime)
@@ -476,12 +475,12 @@
         d (.getDuration pd)]
     (PeriodDuration. (.multipliedBy p factor) (.multipliedBy d factor))))
 
-(defmethod expr/codegen-mono-call [:* :interval :int] [_]
-  {:return-type [:interval :month-day-nano]
+(defmethod expr/codegen-mono-call [:* :interval :int] [{[l-type _] :arg-types}]
+  {:return-type l-type
    :->call-code (fn [[a b]] `(pd-scale ~a ~b))})
 
-(defmethod expr/codegen-mono-call [:* :int :interval] [_]
-  {:return-type [:interval :month-day-nano]
+(defmethod expr/codegen-mono-call [:* :int :interval] [{[_ r-type] :arg-types}]
+  {:return-type r-type
    :->call-code (fn [[a b]] `(pd-scale ~b ~a))})
 
 ;; numeric division for intervals

--- a/test/core2/node_test.clj
+++ b/test/core2/node_test.clj
@@ -93,3 +93,7 @@
     (t/is (= [{:id "foo", :arr [9 8 7 6], :fst 9, :snd 8, :lst 6}]
              (c2/sql-query tu/*node* "SELECT foo.id, foo.arr, foo.arr[1] AS fst, foo.arr[2] AS snd, foo.arr[4] AS lst FROM foo"
                            {:basis {:tx !tx}})))))
+
+(t/deftest test-interval-literal-cce-271
+  (t/is (= [{:a #c2.interval/year-month "P12M"}]
+           (c2/sql-query tu/*node* "select a.a from (values (1 year)) a (a)" {}))))


### PR DESCRIPTION
fixes #271. related to #112 

* We now have three Interval classes to be explicit about which type of interval we have in hand. #271 was a bit of an edge case, in a sense, in that it was caused by the table operator needing to `get-object` out of the vectors, and then `write-value!` back in. doing this with PDs meant that some of the type information was lost (because it's a one concrete class to many col-types mapping) so returning different types meant this was preserved.
* I haven't touched the EE - this still uses PDs throughout, to minimise churn (RFC!)
* If we did have the EE use these three classes, we could also consider basing them on primitives rather than objects - most of the operations involving intervals (and, indeed, the spec) are defined in terms of the constituent parts rather than necessarily needing to know how calendars work.