### PR TITLE
Print 'starting' message with git SHA when running uberjar via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM eclipse-temurin:17
 
 WORKDIR /usr/local/lib/xtdb
 
+ARG GIT_SHA
+
+ENV GIT_SHA=${GIT_SHA}
+
 ENTRYPOINT ["java", \
     "-Dclojure.main.report=stderr", \
     "-Dlogback.configurationFile=logback.xml", \

--- a/bin/docker-build.sh
+++ b/bin/docker-build.sh
@@ -10,6 +10,6 @@ set -e
     fi
 
     echo Building Docker image ...
-    docker build -t core2:latest .
+    docker build -t core2:latest --build-arg GIT_SHA=$(git rev-parse HEAD) .
     echo Done
 )

--- a/core/src/core2/main.clj
+++ b/core/src/core2/main.clj
@@ -2,4 +2,5 @@
   (:gen-class))
 
 (defn -main [& args]
+  (println (str "Starting XTDB Core2 (pre-alpha) @ " (subs (System/getenv "GIT_SHA") 0 7) " ..."))
   ((requiring-resolve 'core2.cli/start-node-from-command-line) args))


### PR DESCRIPTION
Not sure if this is the best approach but it seems to work fine. In any case, something like it could be handy.

```
➜  core2 git:(ac4e91f8) ✗ docker run -p 5432:5432 core2
Starting XTDB Core2 (pre-alpha) @ ac4e91f ...
22:02:25 | DEBUG core2.pgwire | Pgwire server listening on 5432
22:02:25 | INFO  core2.pgwire | PGWire server started on port: 5432
22:02:25 | INFO  core2.server | HTTP server started on port:  3000
22:02:25 | INFO  core2.cli | Node started
```