### PR TITLE
First pass at FlightSQL driver, #519

### DIFF
--- a/DATALOG.adoc
+++ b/DATALOG.adoc
@@ -33,7 +33,7 @@ Main require: `[core2.api :as c2]`
 
 Configuration uses https://github.com/weavejester/integrant[Integrant].
 
-You can still start a completely in-memory node using `(core2.local-node/start-node {})`.
+You can still start a completely in-memory node using `(core2.node/start-node {})`.
 For a Kafka/JDBC node:
 
 [source,clojure]

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -56,10 +56,10 @@ wire protocol endpoint, and adds a few sample records for you to query.
 ----
 (ns xtexample
   (:require [core2.api :as c2]
-            [core2.local-node :as local-node]
+            [core2.node :as node]
             [core2.sql.pgwire :as pgwire]))
 
-(def node (local-node/start-node {}))
+(def node (node/start-node {}))
 
 (def server (pgwire/serve node))
 

--- a/core/dev/core2/sql/jdbc.clj
+++ b/core/dev/core2/sql/jdbc.clj
@@ -3,7 +3,7 @@
             [core2.sql.analyze :as sem]
             [core2.sql.parser :as parser]
             [core2.api :as c2]
-            [core2.local-node :as node]
+            [core2.node :as node]
             [core2.rewrite :as r])
   (:import [java.sql Connection Driver DriverManager DriverPropertyInfo
                      ResultSet ResultSetMetaData PreparedStatement SQLException SQLFeatureNotSupportedException]

--- a/core/src/core2/cli.clj
+++ b/core/src/core2/cli.clj
@@ -5,7 +5,7 @@
             [clojure.string :as str]
             [clojure.tools.cli :as cli]
             [clojure.tools.logging :as log]
-            [core2.local-node :as node]
+            [core2.node :as node]
             [core2.error :as err]
             [core2.util :as util])
   (:import java.io.File

--- a/core/src/core2/sql.clj
+++ b/core/src/core2/sql.clj
@@ -11,7 +11,9 @@
   ([query query-opts]
    (binding [r/*memo* (HashMap.)
              plan/*opts* query-opts]
-     (-> (parser/parse query) parser/or-throw
-         (sem/analyze-query) sem/or-throw
+     (let [ast (-> (parser/parse query) parser/or-throw
+                   (sem/analyze-query) sem/or-throw)]
+       (-> ast
          (plan/plan-query query-opts)
-         #_(doto clojure.pprint/pprint)))))
+           (vary-meta assoc :param-count (sem/param-count ast))
+           #_(doto clojure.pprint/pprint))))))

--- a/core/src/core2/sql/analyze.clj
+++ b/core/src/core2/sql/analyze.clj
@@ -79,6 +79,19 @@
        (count)
        (dec)))
 
+(defn param-count [ag]
+  (apply max
+         (count (->> ag
+                     (r/collect
+                      (fn [ag]
+                        (if (r/ctor? :dynamic_parameter_specification ag)
+                          [:param]
+                          [])))))
+         (->> ag
+              (r/collect (fn [ag]
+                           (r/zmatch ag
+                             [:postgres_parameter_specification s] [(parse-long (subs s 1))]))))))
+
 ;; Identifiers
 
 (defn identifier [ag]

--- a/core/src/core2/types.clj
+++ b/core/src/core2/types.clj
@@ -226,13 +226,10 @@
   UUID
   (value->col-type [_] [:extension-type :uuid [:fixed-size-binary 16] ""])
   (write-value! [^UUID uuid ^IVectorWriter writer]
-    (let [underlying-writer (.getUnderlyingWriter (.asExtension writer))
-          bb (doto (ByteBuffer/allocate 16)
-               (.putLong (.getMostSignificantBits uuid))
-               (.putLong (.getLeastSignificantBits uuid)))]
+    (let [underlying-writer (.getUnderlyingWriter (.asExtension writer))]
       (.setSafe ^FixedSizeBinaryVector (.getVector underlying-writer)
                 (.getPosition underlying-writer)
-                (.array bb))))
+                (util/uuid->bytes uuid))))
 
   URI
   (value->col-type [_] [:extension-type :uri :utf8 ""])

--- a/core/src/core2/util.clj
+++ b/core/src/core2/util.clj
@@ -45,6 +45,12 @@
     (catch Exception e
       (log/warn e "could not close"))))
 
+(defn uuid->bytes ^bytes [^UUID uuid]
+  (let [bb (doto (ByteBuffer/allocate 16)
+             (.putLong (.getMostSignificantBits uuid))
+             (.putLong (.getLeastSignificantBits uuid)))]
+    (.array bb)))
+
 ;;; Common specs
 
 (defn ->path ^Path [path-ish]

--- a/deps.edn
+++ b/deps.edn
@@ -24,6 +24,7 @@
 
         org.postgresql/postgresql {:mvn/version "42.2.20"}
         org.xerial/sqlite-jdbc {:mvn/version "3.36.0.3"}
+        org.apache.arrow/flight-sql-jdbc-driver {:mvn/version "10.0.0"}
 
         com.widdindustries/time-literals {:mvn/version "0.1.6"}
         io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "b3fd0d2"}

--- a/deps.edn
+++ b/deps.edn
@@ -4,6 +4,7 @@
         com.xtdb.labs/core2-client {:local/root "http-client-clj"}
         com.xtdb.labs/core2-server {:local/root "http-server"}
         com.xtdb.labs/core2-pgwire {:local/root "pgwire-server"}
+        com.xtdb.labs/core2-flight-sql {:local/root "modules/flight-sql"}
         com.xtdb.labs/core2-datasets {:local/root "modules/datasets"}
 
         com.xtdb.labs/core2-kafka {:local/root "modules/kafka"}

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -51,7 +51,8 @@
                         :core2.buffer-pool/buffer-pool {:cache-path (io/file dev-node-dir "buffers")}
                         :core2.object-store/file-system-object-store {:root-path (io/file dev-node-dir "objects")}
                         :core2/server {}
-                        :core2/pgwire {:port 5433}}}})
+                        :core2/pgwire {:port 5433}
+                        :core2.flight-sql/server {:port 52358}}}})
 
 (ir/set-prep! (fn [] standalone-config))
 

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -2,7 +2,7 @@
   (:require [clojure.java.io :as io]
             [clojure.java.browse :as browse]
             [core2.ingester :as ingest]
-            [core2.local-node :as node]
+            [core2.node :as node]
             [core2.test-util :as tu]
             [core2.tpch :as tpch]
             [core2.util :as util]

--- a/http-server/src/core2/server.clj
+++ b/http-server/src/core2/server.clj
@@ -6,7 +6,7 @@
             [core2.api :as c2]
             [core2.datalog :as d]
             [core2.error :as err]
-            [core2.local-node :as node]
+            [core2.node :as node]
             [core2.transit :as c2.transit]
             [core2.util :as util]
             [juxt.clojars-mirrors.integrant.core :as ig]

--- a/modules/bench/src/core2/bench.clj
+++ b/modules/bench/src/core2/bench.clj
@@ -3,11 +3,11 @@
             [clojure.tools.logging :as log]
             core2.indexer
             [core2.kafka :as k]
-            [core2.local-node :as node]
+            [core2.node :as node]
             [core2.s3 :as s3]
             [core2.util :as util])
   (:import core2.indexer.Indexer
-           core2.local_node.Node
+           core2.node.Node
            [java.nio.file Files Path]
            java.nio.file.attribute.FileAttribute
            java.util.UUID
@@ -38,7 +38,7 @@
 (defn finish-chunk [^Node node]
   (.finishChunk ^Indexer (util/component node :core2.indexer/indexer)))
 
-(defn ^core2.local_node.Node start-node
+(defn ^core2.node.Node start-node
   ([] (start-node (str (UUID/randomUUID))))
 
   ([node-id]

--- a/modules/bench/src/core2/bench/tpch.clj
+++ b/modules/bench/src/core2/bench/tpch.clj
@@ -2,19 +2,18 @@
   (:require [clojure.tools.logging :as log]
             [core2.bench :as bench]
             [core2.ingester :as ingest]
-            [core2.local-node :as node]
+            [core2.node :as node]
             [core2.test-util :as tu]
             [core2.tpch :as tpch]
             [core2.util :as util])
-  (:import core2.local_node.Node
-           java.util.concurrent.TimeUnit))
+  (:import core2.node.Node
+           java.time.Duration))
 
 (defn ingest-tpch [^Node node {:keys [scale-factor]}]
   (let [tx (bench/with-timing :submit-docs
              (tpch/submit-docs! node scale-factor))]
     (bench/with-timing :await-tx
-      @(-> (node/await-tx-async node tx)
-           (.orTimeout 5 TimeUnit/HOURS)))
+      @(node/snapshot-async node tx (Duration/ofHours 5)))
 
     (bench/with-timing :finish-chunk
       (bench/finish-chunk node))))

--- a/modules/bench/src/core2/bench/ts_devices.clj
+++ b/modules/bench/src/core2/bench/ts_devices.clj
@@ -2,8 +2,8 @@
   (:require [clojure.tools.logging :as log]
             [core2.bench :as bench]
             [core2.ts-devices :as tsd]
-            [core2.local-node :as node])
-  (:import java.util.concurrent.TimeUnit))
+            [core2.node :as node])
+  (:import java.time.Duration))
 
 (def cli-arg-spec
   [[nil "--size <small|med|big>" "Size of ts-devices files to use"
@@ -24,8 +24,7 @@
              (tsd/submit-ts-devices node {:device-info-file device-info-file
                                           :readings-file readings-file}))]
     (bench/with-timing :await-tx
-      @(-> (node/await-tx-async node tx)
-           (.orTimeout 5 TimeUnit/HOURS)))
+      @(node/snapshot-async node tx (Duration/ofHours 5)))
 
     (bench/with-timing :finish-chunk
       (bench/finish-chunk node))))

--- a/modules/bench/src/core2/bench/watdiv.clj
+++ b/modules/bench/src/core2/bench/watdiv.clj
@@ -2,8 +2,8 @@
   (:require [clojure.java.io :as io]
             [core2.bench :as bench]
             [core2.api :as c2]
-            [core2.local-node :as node])
-  (:import java.util.concurrent.TimeUnit))
+            [core2.node :as node])
+  (:import java.time.Duration))
 
 (comment
   ;; run in XTDB 1.x's xtdb.bench.watdiv-xtdb.
@@ -35,8 +35,7 @@
                                       ;; TODO Core2 doesn't support set vals yet
                                       [:put (->> doc (into {} (remove (comp set? val))))])))))]
     (bench/with-timing :await-tx
-      @(-> (node/await-tx-async node tx)
-           (.orTimeout 5 TimeUnit/HOURS)))
+      @(node/snapshot-async node tx (Duration/ofHours 5)))
 
     (bench/with-timing :finish-chunk
       (bench/finish-chunk node))))

--- a/modules/flight-sql/deps.edn
+++ b/modules/flight-sql/deps.edn
@@ -1,0 +1,5 @@
+{:deps {com.xtdb.labs/core2-api {:local/root "../../api"}
+        com.xtdb.labs/core2-core {:local/root "../../core"}
+
+        org.apache.arrow/arrow-vector {:mvn/version "10.0.0"}
+        org.apache.arrow/flight-sql {:mvn/version "10.0.0"}}}

--- a/modules/flight-sql/src/core2/flight_sql.clj
+++ b/modules/flight-sql/src/core2/flight_sql.clj
@@ -1,0 +1,301 @@
+(ns core2.flight-sql
+  (:require [clojure.tools.logging :as log]
+            [core2.api :as c2]
+            [core2.node :as node]
+            [core2.operator :as op]
+            [core2.sql :as sql]
+            [core2.test-util :as test-util]
+            [core2.types :as types]
+            [core2.util :as util]
+            [core2.vector.indirect :as iv]
+            [juxt.clojars-mirrors.integrant.core :as ig])
+  (:import clojure.lang.MapEntry
+           (com.google.protobuf Any ByteString)
+           (core2.operator BoundQuery PreparedQuery)
+           java.io.Closeable
+           (java.util ArrayList HashMap Map)
+           (java.util.concurrent CompletableFuture ConcurrentHashMap)
+           (java.util.function BiConsumer Consumer BiFunction)
+           (org.apache.arrow.flight FlightEndpoint FlightInfo FlightProducer$ServerStreamListener FlightProducer$StreamListener
+                                    FlightServer FlightServer$Builder FlightServerMiddleware FlightServerMiddleware$Factory FlightServerMiddleware$Key
+                                    FlightStream Location PutResult Result Ticket)
+           (org.apache.arrow.flight.sql FlightSqlProducer)
+           (org.apache.arrow.flight.sql.impl FlightSql$ActionBeginTransactionResult
+                                             FlightSql$ActionCreatePreparedStatementResult
+                                             FlightSql$ActionEndTransactionRequest$EndTransaction
+                                             FlightSql$CommandPreparedStatementQuery
+                                             FlightSql$DoPutUpdateResult
+                                             FlightSql$TicketStatementQuery)
+           org.apache.arrow.memory.BufferAllocator
+           (org.apache.arrow.vector VectorSchemaRoot)
+           org.apache.arrow.vector.types.pojo.Schema))
+
+(defn- new-id ^com.google.protobuf.ByteString []
+  (ByteString/copyFrom (util/uuid->bytes (random-uuid))))
+
+(defn- pack-result ^org.apache.arrow.flight.Result [res]
+  (Result. (.toByteArray (Any/pack res))))
+
+(defn then-await-fn ^java.util.concurrent.CompletableFuture [cf {:keys [node]}]
+  (util/then-compose cf
+    (fn [tx]
+      ;; HACK til we have the ability to await on the connection
+      (node/snapshot-async node tx))))
+
+(doto (def ^:private do-put-update-msg
+        (let [^org.apache.arrow.flight.sql.impl.FlightSql$DoPutUpdateResult$Builder
+              b (doto (FlightSql$DoPutUpdateResult/newBuilder)
+                  (.setRecordCount -1))]
+          (.toByteArray (.build b))))
+
+  ;; for some reason, it doesn't work with ^bytes on the symbol :/
+  (alter-meta! assoc :tag 'bytes))
+
+(defn then-send-do-put-update-res
+  ^java.util.concurrent.CompletableFuture
+  [^CompletableFuture cf, ^FlightProducer$StreamListener ack-stream, ^BufferAllocator allocator]
+
+  (.whenComplete cf
+                 (reify BiConsumer
+                   (accept [_ _ e]
+                     (if e
+                       (.onError ack-stream e)
+
+                       (do
+                         (with-open [res (PutResult/metadata
+                                          (doto (.buffer allocator (alength do-put-update-msg))
+                                            (.writeBytes do-put-update-msg)))]
+                           (.onNext ack-stream res))
+
+                         (.onCompleted ack-stream)))))))
+
+(def ^:private dml?
+  (comp #{:insert :delete :erase :merge} first))
+
+(defn- flight-stream->rows [^FlightStream flight-stream]
+  ;; TODO ideally we'd just pass this as a VSR
+  (let [root (.getRoot flight-stream)
+        rows (ArrayList.)
+        col-count (count (.getFieldVectors root))]
+    (while (.next flight-stream)
+      (dotimes [row-idx (.getRowCount root)]
+        (let [row (ArrayList. col-count)]
+          (dotimes [col-idx col-count]
+            (.add row (types/get-object (.getVector root col-idx) row-idx)))
+
+          (.add rows (vec row)))))
+
+    (vec rows)))
+
+(defn- ->fsql-producer [{:keys [allocator node ^Map fsql-txs, ^Map stmts, ^Map tickets] :as svr}]
+  (letfn [(col-types->schema ^org.apache.arrow.vector.types.pojo.Schema [col-types]
+            (Schema. (for [[col-name col-type] col-types]
+                       (types/col-type->field col-name col-type))))
+
+          (exec-dml [dml fsql-tx-id]
+            (if fsql-tx-id
+              (if (.computeIfPresent fsql-txs fsql-tx-id
+                                     (reify BiFunction
+                                       (apply [_ _fsql-tx-id fsql-tx]
+                                         (update fsql-tx :dml conj dml))))
+                (CompletableFuture/completedFuture nil)
+                (CompletableFuture/failedFuture (UnsupportedOperationException. "unknown tx")))
+
+              (-> (c2/submit-tx node [dml])
+                  (then-await-fn svr))))
+
+          (handle-get-stream [^BoundQuery bq, ^FlightProducer$ServerStreamListener listener]
+            (with-open [res (.openCursor bq)
+                        vsr (VectorSchemaRoot/create (col-types->schema (.columnTypes bq)) allocator)]
+              (.start listener vsr)
+
+              (.forEachRemaining res
+                                 (reify Consumer
+                                   (accept [_ in-rel]
+                                     (.clear vsr)
+                                     ;; HACK getting results in a Clojure data structure, putting them back in to a VSR
+                                     ;; because we can get DUVs in the in-rel but the output just expects mono vecs.
+                                     ;; also HACK for using the test-util in main code.
+
+                                     (test-util/populate-root vsr (iv/rel->rows in-rel))
+                                     (.putNext listener))))
+
+              (.completed listener)))]
+
+    (reify FlightSqlProducer
+      (acceptPutStatement [_ cmd _ctx _flight-stream ack-stream]
+        (fn []
+          @(-> (exec-dml [:sql (.getQuery cmd) [[]]]
+                         (when (.hasTransactionId cmd)
+                           (.getTransactionId cmd)))
+               (then-send-do-put-update-res ack-stream allocator))))
+
+      (acceptPutPreparedStatementQuery [_ cmd _ctx flight-stream ack-stream]
+        (fn []
+          ;; TODO in tx?
+          (let [ps-id (.getPreparedStatementHandle cmd)]
+            (or (.computeIfPresent stmts ps-id
+                                   (reify BiFunction
+                                     (apply [_ _ps-id {:keys [^PreparedQuery prepd-query] :as ^Map ps}]
+                                       (doto ps
+                                         (.put :bound-query
+                                               (.bind prepd-query
+                                                      {:srcs {'$ @(node/snapshot-async node)}
+                                                       ;; NOTE we assume there's only one param row for read queries - valid?
+                                                       :params (->> (first (flight-stream->rows flight-stream))
+                                                                    (into {} (map-indexed (fn [idx v]
+                                                                                            (MapEntry/create (symbol (str "?_" idx)) v)))))}))))))
+                (throw (UnsupportedOperationException. "invalid ps-id"))))
+
+          (.onCompleted ack-stream)))
+
+      (acceptPutPreparedStatementUpdate [_ cmd _ctx flight-stream ack-stream]
+        ;; NOTE atm the PSs are either created within a tx and then assumed to be within that tx
+        ;; my mental model would be that you could create a PS outside a tx and then use it inside, but this doesn't seem possible in FSQL.
+        (fn []
+          @(-> (let [{:keys [sql fsql-tx-id]} (or (get stmts (.getPreparedStatementHandle cmd))
+                                                  (throw (UnsupportedOperationException. "invalid ps-id")))
+                     dml [:sql sql (flight-stream->rows flight-stream)]]
+                 (exec-dml dml fsql-tx-id))
+
+               (then-send-do-put-update-res ack-stream allocator))))
+
+      (getFlightInfoStatement [_ cmd _ctx descriptor]
+        (let [sql (.toStringUtf8 (.getQueryBytes cmd))
+              ticket-handle (new-id)
+              ^BoundQuery bq (-> (sql/compile-query sql {})
+                                 (op/prepare-ra)
+                                 ;; HACK need to get the basis from somewhere...
+                                 (.bind {:srcs {'$ @(node/snapshot-async node)}}))
+              ticket (Ticket. (-> (doto (FlightSql$TicketStatementQuery/newBuilder)
+                                    (.setStatementHandle ticket-handle))
+                                  (.build)
+                                  (Any/pack)
+                                  (.toByteArray)))]
+          (.put tickets ticket-handle bq)
+          (FlightInfo. (col-types->schema (.columnTypes bq)) descriptor
+                       [(FlightEndpoint. ticket (make-array Location 0))]
+                       -1 -1)))
+
+      (getStreamStatement [_ ticket _ctx listener]
+        (let [bq (or (.remove tickets (.getStatementHandle ticket))
+                     (throw (UnsupportedOperationException. "unknown ticket-id")))]
+          (handle-get-stream bq listener)))
+
+      (getFlightInfoPreparedStatement [_ cmd _ctx descriptor]
+        (let [ps-id (.getPreparedStatementHandle cmd)
+
+              {:keys [bound-query ^PreparedQuery prepd-query], :as ^Map ps}
+              (or (get stmts ps-id)
+                  (throw (UnsupportedOperationException. "invalid ps-id")))
+
+              ticket (Ticket. (-> (doto (FlightSql$CommandPreparedStatementQuery/newBuilder)
+                                    (.setPreparedStatementHandle ps-id))
+                                  (.build)
+                                  (Any/pack)
+                                  (.toByteArray)))
+
+              ^BoundQuery bound-query (or bound-query
+                                          (.bind prepd-query {:srcs {'$ @(node/snapshot-async node)}}))]
+          (.put ps :bound-query bound-query)
+          (FlightInfo. (col-types->schema (.columnTypes bound-query)) descriptor
+                       [(FlightEndpoint. ticket (make-array Location 0))]
+                       -1 -1)))
+
+      (getStreamPreparedStatement [_ ticket _ctx listener]
+        (let [^Map ps (or (get stmts (.getPreparedStatementHandle ticket))
+                          (throw (UnsupportedOperationException. "invalid ps-id")))
+              bound-query (.remove ps :bound-query)]
+          (handle-get-stream bound-query listener)))
+
+      (createPreparedStatement [_ req _ctx listener]
+        (let [ps-id (new-id)
+              sql (.toStringUtf8 (.getQueryBytes req))
+              plan (sql/compile-query sql)
+              ps (cond-> {:id ps-id, :sql sql
+                          :fsql-tx-id (when (.hasTransactionId req)
+                                        (.getTransactionId req))}
+                   (not (dml? plan)) (assoc :prepd-query (op/prepare-ra plan)))]
+          (.put stmts ps-id (HashMap. ^Map ps))
+
+          (.onNext listener
+                   (pack-result (-> (doto (FlightSql$ActionCreatePreparedStatementResult/newBuilder)
+                                      (.setPreparedStatementHandle ps-id))
+                                    (.build))))
+
+          (.onCompleted listener)))
+
+      (closePreparedStatement [_ req _ctx listener]
+        (let [_ps (.remove stmts (.getPreparedStatementHandle req))]
+          ;; at some point we'll need to close the ps?
+          (.onCompleted listener)))
+
+      (beginTransaction [_ _req _ctx listener]
+        (let [fsql-tx-id (new-id)]
+          (.put fsql-txs fsql-tx-id {:dml []})
+
+          (.onNext listener
+                   (-> (doto (FlightSql$ActionBeginTransactionResult/newBuilder)
+                         (.setTransactionId fsql-tx-id))
+                       (.build))))
+
+        (.onCompleted listener))
+
+      (endTransaction [_ req _ctx listener]
+        (let [fsql-tx-id (.getTransactionId req)
+              {:keys [dml]} (or (.remove fsql-txs fsql-tx-id)
+                                (throw (UnsupportedOperationException. "unknown tx")))]
+
+          (if (= FlightSql$ActionEndTransactionRequest$EndTransaction/END_TRANSACTION_COMMIT
+                 (.getAction req))
+
+            @(-> (c2/submit-tx node dml)
+                 (then-await-fn svr)
+                 (.whenComplete (reify BiConsumer
+                                  (accept [_ _v e]
+                                    (if e
+                                      (.onError listener e)
+                                      (.onCompleted listener))))))
+
+            (.onCompleted listener)))))))
+
+#_{:clj-kondo/ignore [:unused-private-var]}
+(defn- with-error-logging-middleware [^FlightServer$Builder builder]
+  (.middleware builder
+               (FlightServerMiddleware$Key/of "error-logger")
+               (reify FlightServerMiddleware$Factory
+                 (onCallStarted [_ _info _incoming-headers _req-ctx]
+                   (reify FlightServerMiddleware
+                     (onBeforeSendingHeaders [_ _headers])
+                     (onCallCompleted [_ _call-status])
+                     (onCallErrored [_ e]
+                       (log/error e "FSQL server error")))))))
+
+(defmethod ig/prep-key ::server [_ opts]
+  (merge {:allocator (ig/ref :core2/allocator)
+          :node (ig/ref :core2.node/node)
+          :host "127.0.0.1"
+          :port 52358}
+         opts))
+
+(defmethod ig/init-key ::server [_ {:keys [allocator node host ^long port]}]
+  (let [fsql-txs (ConcurrentHashMap.)
+        stmts (ConcurrentHashMap.)
+        tickets (ConcurrentHashMap.)
+        server (doto (-> (FlightServer/builder allocator (Location/forGrpcInsecure host port)
+                                               (->fsql-producer {:allocator allocator, :node node
+                                                                 :fsql-txs fsql-txs, :stmts stmts, :tickets tickets}))
+
+                         #_(doto with-error-logging-middleware)
+
+                         (.build))
+                 (.start))]
+    (log/infof "Flight SQL server started, port %d" port)
+    (reify Closeable
+      (close [_]
+        (util/try-close server)
+        (run! util/try-close (vals stmts))
+        (log/info "Flight SQL server stopped")))))
+
+(defmethod ig/halt-key! ::server [_ server]
+  (util/try-close server))

--- a/pgwire-server/src/core2/pgwire.clj
+++ b/pgwire-server/src/core2/pgwire.clj
@@ -8,14 +8,13 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [core2.api :as c2]
-            [core2.local-node :as node]
+            [core2.node :as node]
             [core2.rewrite :as r]
             [core2.sql.analyze :as sem]
             [core2.sql.parser :as parser]
             [core2.sql.plan :as plan]
             [core2.util :as util]
-            [juxt.clojars-mirrors.integrant.core :as ig]
-            [core2.sql :as sql])
+            [juxt.clojars-mirrors.integrant.core :as ig])
   (:import (clojure.lang PersistentQueue)
            (core2 IResultSet)
            (core2.types IntervalDayTime IntervalMonthDayNano IntervalYearMonth)
@@ -1419,7 +1418,7 @@
         await-ex (when tx
                    (try
                      ;; TODO consider blocking policy
-                     @(node/await-tx-async node tx)
+                     @(node/snapshot-async node tx)
                      nil
                      (catch Throwable e
                        (log/debug e "Error on await-tx")

--- a/test/core2/align_test.clj
+++ b/test/core2/align_test.clj
@@ -4,7 +4,7 @@
             [core2.api :as c2]
             [core2.expression :as expr]
             [core2.ingester :as ingest]
-            [core2.local-node :as node]
+            [core2.node :as node]
             [core2.test-util :as tu]
             [core2.util :as util]
             [core2.vector.indirect :as iv])

--- a/test/core2/api_test.clj
+++ b/test/core2/api_test.clj
@@ -1,7 +1,7 @@
 (ns core2.api-test
   (:require [clojure.test :as t :refer [deftest]]
             [core2.api :as c2]
-            [core2.local-node :as node]
+            [core2.node :as node]
             [core2.test-util :as tu :refer [*node*]]
             [core2.util :as util])
   (:import (java.time Duration ZoneId)

--- a/test/core2/docker_test.clj
+++ b/test/core2/docker_test.clj
@@ -1,20 +1,16 @@
 (ns core2.docker-test
   "Basic regression tests for our Dockerfile"
-  (:require [clojure.test :refer [is deftest testing use-fixtures]]
-            [clojure.java.shell :as sh]
+  (:require [clojure.data.json :as json]
             [clojure.java.io :as io]
-            [clojure.tools.logging :as log]
+            [clojure.java.shell :as sh]
             [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.tools.logging :as log]
             [core2.test-util :as tu]
-            [core2.local-node :as node]
-            [core2.api :as c2]
-            [juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc :as jdbc]
-            [clojure.data.json :as json])
-  (:import (java.util List)
+            [juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc :as jdbc])
+  (:import (java.net Socket)
+           (java.util List)
            (java.util.concurrent TimeUnit)
-           (java.net Socket)
-           (java.nio.file Files)
-           (java.nio.file.attribute FileAttribute)
            (org.postgresql.util PGobject)))
 
 (set! *warn-on-reflection* false)
@@ -196,7 +192,7 @@
                            :core2.buffer-pool/buffer-pool {:cache-path (io/file hostdir "buffers")}
                            :core2.object-store/file-system-object-store {:root-path (io/file hostdir "objects")}}
                           (node/start-node))]
-      (-> (node/await-tx-async node (c2/submit-tx node [[:put {:id 42, :greeting "Hello, world!"}]]))
+      (-> (node/snapshot-async node (c2/submit-tx node [[:put {:id 42, :greeting "Hello, world!"}]]))
           (.orTimeout 5 TimeUnit/SECONDS)
           deref))
 

--- a/test/core2/flight_sql_test.clj
+++ b/test/core2/flight_sql_test.clj
@@ -1,15 +1,19 @@
 (ns core2.flight-sql-test
   (:require [clojure.test :as t]
+            [core2.api :as c2]
             [core2.test-util :as tu]
             [core2.types :as types]
-            [core2.vector.indirect :as iv])
+            [core2.vector.indirect :as iv]
+            [juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc :as jdbc]
+            #_[juxt.clojars-mirrors.nextjdbc.v1v2v674.next.jdbc.prepare :as jdbc-prep])
   (:import (org.apache.arrow.flight CallOption FlightClient FlightEndpoint FlightInfo Location)
            (org.apache.arrow.flight.sql FlightSqlClient)
            (org.apache.arrow.vector VectorSchemaRoot)
            org.apache.arrow.vector.types.pojo.Schema))
 
-(def ^:dynamic *port*)
-(def ^:dynamic ^FlightSqlClient *client*)
+(def ^:private ^:dynamic *port*)
+(def ^:private ^:dynamic ^FlightSqlClient *client*)
+(def ^:private ^:dynamic *conn*)
 
 (t/use-fixtures :each
   tu/with-allocator
@@ -23,8 +27,11 @@
   (fn [f]
     (with-open [flight-client (-> (FlightClient/builder tu/*allocator* (Location/forGrpcInsecure "127.0.0.1" *port*))
                                   (.build))
-                client (FlightSqlClient. flight-client)]
-      (binding [*client* client]
+                client (FlightSqlClient. flight-client)
+
+                conn (jdbc/get-connection {:jdbcUrl (format "jdbc:arrow-flight-sql://localhost:%d?useEncryption=false" *port*)})]
+
+      (binding [*client* client, *conn* conn]
         (f)))))
 
 (def ^:private ^"[Lorg.apache.arrow.flight.CallOption;"
@@ -50,6 +57,39 @@
             {:id "hak", :name "Håkan"}]
            (-> (.execute *client* "SELECT users.id, users.name FROM users" empty-call-opts)
                (flight-info->rows)))))
+
+(t/deftest test-jdbc-client
+  (c2/submit-tx tu/*node* [[:sql "INSERT INTO users (id, name) VALUES ('jms', 'James')"]])
+
+  ;; NOTE FSQL JDBC driver doesn't seem happy with prepared statement updates
+  ;; see https://issues.apache.org/jira/browse/ARROW-18294
+  #_
+  (with-open [ps (jdbc/prepare *conn* ["INSERT INTO users (id, name) VALUES ('jms', 'James')"])]
+    ;; NOTE: next.jdbc submits everything as just `execute` rather than `executeUpdate`
+    ;; FSQL depends on this difference, so we call `.executeUpdate` directly
+    (.executeUpdate ps))
+
+  ;; and ideally we'd do this with params - but this fails with 'parameter index out of range'
+  ;; despite us returning some parameter metadata on the prepared statement
+  #_
+  (with-open [ps (jdbc/prepare *conn* ["INSERT INTO users (id, name) VALUES (?, ?)"])]
+    (.executeUpdate ps)
+    (jdbc-prep/set-parameters ps ["hak" "Håkan"])
+    (.executeUpdate ps))
+
+  #_ ; or batches
+  (jdbc/execute-batch! *conn* "INSERT INTO users (id, name) VALUES (?, ?)"
+                       [["jms" "James"], ["hak" "Håkan"]] {})
+
+  (t/is (= [{:id "jms", :name "James"}]
+           (jdbc/execute! *conn* ["SELECT users.id, users.name FROM users"])))
+
+  (jdbc/with-transaction [tx *conn*]
+    #_ ; FSQL JDBC doesn't seem happy with params in a query
+    (t/is (= [] (jdbc/execute! tx ["SELECT users.id FROM users WHERE users.id = ?" "foo"])))
+
+    (with-open [ps (jdbc/prepare tx ["SELECT users.id, users.name FROM users"])]
+      (t/is (= [{:id "jms", :name "James"}] (jdbc/execute! ps))))))
 
 (t/deftest test-transaction
   (let [fsql-tx (.beginTransaction *client* empty-call-opts)]

--- a/test/core2/flight_sql_test.clj
+++ b/test/core2/flight_sql_test.clj
@@ -1,0 +1,121 @@
+(ns core2.flight-sql-test
+  (:require [clojure.test :as t]
+            [core2.test-util :as tu]
+            [core2.types :as types]
+            [core2.vector.indirect :as iv])
+  (:import (org.apache.arrow.flight CallOption FlightClient FlightEndpoint FlightInfo Location)
+           (org.apache.arrow.flight.sql FlightSqlClient)
+           (org.apache.arrow.vector VectorSchemaRoot)
+           org.apache.arrow.vector.types.pojo.Schema))
+
+(def ^:dynamic *port*)
+(def ^:dynamic ^FlightSqlClient *client*)
+
+(t/use-fixtures :each
+  tu/with-allocator
+  (fn [f]
+    (binding [*port* (tu/free-port)]
+      (tu/with-opts {:core2.flight-sql/server {:port *port*}}
+        f)))
+
+  tu/with-node
+
+  (fn [f]
+    (with-open [flight-client (-> (FlightClient/builder tu/*allocator* (Location/forGrpcInsecure "127.0.0.1" *port*))
+                                  (.build))
+                client (FlightSqlClient. flight-client)]
+      (binding [*client* client]
+        (f)))))
+
+(def ^:private ^"[Lorg.apache.arrow.flight.CallOption;"
+  empty-call-opts
+  (make-array CallOption 0))
+
+(defn- flight-info->rows [^FlightInfo flight-info]
+  (let [ticket (.getTicket ^FlightEndpoint (first (.getEndpoints flight-info)))]
+    (with-open [stream (.getStream *client* ticket empty-call-opts)]
+      (let [root (.getRoot stream)
+            !res (atom [])]
+        (while (.next stream)
+          ;; if this were a real client chances are they wouldn't just
+          ;; eagerly turn the roots into Clojure maps...
+          (swap! !res into (iv/rel->rows (iv/<-root root))))
+
+        @!res))))
+
+(t/deftest test-client
+  (t/is (= -1 (.executeUpdate *client* "INSERT INTO users (id, name) VALUES ('jms', 'James'), ('hak', 'Håkan')" empty-call-opts)))
+
+  (t/is (= [{:id "jms", :name "James"}
+            {:id "hak", :name "Håkan"}]
+           (-> (.execute *client* "SELECT users.id, users.name FROM users" empty-call-opts)
+               (flight-info->rows)))))
+
+(t/deftest test-transaction
+  (let [fsql-tx (.beginTransaction *client* empty-call-opts)]
+    (t/is (= -1 (.executeUpdate *client* "INSERT INTO users (id, name) VALUES ('jms', 'James'), ('hak', 'Håkan')" fsql-tx empty-call-opts)))
+    (t/is (= []
+             (-> (.execute *client* "SELECT users.id, users.name FROM users" empty-call-opts)
+                 (flight-info->rows))))
+    (.commit *client* fsql-tx empty-call-opts)
+
+    (t/is (= [{:id "jms", :name "James"}
+              {:id "hak", :name "Håkan"}]
+             (-> (.execute *client* "SELECT users.id, users.name FROM users" empty-call-opts)
+                 (flight-info->rows))))))
+
+(t/deftest test-prepared-stmts
+  (with-open [ps (.prepare *client* "INSERT INTO users (id, name) VALUES (?, ?)" empty-call-opts)
+              param-root (VectorSchemaRoot/create (Schema. [(types/col-type->field 'id :utf8) (types/col-type->field 'name :utf8)]) tu/*allocator*)]
+    (.setParameters ps param-root)
+
+    (tu/populate-root param-root [{:id "jms", :name "James"}
+                                  {:id "mat", :name "Matt"}])
+    (.executeUpdate ps empty-call-opts)
+
+    (tu/populate-root param-root [{:id "hak", :name "Håkan"}
+                                  {:id "wot", :name "Dan"}])
+    (.executeUpdate ps empty-call-opts))
+
+  (with-open [ps (.prepare *client* "SELECT users.name FROM users WHERE users.id >= ?" empty-call-opts)
+              param-root (VectorSchemaRoot/create (Schema. [(types/col-type->field '$1 :utf8)]) tu/*allocator*)]
+    (.setParameters ps param-root)
+
+    (tu/populate-root param-root [{:$1 "l"}])
+    (t/is (= [{:name "Matt"}
+              {:name "Dan"}]
+             (-> (.execute ps empty-call-opts)
+                 (flight-info->rows))))
+
+    (tu/populate-root param-root [{:$1 "j"}])
+    (t/is (= [{:name "James"}
+              {:name "Matt"}
+              {:name "Dan"}]
+             (-> (.execute ps empty-call-opts)
+                 (flight-info->rows))))))
+
+(t/deftest test-prepared-stmts-in-tx
+  (letfn [(q []
+            (-> (.execute *client* "SELECT users.name FROM users" empty-call-opts)
+                (flight-info->rows)))]
+    (let [fsql-tx (.beginTransaction *client* empty-call-opts)]
+      (with-open [ps (.prepare *client* "INSERT INTO users (id, name) VALUES (?, ?)" fsql-tx empty-call-opts)
+                  param-root (VectorSchemaRoot/create (Schema. [(types/col-type->field 'id :utf8) (types/col-type->field 'name :utf8)]) tu/*allocator*)]
+        (.setParameters ps param-root)
+
+        (tu/populate-root param-root [{:id "jms", :name "James"}
+                                      {:id "mat", :name "Matt"}])
+        (.executeUpdate ps empty-call-opts)
+
+        (t/is (= [] (q)))
+
+        (tu/populate-root param-root [{:id "hak", :name "Håkan"}
+                                      {:id "wot", :name "Dan"}])
+        (.executeUpdate ps empty-call-opts)
+
+        (t/is (= [] (q))))
+
+      (.commit *client* fsql-tx empty-call-opts)
+
+      (t/is (= [{:name "James"} {:name "Matt"} {:name "Håkan"} {:name "Dan"}]
+               (q))))))

--- a/test/core2/indexer_test.clj
+++ b/test/core2/indexer_test.clj
@@ -8,7 +8,7 @@
             [core2.buffer-pool :as bp]
             [core2.indexer :as idx]
             [core2.json :as c2-json]
-            [core2.local-node :as node]
+            [core2.node :as node]
             [core2.metadata :as meta]
             [core2.object-store :as os]
             [core2.test-util :as tu]
@@ -18,7 +18,7 @@
             [core2.watermark :as wm])
   (:import core2.api.TransactionInstant
            [core2.buffer_pool BufferPool IBufferPool]
-           core2.local_node.Node
+           core2.node.Node
            core2.metadata.IMetadataManager
            core2.object_store.ObjectStore
            core2.indexer.InternalIdManager

--- a/test/core2/kafka_test.clj
+++ b/test/core2/kafka_test.clj
@@ -3,7 +3,7 @@
             [core2.api :as c2]
             [core2.ingester :as ingest]
             [core2.kafka :as k]
-            [core2.local-node :as node]
+            [core2.node :as node]
             [core2.test-util :as tu])
   (:import java.util.UUID))
 

--- a/test/core2/pgwire_test.clj
+++ b/test/core2/pgwire_test.clj
@@ -15,9 +15,10 @@
            (core2 IResultSet)
            (java.lang Thread$State)
            (java.net SocketException)
-           (java.sql Connection)
+           (java.sql Connection DriverManager)
            (java.time Clock Instant ZoneId ZoneOffset)
            (java.util.concurrent CompletableFuture CountDownLatch TimeUnit)
+           org.apache.arrow.driver.jdbc.ArrowFlightJdbcDriver
            (org.postgresql.util PGobject PSQLException)))
 
 (set! *warn-on-reflection* false)
@@ -43,36 +44,44 @@
           (pgwire/serve *node*)
           (set! *server*)))))
 
-(defn- each-fixture [f]
-  (binding [*port* nil
-            *server* nil
-            *node* nil]
-    (try
-      (f)
-      (finally
-        (some-> *node* .close)
-        (some-> *server* .close)))))
+(t/use-fixtures :once
+  (fn [f]
+    (let [check-if-no-pgwire-threads (zero? (count @#'pgwire/servers))]
+      (try
+        (f)
+        (finally
+          (when check-if-no-pgwire-threads
+            ;; warn if it looks like threads are stick around (for CI logs)
+            (when-not (zero? (->> (Thread/getAllStackTraces)
+                                  keys
+                                  (map #(.getName ^Thread %))
+                                  (filter #(str/starts-with? % "pgwire"))
+                                  count))
+              (log/warn "dangling pgwire resources discovered after tests!"))
 
-(t/use-fixtures :each #'each-fixture)
+            ;; stop all just in case we can clean up anyway
+            (pgwire/stop-all))))))
 
-(defn- once-fixture [f]
-  (let [check-if-no-pgwire-threads (zero? (count @#'pgwire/servers))]
-    (try
-      (f)
-      (finally
-        (when check-if-no-pgwire-threads
-          ;; warn if it looks like threads are stick around (for CI logs)
-          (when-not (zero? (->> (Thread/getAllStackTraces)
-                                keys
-                                (map #(.getName %))
-                                (filter #(str/starts-with? % "pgwire"))
-                                count))
-            (log/warn "dangling pgwire resources discovered after tests!"))
+  (fn [f]
+    ;; HACK see https://issues.apache.org/jira/browse/ARROW-18296
+    ;; this ensures the FSQL driver is at the end of the DriverManager list
+    (when-let [fsql-driver (->> (enumeration-seq (DriverManager/getDrivers))
+                                (filter #(instance? ArrowFlightJdbcDriver %))
+                                first)]
+      (DriverManager/deregisterDriver fsql-driver)
+      (DriverManager/registerDriver fsql-driver))
+    (f)))
 
-          ;; stop all just in case we can clean up anyway
-          (pgwire/stop-all))))))
-
-(t/use-fixtures :once #'once-fixture)
+(t/use-fixtures :each
+  (fn [f]
+    (binding [*port* nil
+              *server* nil
+              *node* nil]
+      (try
+        (f)
+        (finally
+          (util/try-close *server*)
+          (util/try-close *node*))))))
 
 (defn- jdbc-url [& params]
   (require-server)

--- a/test/core2/sql/logic_test/xtdb_engine.clj
+++ b/test/core2/sql/logic_test/xtdb_engine.clj
@@ -9,7 +9,7 @@
             [core2.sql.parser :as p]
             [core2.sql.plan :as plan]
             [core2.test-util :as tu])
-  (:import core2.local_node.Node
+  (:import core2.node.Node
            [java.util HashMap UUID]
            [java.time Instant]))
 


### PR DESCRIPTION
Still plenty to do (see #519 for the checklist) but this PR adds a simple PoC Flight SQL driver with queries, transactions and prepared statements.

Particularly, we're still missing non-trivial error handling, req cancellation, support for bases, timeouts for cleaning up the various resources, etc - these are all more incremental though, so they're in the #519 checklist and we can gradually tick them off.

The bulk of the work we had to do was implement the `FlightSqlProducer` class from upstream. The [Arrow FSQL announcement blog](https://arrow.apache.org/blog/2022/02/16/introducing-arrow-flight-sql/) has a few diagrams of the interactions, but how it manifested on the producer and the requirements on us were a little unclear to me. So, the main code paths are as follows:

* Simple queries: 
  * call `execute` on the client with the SQL - this appears on the producer first as a call to `getFlightInfoStatement`, along with the SQL wrapped up in a `CommandStatementQuery` object. This needs to return a `FlightInfo` object, which consists of: the `Schema` of the result, and a collection of `FlightEndpoint`s. 
    * In theory you can return multiple endpoints to distribute the query around a cluster, with the expectation that the client then pings each endpoint (likely in parallel) to get its part of the resultset - we only return one, so the client just comes back to our node.
    * Each endpoint contains a `Ticket`, which is an opaque blob containing bytes of our choice - our ticket is a UUID. In the simple-query case, this UUID has to be wrapped in a `TicketStatementQuery` object so that the subsequent request comes back to the right method. On the server we store the submitted SQL (so that we don't have to send it back and forth over the wire again), and we'll likely also store the query basis - we've returned the Schema to the client at this point, so we don't want any later transactions potentially changing the schema.
  * The client then calls `getStream` on each endpoint with its ticket. On the server (because the ticket is wrapped in the `TicketStatementQuery`), this comes to us as a `getStreamStatement` call. We then look up the ticket details, and fire query results back to the client in a VSR.
    * At the moment, we copy the results from the result cursor into a separate VSR, round-tripping them via Java objects - in the future we could avoid this copy/codec.
* Simple DML: 
  * On the client, call `executeUpdate` - this appears as an `acceptPutStatement` call, containing the DML wrapped in a `CommandStatementUpdate` object.
  * Assuming we're not in a transaction, we submit and await the transaction, and then return a `PutResult` object containing (as its 'application metadata' - a byte array) a serialised `DoPutUpdateResult` message containing the affected row count (we return `-1`).
* Transactions:
  * These are created with `beginTransaction` on the client, `beginTransaction` on the server. We return a `BeginTransactionResult` containing the transaction ID (again, for us, a byte-array encoded UUID). 
  * We store a map of open transactions on the server. We don't have a persistent connection (unlike pgwire) so the user attaches this fsql-tx-id to each request in the transaction. It's assumed (in the FlightSQL schema spec) that transactions will have a TTL - if there are no statements sent for a certain transaction in a certain time period, it should get rolled back and cleaned up (on the checklist). 
  * For simple queries and simple DML, these requests are then broadly the same except the command objects also contain a transaction id.
  * For DML, similar to pgwire, we buffer up the DML until commit
  * `commit` on the client becomes `endTransaction` on the server, with the `ActionEndTransactionRequest` containing an `ActionEndTransactionRequest$EndTransaction/END_TRANSACTION_COMMIT` enum value.
  * `rollback` on the client also becomes `endTransaction` on the server, with `END_TRANSACTION_ROLLBACK` enum.
* Prepared statements:
  * Both DQL and DML start off as a `prepare` call on the client, passing the SQL and (optionally) a transaction. Prepared statements in FSQL are either attached to a transaction or not - you can't prepare a statement outside of a transaction and then use it within, and vice versa (I _think_ this is possible in 'normal' JDBC?)
  * On the server, we see this as a `createPreparedStatement` call, containing an `ActionCreatePreparedStatementRequest` object. We need to decide whether it's DML or not at this point - if it's not, we can 'prepare' the query (essentially compiling the SQL to the LP). In either case, we need to return a prepared statement handle (for us, another UUID), the parameter schema and the result schema to the user.
    * We can't (easily) return the param schemas, because there are a few cases where we just don't know. e.g. `INSERT INTO foo (a, b) VALUES (?, ?)` - for us, those could be anything. Even statically typed DBs aren't invulnerable to this, though. Take `SELECT ? FROM foo`, for example - in this case the Postgres JDBC driver throws an error if asked what the type of the param is. We could consider requiring the user to type-hint the param, but this seems overly onerous. 
    * We can't return the result schema, because (unlike simple queries) we don't want to tie the prepared statement to a given transaction at this point. (Postgres does throw an error if the plan for a prepared statement changes between its preparation and use, so we could consider something similar - but, for now, returning a null result schema doesn't seem to do any harm)
  * The user then calls `setParameters` on the returned `PreparedStatement`, passing it a VSR - the client keeps the params safe until the user executes the query.
  * For DML, the user then calls `executeUpdate` - this shows up as `acceptPutPreparedStatementUpdate`, containing the prepared statement id and a stream of parameters as a VSR. We (currently) turn the params back into Java objects, and then follow a similar route to the 'simple DML' (above), including the branches for tx/no tx.
  * For DQL, the user calls `execute` - the client then makes two calls:
    * `acceptPutPreparedStatementQuery`, containing the params (similar to `acceptPutPreparedStatementQuery`). We store the params, and sit tight.
    * `getFlightInfoPreparedStatement` returns a `FlightInfo` with a `Ticket` but this time with the ticket handle wrapped in a `CommandPreparedStatementQuery` object. At this time, we should also fix the basis. With the basis and the param types now known, we can definitively return a result schema at this point.
    * The user calls `getStream` with this ticket, which (because of the different wrapper object) calls `getStreamPreparedStatement` on the server.
  * I'm assuming that prepared statements aren't to be used concurrently, because of the separate accept-params and execute calls - we have to store the params between these calls, so it doesn't make any sense to have the client using the same prepared statement in multiple threads. I think this is also true in JDBC more generally.
  * I think prepared statements are also assumed to have a TTL, so that the server can close any associated resources after a finite time if it's unused.

Whew.

Other implementation notes:

* It's a right PITA to deal with all of these different classes in Clojure - would have been pretty tempting to write this part in Java, if it wasn't also a PITA to talk to Core2 from Java.
* Based on these access patterns, I've split the Core2 internal query API up into three phases: prepare, bind and execute. 'prepare' takes the query and generates the logical plan; 'bind' binds the parameters and the scan sources (implicitly containing the tx basis), and does as much of the query emission as it can (we can compile the EE expressions, for example, because we now know the column and the param types); execute opens the cursors and runs the thing.
* In 'bind', we'll likely soon want to accept params as a VSR rather than objects, so that we don't have to translate the VSR from the client into Java objects back into (essentially) a VSR in the expression engine.
* Flight SQL doesn't (obviously? yet?) contain any means of propagating standard flags like the transaction isolation, access mode (RO/RW), time zone etc. It seems possible to do this through cookies (see `ClientCookieMiddleware`, I couldn't find the server equivalent). Suspect we could use something similar for the tx-basis, but we'd be more on our own for this one given it's not SQL standard.
* We've got some more DUV fun to come - when we know the output column is monomorphic, we specify 'string' (or even 'nullable string') in the schema, and this means a monomorphic vector in the output VSR. Thing is, if those come straight from the content store, they're single-leg DUVs, so we'll have to pipe the values into the monomorphic output vector. (We currently go via Java objects, which is definitely cheating.)
* TTLs could be quite different for each of the different server resources - I'd guess that tickets would be about 60s, transactions and prepared statements on the order of hours?
* I ran into a few issues relatively early trying to use the Flight SQL JDBC driver:
  * There's a bug trying to call `executeUpdate` on any prepared statement - raised as [ARROW-18294](https://issues.apache.org/jira/browse/ARROW-18294).
  * I couldn't set parameters on prepared statements - it failed with 'parameter out of range', even when we returned the correct number of params in the create-prepared-statement response (if not necessarily the correct types). Will see if I can narrow this one down and file another report
  * The Flight SQL JDBC driver throws an exception if it's given a connection string it's not responsible for (e.g. a postgres one) - it's supposed to return null. this was fun for our pgwire tests :sweat_smile:. raised as [ARROW-18296](https://issues.apache.org/jira/browse/ARROW-18296). I've put a temporary hack in the pgwire test (please don't judge me) which ensures the FSQL JDBC driver always gets tried last :see_no_evil: - we should be able to remove this when it's fixed upstream.
