### PR TITLE
Add support for subqueries in qualified join clauses

### DIFF
--- a/test-resources/core2/sql/plan_test_expectations/deeply-nested-correlated-query.edn
+++ b/test-resources/core2/sql/plan_test_expectations/deeply-nested-correlated-query.edn
@@ -4,7 +4,7 @@
   [x1 x2]
   [:apply
    :semi-join
-   {x2 ?x18, x5 ?x17}
+   {x2 ?x17, x5 ?x18}
    [:cross-join
     [:rename
      {A x1, B x2, _table x3}
@@ -13,10 +13,10 @@
    [:project
     [x8 x9]
     [:semi-join
-     [{x9 x12} {?x17 x13}]
+     [{x9 x12} (= x13 ?x18)]
      [:rename
       {A x8, B x9, _table x10}
-      [:scan [{A (= A ?x18)} B {_table (= _table "R")}]]]
+      [:scan [{A (= A ?x17)} B {_table (= _table "R")}]]]
      [:rename
       {A x12, B x13, _table x14}
       [:scan [A B {_table (= _table "R")}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
+++ b/test-resources/core2/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
@@ -2,19 +2,18 @@
  {x1 a}
  [:project
   [x1]
-  [:select
-   (= x4 x8)
-   [:apply
-    :single-join
-    {x5 ?x12}
-    [:join
-     []
-     [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+  [:cross-join
+   [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+   [:select
+    (= x4 x8)
+    [:apply
+     :single-join
+     {x5 ?x12}
      [:rename
       {c x4, b x5, _table x6}
-      [:scan [c b {_table (= _table "bar")}]]]]
-    [:project
-     [x8]
-     [:rename
-      {b x8, a x9, _table x10}
-      [:scan [b {a (= a ?x12)} {_table (= _table "foo")}]]]]]]]]
+      [:scan [c b {_table (= _table "bar")}]]]
+     [:project
+      [x8]
+      [:rename
+       {b x8, a x9, _table x10}
+       [:scan [b {a (= a ?x12)} {_table (= _table "foo")}]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
+++ b/test-resources/core2/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
@@ -2,18 +2,17 @@
  {x1 a}
  [:project
   [x1]
-  [:apply
-   :semi-join
-   {x5 ?x12, x4 ?x13}
-   [:join
-    []
-    [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+  [:cross-join
+   [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+   [:apply
+    :semi-join
+    {x5 ?x12, x4 ?x13}
     [:rename
      {c x4, b x5, _table x6}
-     [:scan [c b {_table (= _table "bar")}]]]]
-   [:project
-    [x8]
-    [:rename
-     {b x8, a x9, _table x10}
-     [:scan
-      [{b (= ?x13 b)} {a (= a ?x12)} {_table (= _table "foo")}]]]]]]]
+     [:scan [c b {_table (= _table "bar")}]]]
+    [:project
+     [x8]
+     [:rename
+      {b x8, a x9, _table x10}
+      [:scan
+       [{b (= ?x13 b)} {a (= a ?x12)} {_table (= _table "foo")}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/subquery-in-join-uncorrelated-subquery.edn
+++ b/test-resources/core2/sql/plan_test_expectations/subquery-in-join-uncorrelated-subquery.edn
@@ -2,16 +2,15 @@
  {x1 a}
  [:project
   [x1]
-  [:select
-   (= x4 x7)
-   [:single-join
-    []
-    [:join
+  [:cross-join
+   [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+   [:select
+    (= x4 x7)
+    [:single-join
      []
-     [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
-     [:rename {c x4, _table x5} [:scan [c {_table (= _table "bar")}]]]]
-    [:project
-     [x7]
-     [:rename
-      {b x7, _table x8}
-      [:scan [b {_table (= _table "foo")}]]]]]]]]
+     [:rename {c x4, _table x5} [:scan [c {_table (= _table "bar")}]]]
+     [:project
+      [x7]
+      [:rename
+       {b x7, _table x8}
+       [:scan [b {_table (= _table "foo")}]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q13-customer-distribution.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q13-customer-distribution.edn
@@ -1,14 +1,14 @@
 [:rename
- {x9 c_count, x12 custdist}
+ {x10 c_count, x13 custdist}
  [:order-by
-  [[x12 {:direction :desc, :null-ordering :nulls-last}]
-   [x9 {:direction :desc, :null-ordering :nulls-last}]]
+  [[x13 {:direction :desc, :null-ordering :nulls-last}]
+   [x10 {:direction :desc, :null-ordering :nulls-last}]]
   [:group-by
-   [x9 {x12 (count x11)}]
+   [x10 {x13 (count x12)}]
    [:map
-    [{x11 1}]
+    [{x12 1}]
     [:group-by
-     [x1 {x9 (count x4)}]
+     [x1 {x10 (count x4)}]
      [:left-outer-join
       [{x1 x5}]
       [:rename

--- a/test/core2/operator/apply_test.clj
+++ b/test/core2/operator/apply_test.clj
@@ -116,3 +116,16 @@
                                [:select false
                                 [:table [{x2 20}]]]]]
                             {:with-col-types? true})))))
+
+(t/deftest test-nested-apply
+  (t/is (= [{:z 0, :x 0, :y 0}
+            {:z 0, :x 1, :y 0}
+            {:z 1, :x 0, :y 1}
+            {:z 1, :x 1, :y 1}]
+          (tu/query-ra
+              '[:apply :cross-join {z ?x2}
+                [:table [{:z 0}, {:z 1}]]
+                [:apply :cross-join {}
+                 [:table [{:x 0}, {:x 1}]]
+                 [:select (= ?x2 y)
+                  [:table [{:y 0}, {:y 1}]]]]] {}))))

--- a/test/core2/sql/logic_test/direct-sql/qualified_joins.test
+++ b/test/core2/sql/logic_test/direct-sql/qualified_joins.test
@@ -1,0 +1,440 @@
+hash-threshold 100
+
+statement ok
+INSERT INTO foo (id, x) VALUES (1, 1), (2, 2)
+
+statement ok
+INSERT INTO bar (id, x) VALUES (1, 1), (2, 3)
+
+statement ok
+INSERT INTO baz (id, x) VALUES (1, 2)
+
+# named column joins
+
+query IIII rowsort
+SELECT foo.id foo, foo.x foo_x, bar.id bar, bar.x bar_x FROM foo LEFT JOIN bar USING (id, x)
+----
+1
+1
+1
+1
+2
+2
+NULL
+NULL
+
+query IIII rowsort
+SELECT foo.id foo, foo.x foo_x, bar.id bar, bar.x bar_x FROM foo LEFT JOIN bar USING (id) WHERE foo.x = bar.x
+----
+1
+1
+1
+1
+
+query IIII rowsort
+SELECT foo.id foo, foo.x foo_x, bar.id bar, bar.x bar_x FROM foo JOIN bar USING (id, x)
+----
+1
+1
+1
+1
+
+query IIII rowsort
+SELECT foo.id foo, foo.x foo_x, bar.id bar, bar.x bar_x FROM foo JOIN bar USING (id) WHERE foo.x = bar.x
+----
+1
+1
+1
+1
+
+query IIII rowsort
+SELECT foo.id foo, foo.x foo_x, bar.id bar, bar.x bar_x FROM foo RIGHT JOIN bar USING (id, x)
+----
+1
+1
+1
+1
+NULL
+NULL
+2
+3
+
+query IIII rowsort
+SELECT foo.id foo, foo.x foo_x, bar.id bar, bar.x bar_x FROM foo RIGHT JOIN bar USING (id) WHERE foo.x = bar.x
+----
+1
+1
+1
+1
+
+query IIII rowsort
+SELECT foo.id foo, foo.x foo_x, bar.id bar, bar.x bar_x FROM foo INNER JOIN bar USING (id, x)
+----
+1
+1
+1
+1
+
+query IIII rowsort
+SELECT foo.id foo, foo.x foo_x, bar.id bar, bar.x bar_x FROM foo INNER JOIN bar USING (id) WHERE foo.x = bar.x
+----
+1
+1
+1
+1
+
+# simple qualified joins
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON foo.x = foo.x
+----
+1
+1
+1
+3
+2
+1
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON bar.x = foo.x
+----
+1
+1
+2
+NULL
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON bar.x = bar.x
+----
+1
+1
+1
+3
+2
+1
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo RIGHT JOIN bar ON bar.x = foo.x
+----
+1
+1
+NULL
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo JOIN bar ON bar.x = foo.x
+----
+1
+1
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo INNER JOIN bar ON bar.x = foo.x
+----
+1
+1
+
+# uncorrelated subquery in join clause
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON bar.x = (SELECT baz.x FROM baz)
+----
+1
+NULL
+2
+NULL
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON foo.x = (SELECT baz.x FROM baz)
+----
+1
+NULL
+2
+1
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo RIGHT JOIN bar ON bar.x = (SELECT baz.x FROM baz)
+----
+NULL
+1
+NULL
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo RIGHT JOIN bar ON foo.x = (SELECT baz.x FROM baz)
+----
+2
+1
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo JOIN bar ON bar.x = (SELECT baz.x FROM baz)
+----
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo JOIN bar ON foo.x = (SELECT baz.x FROM baz)
+----
+2
+1
+2
+3
+
+# uncorrelated subquery in join clause with additional clause
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON bar.x = (SELECT baz.x FROM baz) AND foo.x = bar.x
+----
+1
+NULL
+2
+NULL
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON foo.x = (SELECT baz.x FROM baz) AND foo.x = bar.x
+----
+1
+NULL
+2
+NULL
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON foo.x = (SELECT baz.x FROM baz) AND foo.x = 2
+----
+1
+NULL
+2
+1
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo RIGHT JOIN bar ON bar.x = (SELECT baz.x FROM baz) AND foo.x = 2
+----
+NULL
+1
+NULL
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo RIGHT JOIN bar ON foo.x = (SELECT baz.x FROM baz) AND foo.x = 2
+----
+2
+1
+2
+3
+
+# correlated subquery in join clause
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON bar.x = (SELECT baz.x FROM baz WHERE baz.x = bar.x)
+----
+1
+NULL
+2
+NULL
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON bar.x = (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+1
+NULL
+2
+NULL
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON foo.x = (SELECT baz.x FROM baz WHERE baz.x = bar.x)
+----
+1
+NULL
+2
+NULL
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON foo.x = (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+1
+NULL
+2
+1
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo RIGHT JOIN bar ON bar.x = (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+NULL
+1
+NULL
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo RIGHT JOIN bar ON foo.x = (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+2
+1
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo INNER JOIN bar ON foo.x = (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+2
+1
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo JOIN bar ON bar.x = (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON foo.x = (SELECT baz.x FROM baz WHERE baz.x = foo.x) AND foo.x = (bar.x + 1)
+----
+1
+NULL
+2
+1
+
+# mulitple correlated subqueries in join clause
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON (SELECT baz.x FROM baz WHERE baz.x = foo.x) = (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+1
+NULL
+2
+1
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON (SELECT baz.x FROM baz WHERE NOT baz.x = bar.x) = (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+1
+NULL
+2
+1
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON (SELECT baz.x FROM baz WHERE foo.x = bar.x) = (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+1
+NULL
+2
+NULL
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON (SELECT baz.x FROM baz WHERE foo.x = bar.x) = (SELECT baz.x FROM baz WHERE baz.x = bar.x)
+----
+1
+NULL
+2
+NULL
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo RIGHT JOIN bar ON (SELECT baz.x FROM baz WHERE baz.x = foo.x) = (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+2
+1
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo JOIN bar ON (SELECT baz.x FROM baz WHERE foo.x = bar.x) = (SELECT baz.x FROM baz WHERE baz.x = bar.x)
+----
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON (SELECT baz.x FROM baz WHERE NOT baz.x = bar.x AND foo.x = baz.x) = (SELECT baz.x FROM baz WHERE baz.x = foo.x AND bar.x = foo.x)
+----
+1
+NULL
+2
+NULL
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON (SELECT baz.x FROM baz WHERE NOT baz.x = bar.x AND foo.x = baz.x) = (SELECT baz.x FROM baz WHERE baz.x = foo.x AND bar.x = 3)
+----
+1
+NULL
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo RIGHT JOIN bar ON (SELECT baz.x FROM baz WHERE NOT baz.x = bar.x AND foo.x = baz.x) = (SELECT baz.x FROM baz WHERE baz.x = foo.x AND bar.x = 3)
+----
+2
+3
+NULL
+1
+
+# join over subquery tables with subquery join clause
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM (SELECT foo.id, foo.x FROM foo) AS foo LEFT JOIN (SELECT bar.id, bar.x FROM bar) AS bar ON (SELECT baz.x FROM baz WHERE NOT baz.x = bar.x AND foo.x = baz.x) = (SELECT baz.x FROM baz WHERE baz.x = foo.x AND bar.x = 3)
+----
+1
+NULL
+2
+3
+
+# correlated quantified comparison join clause
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON foo.x IN (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+1
+NULL
+2
+1
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON bar.x IN (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+1
+NULL
+2
+NULL
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo RIGHT JOIN bar ON bar.x IN (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+NULL
+1
+NULL
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo INNER JOIN bar ON bar.x IN (SELECT baz.x FROM baz WHERE baz.x = foo.x)
+----
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo JOIN bar ON foo.x IN (SELECT baz.x FROM baz WHERE baz.x = foo.x AND bar.x = 3)
+----
+2
+3
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON foo.x IN (SELECT baz.x FROM baz WHERE baz.x = foo.x AND bar.x = 1)
+----
+1
+NULL
+2
+1
+
+query II rowsort
+SELECT foo.x, bar.x bar_x FROM foo LEFT JOIN bar ON foo.x IN (SELECT baz.x FROM baz WHERE baz.x = foo.x AND bar.x = 1) AND bar.x IN (SELECT foo.x FROM foo WHERE bar.x = foo.x)
+----
+1
+NULL
+2
+1

--- a/test/core2/sql/logic_test/direct_sql_test.clj
+++ b/test/core2/sql/logic_test/direct_sql_test.clj
@@ -16,3 +16,4 @@
 (slt/def-slt-test direct-sql--sl-a5 {:direct-sql true})
 (slt/def-slt-test direct-sql--slt-variables {:direct-sql true})
 (slt/def-slt-test direct-sql--sl-demo {:direct-sql true})
+(slt/def-slt-test direct-sql--qualified_joins {:direct-sql true})


### PR DESCRIPTION
Commit does this by creating nested dependant joins (apply)
where the result of any subquery is first joined onto the RHS and
then used as part of the join clause for the qualified join. This outer
join is responsible for brining in any parameters from the LHS so they
are accessable to the rest of the subtree.

Commit also fixes a bug in rewrite-equals-predicates-in-join-as-equi-join-map
which resulted in invalid join clause. As well as changing apply to no
longer pass params from its parent as this is no longer needed.