### PR TITLE
Fold unqoted identifiers to lowercase and treat quoted identifiers as case sensitive

### DIFF
--- a/core/src/core2/sql/plan.clj
+++ b/core/src/core2/sql/plan.clj
@@ -1810,8 +1810,8 @@
     [:directly_executable_statement ^:z dsds]
     (plan dsds)
 
-    [:insert_statement "INSERT" "INTO" [:regular_identifier table] ^:z from-subquery]
-    [:insert {:table table}
+    [:insert_statement "INSERT" "INTO" ^:z table ^:z from-subquery]
+    [:insert {:table (sem/identifier table)}
      (let [inner-plan (plan from-subquery)
            projection (first (sem/projected-columns z))]
        (if (some app-time-col? projection)
@@ -1974,6 +1974,9 @@
     ;; if and when query_name becomes a valid child of table_or_query_name
     ;; this needs changing to specifically match on the table case
 
+    ;; table case in above comment refers to the situation in which a real
+    ;; table appears as a child, not the case of the characters in the table name
+
     [:table_primary [:regular_identifier _]]
     ;;=>
     (->> (build-table-primary z)
@@ -2005,6 +2008,44 @@
          (wrap-with-application-time-select z))
 
     [:table_primary [:regular_identifier _] _ _ _ _ _]
+    ;;=>
+    (->> (build-table-primary z)
+         (wrap-with-system-time-select z)
+         (wrap-with-application-time-select z))
+
+    ;; duplicates matches for delimited_identifier for the same reason as above
+
+    [:table_primary [:delimited_identifier _]]
+    ;;=>
+    (->> (build-table-primary z)
+         (wrap-with-system-time-select z)
+         (wrap-with-application-time-select z))
+
+    [:table_primary [:delimited_identifier _] _]
+    ;;=>
+    (->> (build-table-primary z)
+         (wrap-with-system-time-select z)
+         (wrap-with-application-time-select z))
+
+    [:table_primary [:delimited_identifier _] _ _]
+    ;;=>
+    (->> (build-table-primary z)
+         (wrap-with-system-time-select z)
+         (wrap-with-application-time-select z))
+
+    [:table_primary [:delimited_identifier _] _ _ _]
+    ;;=>
+    (->> (build-table-primary z)
+         (wrap-with-system-time-select z)
+         (wrap-with-application-time-select z))
+
+    [:table_primary [:delimited_identifier _] _ _ _ _]
+    ;;=>
+    (->> (build-table-primary z)
+         (wrap-with-system-time-select z)
+         (wrap-with-application-time-select z))
+
+    [:table_primary [:delimited_identifier _] _ _ _ _ _]
     ;;=>
     (->> (build-table-primary z)
          (wrap-with-system-time-select z)

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-1.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-1.edn
@@ -1,15 +1,15 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:project
   [x1]
   [:join
    [{x2 x5}]
    [:rename
-    {movieTitle x1, starName x2, _table x3}
-    [:scan [movieTitle starName {_table (= _table "StarsIn")}]]]
+    {movietitle x1, starname x2, _table x3}
+    [:scan [movietitle starname {_table (= _table "starsin")}]]]
    [:rename
     {name x5, birthdate x6, _table x7}
     [:scan
      [name
       {birthdate (= birthdate 1960)}
-      {_table (= _table "MovieStar")}]]]]]]
+      {_table (= _table "moviestar")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-10.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-10.edn
@@ -4,4 +4,4 @@
   [{x4 (sum x1)}]
   [:rename
    {length x1, _table x2}
-   [:scan [length {_table (= _table "Movie")}]]]]]
+   [:scan [length {_table (= _table "movie")}]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-11.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-11.edn
@@ -4,4 +4,4 @@
   [x1]
   [:rename
    {name x1, _table x2}
-   [:scan [name {_table (= _table "StarsIn")}]]]]]
+   [:scan [name {_table (= _table "starsin")}]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-12.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-12.edn
@@ -4,4 +4,4 @@
   [x1]
   [:rename
    {name x1, _table x2}
-   [:scan [name {_table (= _table "StarsIn")}]]]]]
+   [:scan [name {_table (= _table "starsin")}]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-13.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-13.edn
@@ -6,4 +6,4 @@
    {name x1, lastname x2, _table x3}
    [:select
     (= name lastname)
-    [:scan [name lastname {_table (= _table "StarsIn")}]]]]]]
+    [:scan [name lastname {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-14.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-14.edn
@@ -1,8 +1,8 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:distinct
   [:project
    [x1]
    [:rename
-    {movieTitle x1, _table x2}
-    [:scan [movieTitle {_table (= _table "StarsIn")}]]]]]]
+    {movietitle x1, _table x2}
+    [:scan [movietitle {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-15.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-15.edn
@@ -6,10 +6,10 @@
     [x1]
     [:rename
      {name x1, _table x2}
-     [:scan [name {_table (= _table "StarsIn")}]]]]]
+     [:scan [name {_table (= _table "starsin")}]]]]]
   [:distinct
    [:project
     [x1]
     [:rename
      {name x1, _table x5}
-     [:scan [name {_table (= _table "StarsIn")}]]]]]]]
+     [:scan [name {_table (= _table "starsin")}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-16.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-16.edn
@@ -5,9 +5,9 @@
    [x1]
    [:rename
     {name x1, _table x2}
-    [:scan [name {_table (= _table "StarsIn")}]]]]
+    [:scan [name {_table (= _table "starsin")}]]]]
   [:project
    [x1]
    [:rename
     {name x1, _table x5}
-    [:scan [name {_table (= _table "StarsIn")}]]]]]]
+    [:scan [name {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-17.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-17.edn
@@ -6,9 +6,9 @@
     [x1]
     [:rename
      {name x1, _table x2}
-     [:scan [name {_table (= _table "StarsIn")}]]]]
+     [:scan [name {_table (= _table "starsin")}]]]]
    [:project
     [x1]
     [:rename
      {name x1, _table x5}
-     [:scan [name {_table (= _table "StarsIn")}]]]]]]]
+     [:scan [name {_table (= _table "starsin")}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-18.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-18.edn
@@ -1,14 +1,14 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:distinct
   [:union-all
    [:project
     [x1]
     [:rename
-     {movieTitle x1, _table x2}
-     [:scan [movieTitle {_table (= _table "StarsIn")}]]]]
+     {movietitle x1, _table x2}
+     [:scan [movietitle {_table (= _table "starsin")}]]]]
    [:project
     [x1]
     [:rename
      {name x1, _table x5}
-     [:scan [name {_table (= _table "StarsIn")}]]]]]]]
+     [:scan [name {_table (= _table "starsin")}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-19.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-19.edn
@@ -8,9 +8,9 @@
      [x1]
      [:rename
       {name x1, _table x2}
-      [:scan [name {_table (= _table "StarsIn")}]]]]
+      [:scan [name {_table (= _table "starsin")}]]]]
     [:project
      [x1]
      [:rename
       {name x1, _table x5}
-      [:scan [name {_table (= _table "StarsIn")}]]]]]]]]
+      [:scan [name {_table (= _table "starsin")}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-2.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-2.edn
@@ -1,15 +1,15 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:project
   [x1]
   [:join
    [{x2 x5}]
    [:rename
-    {movieTitle x1, starName x2, _table x3}
-    [:scan [movieTitle starName {_table (= _table "StarsIn")}]]]
+    {movietitle x1, starname x2, _table x3}
+    [:scan [movietitle starname {_table (= _table "starsin")}]]]
    [:rename
     {name x5, birthdate x6, _table x7}
     [:scan
      [name
       {birthdate (and (< birthdate 1960) (> birthdate 1950))}
-      {_table (= _table "MovieStar")}]]]]]]
+      {_table (= _table "moviestar")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-20.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-20.edn
@@ -1,9 +1,9 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:top
   {:limit 10}
   [:project
    [x1]
    [:rename
-    {movieTitle x1, _table x2}
-    [:scan [movieTitle {_table (= _table "StarsIn")}]]]]]]
+    {movietitle x1, _table x2}
+    [:scan [movietitle {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-21.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-21.edn
@@ -1,9 +1,9 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:top
   {:skip 5}
   [:project
    [x1]
    [:rename
-    {movieTitle x1, _table x2}
-    [:scan [movieTitle {_table (= _table "StarsIn")}]]]]]]
+    {movietitle x1, _table x2}
+    [:scan [movietitle {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-22.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-22.edn
@@ -1,9 +1,9 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:top
   {:skip 5, :limit 10}
   [:project
    [x1]
    [:rename
-    {movieTitle x1, _table x2}
-    [:scan [movieTitle {_table (= _table "StarsIn")}]]]]]]
+    {movietitle x1, _table x2}
+    [:scan [movietitle {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-23.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-23.edn
@@ -1,9 +1,9 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:order-by
   [[x1 {:direction :asc, :null-ordering :nulls-last}]]
   [:project
    [x1]
    [:rename
-    {movieTitle x1, _table x2}
-    [:scan [movieTitle {_table (= _table "StarsIn")}]]]]]]
+    {movietitle x1, _table x2}
+    [:scan [movietitle {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-24.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-24.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:top
   {:skip 100}
   [:order-by
@@ -7,5 +7,5 @@
    [:project
     [x1]
     [:rename
-     {movieTitle x1, _table x2}
-     [:scan [movieTitle {_table (= _table "StarsIn")}]]]]]]]
+     {movietitle x1, _table x2}
+     [:scan [movietitle {_table (= _table "starsin")}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-25.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-25.edn
@@ -1,9 +1,9 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:order-by
   [[x1 {:direction :desc, :null-ordering :nulls-last}]]
   [:project
    [x1]
    [:rename
-    {movieTitle x1, _table x2}
-    [:scan [movieTitle {_table (= _table "StarsIn")}]]]]]]
+    {movietitle x1, _table x2}
+    [:scan [movietitle {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-26.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-26.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:project
   [x1]
   [:order-by
@@ -10,5 +10,5 @@
     [:map
      [{x5 (= x2 "foo")}]
      [:rename
-      {movieTitle x1, year x2, _table x3}
-      [:scan [movieTitle year {_table (= _table "StarsIn")}]]]]]]]]
+      {movietitle x1, year x2, _table x3}
+      [:scan [movietitle year {_table (= _table "starsin")}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-27.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-27.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:project
   [x1]
   [:order-by
@@ -7,5 +7,5 @@
    [:project
     [x1 x2]
     [:rename
-     {movieTitle x1, year x2, _table x3}
-     [:scan [movieTitle year {_table (= _table "StarsIn")}]]]]]]]
+     {movietitle x1, year x2, _table x3}
+     [:scan [movietitle year {_table (= _table "starsin")}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-28.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-28.edn
@@ -6,4 +6,4 @@
    [{x4 (= x1 "foo")}]
    [:rename
     {year x1, _table x2}
-    [:scan [year {_table (= _table "StarsIn")}]]]]]]
+    [:scan [year {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-29.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-29.edn
@@ -7,4 +7,4 @@
    {}
    [:rename
     {films x1, _table x2}
-    [:scan [films {_table (= _table "StarsIn")}]]]]]]
+    [:scan [films {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-3.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-3.edn
@@ -1,15 +1,15 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:project
   [x1]
   [:join
    [{x2 x5}]
    [:rename
-    {movieTitle x1, starName x2, _table x3}
-    [:scan [movieTitle starName {_table (= _table "StarsIn")}]]]
+    {movietitle x1, starname x2, _table x3}
+    [:scan [movietitle starname {_table (= _table "starsin")}]]]
    [:rename
     {name x5, birthdate x6, _table x7}
     [:scan
      [{name (= name "Foo")}
       {birthdate (< birthdate 1960)}
-      {_table (= _table "MovieStar")}]]]]]]
+      {_table (= _table "moviestar")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-30.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-30.edn
@@ -7,4 +7,4 @@
    {}
    [:rename
     {films x1, _table x2}
-    [:scan [films {_table (= _table "StarsIn")}]]]]]]
+    [:scan [films {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-31.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-31.edn
@@ -7,4 +7,4 @@
    {:ordinality-column x5}
    [:rename
     {films x1, _table x2}
-    [:scan [films {_table (= _table "StarsIn")}]]]]]]
+    [:scan [films {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-4.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-4.edn
@@ -1,12 +1,12 @@
 [:rename
- {x1 movieTitle}
+ {x1 movietitle}
  [:project
   [x1]
   [:join
    [{x2 x5}]
    [:rename
-    {movieTitle x1, starName x2, _table x3}
-    [:scan [movieTitle starName {_table (= _table "StarsIn")}]]]
+    {movietitle x1, starname x2, _table x3}
+    [:scan [movietitle starname {_table (= _table "starsin")}]]]
    [:project
     [x5]
     [:rename
@@ -14,4 +14,4 @@
      [:scan
       [name
        {birthdate (= birthdate 1960)}
-       {_table (= _table "MovieStar")}]]]]]]]
+       {_table (= _table "moviestar")}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-5.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-5.edn
@@ -1,12 +1,12 @@
 [:rename
- {x5 movieTitle}
+ {x5 movietitle}
  [:project
   [x5]
   [:join
    [{x1 x5} {x2 x6}]
    [:rename
-    {title x1, movieYear x2, _table x3}
-    [:scan [title movieYear {_table (= _table "Movie")}]]]
+    {title x1, movieyear x2, _table x3}
+    [:scan [title movieyear {_table (= _table "movie")}]]]
    [:rename
-    {movieTitle x5, year x6, _table x7}
-    [:scan [movieTitle year {_table (= _table "StarsIn")}]]]]]]
+    {movietitle x5, year x6, _table x7}
+    [:scan [movietitle year {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-6.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-6.edn
@@ -1,12 +1,12 @@
 [:rename
- {x5 movieTitle}
+ {x5 movietitle}
  [:project
   [x5]
   [:left-outer-join
    [{x1 x5} {x2 x6}]
    [:rename
-    {title x1, movieYear x2, _table x3}
-    [:scan [title movieYear {_table (= _table "Movie")}]]]
+    {title x1, movieyear x2, _table x3}
+    [:scan [title movieyear {_table (= _table "movie")}]]]
    [:rename
-    {movieTitle x5, year x6, _table x7}
-    [:scan [movieTitle year {_table (= _table "StarsIn")}]]]]]]
+    {movietitle x5, year x6, _table x7}
+    [:scan [movietitle year {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-7.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-7.edn
@@ -6,7 +6,7 @@
    [{x1 x4}]
    [:rename
     {title x1, _table x2}
-    [:scan [title {_table (= _table "Movie")}]]]
+    [:scan [title {_table (= _table "movie")}]]]
    [:rename
     {title x4, _table x5}
-    [:scan [title {_table (= _table "StarsIn")}]]]]]]
+    [:scan [title {_table (= _table "starsin")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-8.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-8.edn
@@ -6,7 +6,7 @@
    [{x1 x4}]
    [:rename
     {title x1, _table x2}
-    [:scan [title {_table (= _table "StarsIn")}]]]
+    [:scan [title {_table (= _table "starsin")}]]]
    [:rename
     {title x4, _table x5}
-    [:scan [title {_table (= _table "Movie")}]]]]]]
+    [:scan [title {_table (= _table "movie")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-9.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-9.edn
@@ -10,7 +10,7 @@
      [{x2 x6}]
      [:rename
       {name x1, cert x2, _table x3}
-      [:scan [name cert {_table (= _table "MovieExec")}]]]
+      [:scan [name cert {_table (= _table "movieexec")}]]]
      [:rename
       {length x5, producer x6, year x7, _table x8}
-      [:scan [length producer year {_table (= _table "Movie")}]]]]]]]]
+      [:scan [length producer year {_table (= _table "movie")}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/deeply-nested-correlated-query.edn
+++ b/test-resources/core2/sql/plan_test_expectations/deeply-nested-correlated-query.edn
@@ -1,5 +1,5 @@
 [:rename
- {x1 A, x2 B}
+ {x1 a, x2 b}
  [:project
   [x1 x2]
   [:apply
@@ -7,16 +7,16 @@
    {x2 ?x17, x5 ?x18}
    [:cross-join
     [:rename
-     {A x1, B x2, _table x3}
-     [:scan [A B {_table (= _table "R")}]]]
-    [:rename {C x5, _table x6} [:scan [C {_table (= _table "S")}]]]]
+     {a x1, b x2, _table x3}
+     [:scan [a b {_table (= _table "r")}]]]
+    [:rename {c x5, _table x6} [:scan [c {_table (= _table "s")}]]]]
    [:project
     [x8 x9]
     [:semi-join
      [{x9 x12} (= x13 ?x18)]
      [:rename
-      {A x8, B x9, _table x10}
-      [:scan [{A (= A ?x17)} B {_table (= _table "R")}]]]
+      {a x8, b x9, _table x10}
+      [:scan [{a (= a ?x17)} b {_table (= _table "r")}]]]
      [:rename
-      {A x12, B x13, _table x14}
-      [:scan [A B {_table (= _table "R")}]]]]]]]]
+      {a x12, b x13, _table x14}
+      [:scan [a b {_table (= _table "r")}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-period-specs-with-dml-subqueries-and-defaults-407.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-period-specs-with-dml-subqueries-and-defaults-407.edn
@@ -27,4 +27,4 @@
         {application_time_end
          (> application_time_end (current-timestamp))}
         {id (= id 1)}
-        {_table (= _table "Prop_Owner")}]]]]]]]]
+        {_table (= _table "prop_owner")}]]]]]]]]

--- a/test/core2/sql/analyze_test.clj
+++ b/test/core2/sql/analyze_test.clj
@@ -391,14 +391,14 @@ SELECT t1.d-t1.e AS a, SUM(t1.a) AS b
   (valid? "SELECT 1 FROM t1 OFFSET 1"))
 
 (t/deftest test-check-period-predicand
-  (invalid? [#"Please use a qualified reference to APPLICATION_TIME"]
+  (invalid? [#"Please use a qualified reference to application_time"]
     "SELECT foo.name, bar.also_name
     FROM foo, bar
-    WHERE foo.random_col OVERLAPS bar.APPLICATION_TIME")
-  (invalid? [#"Please use a qualified reference to APPLICATION_TIME"]
+    WHERE foo.random_col OVERLAPS bar.APPLICATIOn_TIME")
+  (invalid? [#"Please use a qualified reference to application_time"]
     "SELECT foo.name, bar.also_name
     FROM foo, bar
-    WHERE foo.APP_TIME OVERLAPS bar.fooble"))
+    WHERE foo.SYSTEM_TImE OVERLAPS bar.fooble"))
 
 (t/deftest test-invalid-table-names
   (invalid? [#"Unexpected:\nAPPLICATION_TIME"]
@@ -417,8 +417,8 @@ SELECT t1.d-t1.e AS a, SUM(t1.a) AS b
     FROM foo")
 
   (invalid?
-    [#"Period not in scope: f.APPLICATION_TIME"
-     #"Period not in scope: f.SYSTEM_TIME"]
+    [#"Period not in scope: f.application_time"
+     #"Period not in scope: f.system_time"]
     "SELECT f.APPLICATION_TIME OVERLAPS f.SYSTEM_TIME
     FROM foo AS f (a)")
 
@@ -427,16 +427,16 @@ SELECT t1.d-t1.e AS a, SUM(t1.a) AS b
     FROM foo
     AS f (system_time_start, system_time_end, application_time_start, application_time_end)")
 
-  (invalid? [#"References to periods may only appear within period predicates: foo.APPLICATION_TIME"]
+  (invalid? [#"References to periods may only appear within period predicates: foo.application_time"]
     "SELECT foo.APPLICATION_TIME
     FROM foo")
 
-  (invalid? [#"References to periods may only appear within period predicates: foo.SYSTEM_TIME"]
+  (invalid? [#"References to periods may only appear within period predicates: foo.system_time"]
     "SELECT foo.bar
     FROM foo
     WHERE foo.SYSTEM_TIME = 20")
 
-  (invalid? [#"References to periods may only appear within period predicates: foo.SYSTEM_TIME"]
+  (invalid? [#"References to periods may only appear within period predicates: foo.system_time"]
     "UPDATE foo SET bar = foo.SYSTEM_TIME"))
 
 (t/deftest check-period-specifications
@@ -470,8 +470,8 @@ SELECT t1.d-t1.e AS a, SUM(t1.a) AS b
     AS f (bar)")
 
   (invalid?
-    [#"Period not in scope: f.APPLICATION_TIME"
-     #"Period not in scope: f.SYSTEM_TIME"]
+    [#"Period not in scope: f.application_time"
+     #"Period not in scope: f.system_time"]
     "SELECT f.APPLICATION_TIME OVERLAPS f.SYSTEM_TIME
     FROM foo
     FOR SYSTEM_TIME AS OF CURRENT_TIMESTAMP

--- a/test/core2/sql/logic_test/direct-sql/identifier-case-sensitivity.test
+++ b/test/core2/sql/logic_test/direct-sql/identifier-case-sensitivity.test
@@ -1,0 +1,119 @@
+hash-threshold 100
+
+statement ok
+INSERT INTO T1(id, col1, col2) VALUES(1,'fish',1000)
+
+statement ok
+INSERT INTO t1(id, coL1, COL2) VALUES(2,'dog',2000)
+
+query ITI rowsort
+SELECT t1.ID, T1.col1, t1.cOl2 FROM T1
+----
+1
+fish
+1000
+2
+dog
+2000
+
+query ITI rowsort
+SELECT "t1".id, T1."col1", t1.cOl2 FROM "t1"
+----
+1
+fish
+1000
+2
+dog
+2000
+
+query ITI rowsort
+SELECT "T1".id, "T1".col1, "T1".cOl2 FROM "T1"
+----
+
+statement ok
+INSERT INTO "T1"(id, "COl1", "col2") VALUES(3,'cat',3000)
+
+query ITI rowsort
+SELECT "T1".id, "T1"."COl1", "T1".cOl2 FROM "T1"
+----
+3
+cat
+3000
+
+statement ok
+UPDATE T1 SET cOl1 = 30 WHERE t1.col2 IN (313, 2000)
+
+query ITI rowsort
+SELECT t1.iD, T1.col1, "t1".col2 FROM t1
+----
+1
+fish
+1000
+2
+30
+2000
+
+statement ok
+UPDATE "T1" SET "cOL2" = 'rabbit' WHERE "T1"."COl1" = 'cat'
+
+statement ok
+UPDATE "T1" SET "COl1" = 40 WHERE "T1"."COl1" = 'cat'
+
+query IIIT rowsort
+SELECT "T1".ID, "T1"."COl1", "T1".COL2, "T1"."cOL2" FROM "T1"
+----
+3
+40
+3000
+rabbit
+
+query II
+SELECT T1.col1, AVG(t1.col2) FROM t1 GROUP BY T1.col1
+----
+0
+1000
+30
+2000
+
+query II
+SELECT "T1"."COl1", AVG("T1".col2) FROM "T1" GROUP BY "T1"."COl1"
+----
+40
+3000
+
+query I
+SELECT t1.col1 FROM T1 WHERE t1.col1 IN ( T1.COL1 )
+----
+0
+30
+
+query I
+SELECT teeone.col2 FROM t1 AS TEEoNE WHERE TEEone.col1 = ( SELECT t1.col1 FROM T1 WHERE t1.col1 = teeONe.cOL1 )
+----
+1000
+2000
+
+query I
+SELECT "T1"."col2" AS "foo" FROM "T1" WHERE "T1"."COl1" IN ( "T1"."COl1" )
+----
+3000
+
+query I
+SELECT "TeeoNE".col2 FROM "T1" AS "TeeoNE" WHERE "TeeoNE"."COl1" = ( SELECT "T1"."COl1" FROM "T1" WHERE "T1"."COl1" = "TeeoNE"."COl1" )
+----
+3000
+
+statement ok
+DELETE FROM T1 WHERE t1.cOl1 = 'fish'
+
+query ITI rowsort
+SELECT t1.ID FROM T1
+----
+2
+
+statement ok
+DELETE FROM "T1" WHERE "T1"."cOL2" = 'rabbit'
+
+query I rowsort
+SELECT "T1".Id FROM "T1"
+----

--- a/test/core2/sql/logic_test/direct_sql_test.clj
+++ b/test/core2/sql/logic_test/direct_sql_test.clj
@@ -25,4 +25,5 @@
   direct-sql--sl-a5
   direct-sql--slt-variables
   direct-sql--sl-demo
-  direct-sql--qualified_joins)
+  direct-sql--qualified_joins
+  direct-sql--identifier-case-sensitivity)


### PR DESCRIPTION
- This goes against the SQL standard which declares uppercase as the normal form for identifiers. However this is in line with postgres and a general practice that identifiers are written in lowercase.
- A side effect of this is apparent when dealing with quoted identifiers, here is an example taken from the postgres docs
> Quoting an identifier also makes it case-sensitive, whereas unquoted names are always folded to lower case. For example, the identifiers FOO, foo, and "foo" are considered the same by PostgreSQL, but "Foo" and "FOO" are different from these three and each other. (The folding of unquoted names to lower case in PostgreSQL is incompatible with the SQL standard, which says that unquoted names should be folded to upper case. Thus, foo should be equivalent to "FOO" not "foo" according to the standard. If you want to write portable applications you are advised to always quote a particular name or never quote it.) 
- Another side effect of this is analysis errors and returned identifiers are always appear as the lowercased version of themselves, this is also in line with the observable behaviour of postgres, however I think there are methods we could use to change this if we desired (probably outside the logical plan).