### PR TITLE
Fix scan bugs where single row ids had multiple validity ranges. #409

### DIFF
--- a/core/src/core2/align.clj
+++ b/core/src/core2/align.clj
@@ -1,7 +1,11 @@
 (ns core2.align
   (:require [core2.temporal :as temporal]
-            [core2.vector.indirect :as iv])
-  (:import [java.util ArrayList LinkedList List Map]
+            [core2.vector.indirect :as iv]
+            [core2.vector :as vec])
+  (:import (core2.vector IIndirectRelation IIndirectVector)
+           [java.util HashMap LinkedList List Map]
+           java.util.function.BiFunction
+           java.util.stream.IntStream
            [org.apache.arrow.vector BigIntVector VectorSchemaRoot]
            org.roaringbitmap.longlong.Roaring64Bitmap
            org.roaringbitmap.RoaringBitmap))
@@ -28,28 +32,38 @@
         (.add res idx)))
     (.toArray res)))
 
-(defn- <-row-id-bitmap-with-repetitions ^ints [^Map row-id->repeat-count ^BigIntVector row-id-vec]
-  (let [res (ArrayList.)]
+(defn- ->row-id->repeat-count ^java.util.Map [^IIndirectVector row-id-col]
+  (let [res (HashMap.)
+        ^BigIntVector row-id-vec (.getVector row-id-col)]
+    (dotimes [idx (.getValueCount row-id-col)]
+      (let [row-id (.get row-id-vec (.getIndex row-id-col idx))]
+        (.compute res row-id (reify BiFunction
+                               (apply [_ _k v]
+                                 (if v
+                                   (inc (long v))
+                                   1))))))
+    res))
+
+(defn- align-vector ^core2.vector.IIndirectVector [^VectorSchemaRoot content-root, ^Map row-id->repeat-count]
+  (let [^BigIntVector row-id-vec (.getVector content-root 0)
+        in-vec (.getVector content-root 1)
+        res (IntStream/builder)]
     (dotimes [idx (.getValueCount row-id-vec)]
       (let [row-id (.get row-id-vec idx)]
         (when-let [ns (.get row-id->repeat-count row-id)]
           (dotimes [_ ns]
             (.add res idx)))))
-    (int-array res)))
 
-(defn align-vectors ^core2.vector.IIndirectRelation [^List roots, ^Roaring64Bitmap row-id-bitmap
-                                                     {:keys [^Map row-id->repeat-count, with-row-id-vec?]}]
-  (let [read-cols (LinkedList.)]
-    (doseq [^VectorSchemaRoot root roots
-            :let [row-id-vec (.getVector root 0)
-                  in-vec (.getVector root 1)
-                  idxs (if (and row-id->repeat-count
-                                (not (temporal/temporal-column? (.getName in-vec))))
-                         (<-row-id-bitmap-with-repetitions row-id->repeat-count row-id-vec)
-                         (<-row-id-bitmap row-id-bitmap row-id-vec))]]
-      (when (and with-row-id-vec? (empty? read-cols))
-        (.add read-cols (iv/->indirect-vec row-id-vec idxs)))
+    (iv/->indirect-vec in-vec (.toArray (.build res)))))
 
-      (.add read-cols (iv/->indirect-vec in-vec idxs)))
+(defn align-vectors ^core2.vector.IIndirectRelation [^List content-roots, ^IIndirectRelation temporal-rel]
+   ;; assumption: temporal-rel is sorted by row-id
+  (let [read-cols (LinkedList. (seq temporal-rel))
+        temporal-row-id-col (.vectorForName temporal-rel "_row-id")]
+    (assert temporal-row-id-col)
+
+    (let [row-id->repeat-count (->row-id->repeat-count temporal-row-id-col)]
+      (doseq [^VectorSchemaRoot content-root content-roots]
+        (.add read-cols (align-vector content-root row-id->repeat-count))))
 
     (iv/->indirect-rel read-cols)))

--- a/core/src/core2/expression/temporal.clj
+++ b/core/src/core2/expression/temporal.clj
@@ -31,7 +31,7 @@
 (defn ->temporal-min-max-range [selects params]
   (let [min-range (temporal/->min-range)
         max-range (temporal/->max-range)
-        col-types (zipmap (map symbol (keys temporal/temporal-fields))
+        col-types (zipmap (map symbol (keys temporal/temporal-col-types))
                           (repeat temporal/temporal-col-type))]
     (doseq [[col-name select-form] selects
             :when (temporal/temporal-column? col-name)]

--- a/core/src/core2/sql.clj
+++ b/core/src/core2/sql.clj
@@ -13,4 +13,5 @@
              plan/*opts* query-opts]
      (-> (parser/parse query) parser/or-throw
          (sem/analyze-query) sem/or-throw
-         (plan/plan-query query-opts)))))
+         (plan/plan-query query-opts)
+         #_(doto clojure.pprint/pprint)))))


### PR DESCRIPTION
This fixes two similar issues:

Firstly, that the cardinality of a query depended on whether the user implicitly or explicitly scanned for temporal columns:

```sql
START TRANSACTION READ WRITE;
INSERT INTO foo (id, v) VALUES (1, 1);
COMMIT;

START TRANSACTION READ WRITE;
UPDATE foo 
  FOR PORTION OF APPLICATION_TIME FROM DATE '2023-01-01' TO DATE '2024-01-01' 
  SET v = 2;
COMMIT;

SELECT foo.id, foo.v FROM foo;

-- previously
 id | v 
----+---
 1  | 1
 1  | 2
(2 rows)

-- now
 id | v 
----+---
 1  | 1
 1  | 2
 1  | 1
(3 rows)
```

Secondly (fixes xtdb/xtdb#2261), that if a row had been temporally split _and_ the temporal filter of a query used an expression that couldn't be resolved to a literal (e.g. `FOR APPLICATION_TIME AS OF CURRENT_TIMESTAMP` / `(<= application_time_start (current-timestamp)`), we were returning temporally invalid rows:

```sql
SELECT foo.id, foo.v, foo.application_time_start, foo.application_time_end
  FROM foo
  ORDER BY foo.application_time_start;

-- correct, for illustration
 id | v |    application_time_start     |     application_time_end      
----+---+-------------------------------+-------------------------------
 1  | 1 | "2022-09-08T10:39:25.349706Z" | "2023-01-01T00:00Z"
 1  | 2 | "2023-01-01T00:00Z"           | "2024-01-01T00:00Z"
 1  | 1 | "2024-01-01T00:00Z"           | "9999-12-31T23:59:59.999999Z"
(3 rows)


SELECT foo.id, foo.v, foo.application_time_start, foo.application_time_end
  FROM foo FOR APPLICATION_TIME AS OF DATE '2025-01-01'
  ORDER BY foo.application_time_start;

-- previously
 id | v |    application_time_start     |     application_time_end      
----+---+-------------------------------+-------------------------------
 1  | 1 | "2022-09-08T10:39:25.349706Z" | "2023-01-01T00:00Z"
 1  | 1 | "2024-01-01T00:00Z"           | "9999-12-31T23:59:59.999999Z"
(2 rows)

-- now
 id | v |    application_time_start     |     application_time_end      
----+---+-------------------------------+-------------------------------
 1  | 1 | "2024-01-01T00:00Z"           | "9999-12-31T23:59:59.999999Z"
(1 row)
```

Implementation notes:

* TemporalRoots had a row-id-bitmap, which erroneously de-duplicated the row-ids. This meant that a single row-id could only be completely valid or completely invalid.
* TemporalRoots are now represented by a 'temporal relation' (an IIndirectRelation) which allows for duplicate row-ids.
* We also filter this relation early so that invalid temporal ranges are removed - this means that a single row-id can be valid for some of its temporal ranges but not others.
* We contain both the temporal data and the selection vector within one object (the temporal-rel), so that we don't have to refer to several different objs/mappings/bitmaps in scan to know what's valid - this turned out to be a source of both confusion and bugs.