### PR TITLE
Represent field_references as keywords in plan

### DIFF
--- a/core/src/core2/expression.clj
+++ b/core/src/core2/expression.clj
@@ -108,15 +108,15 @@
                              :form form})))
 
   (let [[struct field] args]
-    (when-not (symbol? field)
+    (when-not (or (symbol? field) (keyword? field))
       (throw (err/illegal-arg :core2.expression/arity-error
-                              {::err/message (str "'.' expects symbol fields: " (pr-str form))
+                              {::err/message (str "'.' expects symbol or keyword fields: " (pr-str form))
                                :form form})))
 
     {:op :vectorised-call
      :f :get-field
      :args [(form->expr struct env)]
-     :field field}))
+     :field (symbol field)}))
 
 (defmethod parse-list-form '.. [[_ & args :as form] env]
   (let [[struct & fields] args]
@@ -124,15 +124,15 @@
       (throw (err/illegal-arg :core2.expression/arity-error
                               {::err/message (str "'..' expects at least 2 args: " (pr-str form))
                                :form form})))
-    (when-not (every? symbol? fields)
+    (when-not (every? #(or (symbol? %) (keyword? %)) fields)
       (throw (err/illegal-arg :core2.expression/parse-error
-                              {::err/message (str "'..' expects symbol fields: " (pr-str form))
+                              {::err/message (str "'..' expects symbol or keyword fields: " (pr-str form))
                                :form form})))
     (reduce (fn [struct-expr field]
               {:op :vectorised-call
                :f :get-field
                :args [struct-expr]
-               :field field})
+               :field (symbol field)})
             (form->expr struct env)
             (rest args))))
 

--- a/core/src/core2/sql/plan.clj
+++ b/core/src/core2/sql/plan.clj
@@ -798,7 +798,7 @@
 
     ;; Does not work for column references, see above.
     [:field_reference ^:z vep [:regular_identifier fn]]
-    (list '. (expr vep) (symbol fn))
+    (list '. (expr vep) (keyword fn))
 
     [:array_value_constructor_by_enumeration]
     ;; =>

--- a/test/core2/sql/logic_test/direct-sql/object-array.test
+++ b/test/core2/sql/logic_test/direct-sql/object-array.test
@@ -1,0 +1,136 @@
+hash-threshold 100
+
+statement ok
+INSERT INTO t1(id) VALUES(1)
+
+# testing projection/construction
+
+query T rowsort
+SELECT OBJECT('id': 1) FROM t1
+----
+{:id 1}
+
+query T rowsort
+SELECT OBJECT ('foo': 2, 'bar': OBJECT('baz': 'biff')) FROM t1
+----
+{:foo 2, :bar {:baz "biff"}}
+
+query T rowsort
+SELECT OBJECT ('foo': OBJECT('bibble': true),
+			   'bar': OBJECT('baz': -4113466,
+							 'flib': OBJECT('true': false)))
+FROM t1
+----
+{:foo {:bibble true}, :bar {:baz -4113466, :flib {:true false}}}
+
+query T rowsort
+SELECT ARRAY ['foo', 'bar'] FROM t1
+----
+["foo","bar"]
+
+query T rowsort
+SELECT ARRAY [1, 5, -23] FROM t1
+----
+[1,5,-23]
+
+query T rowsort
+SELECT ARRAY [true, FALSE, true, TRUE, false] FROM t1
+----
+[true,false,true,true,false]
+
+query T rowsort
+SELECT OBJECT ('foo': 5, 'bar': OBJECT('baz': ARRAY [-45, 1, 24])) FROM t1
+----
+{:foo 5, :bar {:baz [-45 1 24]}}
+
+query T rowsort
+SELECT ARRAY [OBJECT('foo': 5), OBJECT('foo': 5)] FROM t1
+----
+[{"foo":5},{"foo":5}]
+
+statement ok
+INSERT INTO t1(id) VALUES(2)
+
+# testing more than one row
+
+query T rowsort
+SELECT OBJECT ('foo': OBJECT('bibble': true),
+			   'bar': OBJECT('baz': -4113466,
+							 'flib': OBJECT('true': false)))
+FROM t1
+----
+{:foo {:bibble true}, :bar {:baz -4113466, :flib {:true false}}}
+{:foo {:bibble true}, :bar {:baz -4113466, :flib {:true false}}}
+
+# testing field refs
+
+query T nosort
+SELECT foo.a.b
+FROM (VALUES ({'b': 42}),
+			 ({'d': 100})) AS foo(a)
+----
+42
+NULL
+
+query T nosort
+SELECT foo.a.b.c
+FROM (VALUES ({'b': {'c': 'cat'}}),
+ 			 ({'d': 100})) AS foo(a)
+----
+cat
+NULL
+
+# testing OBJECT round trip
+
+statement ok
+INSERT INTO t2(id, data)
+VALUES(1, OBJECT ('foo': OBJECT('bibble': true),
+				  'bar': OBJECT('baz': -4113466,
+				        		'flib': OBJECT('true': false))))
+
+statement ok
+INSERT INTO t2(id, data)
+VALUES(2, {'foo': {'bibble': true},
+		   'bar': {'baz': 1001}})
+
+query T rowsort
+SELECT t2.data FROM t2
+----
+{:foo {:bibble true}, :bar {:baz -4113466, :flib {:true false}}}
+{:foo {:bibble true}, :bar {:baz 1001}}
+
+# SEE 440
+#query T rowsort
+#SELECT t2.data.foo FROM t2
+#----
+#{:bibble true}
+#{:bibble true}
+
+#query T nosort
+#SELECT t2.data.foo.bibble FROM t2
+#----
+#true
+#true
+
+# SEE #244
+#SELECT t2.data, t1.data FROM t2, t2 AS t1
+
+# testing ARRAY round trip
+
+statement ok
+INSERT INTO t3(id, data) VALUES (1, [2, 3])
+
+statement ok
+INSERT INTO t3(id, data) VALUES (2, [6, 7])
+
+query T nosort
+SELECT t3.data FROM t3
+----
+[2,3]
+[6,7]
+
+query T nosort
+SELECT t3.data[2] FROM t3
+----
+3
+7

--- a/test/core2/sql/logic_test/direct_sql_test.clj
+++ b/test/core2/sql/logic_test/direct_sql_test.clj
@@ -10,3 +10,4 @@
 (slt/def-slt-test direct-sql--system_time {:direct-sql true})
 (slt/def-slt-test direct-sql--period_specifications {:direct-sql true})
 (slt/def-slt-test direct-sql--periods-and-derived-cols {:direct-sql true})
+(slt/def-slt-test direct-sql--object-array {:direct-sql true})

--- a/test/core2/sql/logic_test/runner.clj
+++ b/test/core2/sql/logic_test/runner.clj
@@ -407,7 +407,7 @@
 
   (time (-main "--verify" "--db" "sqlite" "test/core2/sql/logic_test/sqlite_test/select4.test"))
 
-  (time (-main "--verify" "--direct-sql" "--db" "xtdb" "test/core2/sql/logic_test/direct-sql/system_time.test"))
+  (time (-main "--verify" "--direct-sql" "--db" "xtdb" "test/core2/sql/logic_test/direct-sql/object-array.test"))
 
   (= (time
       (with-out-str

--- a/test/core2/sql_test.clj
+++ b/test/core2/sql_test.clj
@@ -731,12 +731,12 @@
   (t/are [sql expected]
     (= expected (plan-expr sql))
 
-    "OBJECT('foo': 2).foo" '(. {:foo 2} foo)
-    "{'foo': 2}.foo" '(. {:foo 2} foo)
-    "{'foo': 2}.foo.bar" '(. (. {:foo 2} foo) bar)
+    "OBJECT('foo': 2).foo" '(. {:foo 2} :foo)
+    "{'foo': 2}.foo" '(. {:foo 2} :foo)
+    "{'foo': 2}.foo.bar" '(. (. {:foo 2} :foo) :bar)
 
-    "foo.a.b" '(. x1 b)
-    "foo.a.b.c" '(. (. x1 b) c)))
+    "foo.a.b" '(. x1 :b)
+    "foo.a.b.c" '(. (. x1 :b) :c)))
 
 (deftest test-array-subqueries
   (t/are [file q]


### PR DESCRIPTION
dot field accessor expression now takes keywords or symbols, coercing the former to the latter before calling get-field.

commit also adds tests for the current state of object and array