### PR TITLE
Add cross-joins to mega-join operator

### DIFF
--- a/core/src/core2/sql/plan.clj
+++ b/core/src/core2/sql/plan.clj
@@ -2432,14 +2432,16 @@
       [:join [predicate] lhs rhs])))
 
 (defn- merge-joins-to-mega-join [z]
-  (r/zmatch
-    z
+  (r/zmatch z
     [:join jc r1 r2]
     ;;=>
     [:mega-join jc [r1 r2]]
 
-    [:mega-join jc
-     ^:z rels]
+    [:cross-join r1 r2]
+    ;;=>
+    [:mega-join [] [r1 r2]]
+
+    [:mega-join jc ^:z rels]
     ;;=>
     (when-let [mega-join (r/find-first (partial r/ctor? :mega-join) rels)]
       (let [[_ inner-jc inner-rels :as inner-mega-join] (r/znode mega-join)

--- a/test-resources/core2/sql/plan_test_expectations/deeply-nested-correlated-query.edn
+++ b/test-resources/core2/sql/plan_test_expectations/deeply-nested-correlated-query.edn
@@ -5,11 +5,12 @@
   [:apply
    :semi-join
    {x2 ?x17, x5 ?x18}
-   [:cross-join
-    [:rename
-     {a x1, b x2, _table x3}
-     [:scan [a b {_table (= _table "r")}]]]
-    [:rename {c x5, _table x6} [:scan [c {_table (= _table "s")}]]]]
+   [:mega-join
+    []
+    [[:rename
+      {a x1, b x2, _table x3}
+      [:scan [a b {_table (= _table "r")}]]]
+     [:rename {c x5, _table x6} [:scan [c {_table (= _table "s")}]]]]]
    [:project
     [x8 x9]
     [:semi-join

--- a/test-resources/core2/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-2.edn
+++ b/test-resources/core2/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-2.edn
@@ -2,16 +2,17 @@
  {x1 a}
  [:project
   [x1]
-  [:cross-join
-   [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
-   [:select
-    (= true x7)
-    [:top
-     {:limit 1}
-     [:union-all
-      [:project
-       [{x7 true}]
-       [:rename
-        {c x4, _table x5}
-        [:scan [c {_table (= _table "foo")}]]]]
-      [:table [{x7 false}]]]]]]]]
+  [:mega-join
+   []
+   [[:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+    [:select
+     (= true x7)
+     [:top
+      {:limit 1}
+      [:union-all
+       [:project
+        [{x7 true}]
+        [:rename
+         {c x4, _table x5}
+         [:scan [c {_table (= _table "foo")}]]]]
+       [:table [{x7 false}]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/push-semi-and-anti-joins-down.edn
+++ b/test-resources/core2/sql/plan_test_expectations/push-semi-and-anti-joins-down.edn
@@ -4,11 +4,14 @@
   [x1]
   [:semi-join
    [{x1 x7} {x4 x8}]
-   [:cross-join
-    [:rename {foo x1, _table x2} [:scan [foo {_table (= _table "x")}]]]
-    [:rename
-     {biz x4, _table x5}
-     [:scan [biz {_table (= _table "y")}]]]]
+   [:mega-join
+    []
+    [[:rename
+      {foo x1, _table x2}
+      [:scan [foo {_table (= _table "x")}]]]
+     [:rename
+      {biz x4, _table x5}
+      [:scan [biz {_table (= _table "y")}]]]]]
    [:rename
     {bar x7, baz x8, _table x9}
     [:scan [bar baz {_table (= _table "z")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
+++ b/test-resources/core2/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
@@ -2,18 +2,19 @@
  {x1 a}
  [:project
   [x1]
-  [:cross-join
-   [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
-   [:select
-    (= x4 x8)
-    [:apply
-     :single-join
-     {x5 ?x12}
-     [:rename
-      {c x4, b x5, _table x6}
-      [:scan [c b {_table (= _table "bar")}]]]
-     [:project
-      [x8]
+  [:mega-join
+   []
+   [[:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+    [:select
+     (= x4 x8)
+     [:apply
+      :single-join
+      {x5 ?x12}
       [:rename
-       {b x8, a x9, _table x10}
-       [:scan [b {a (= a ?x12)} {_table (= _table "foo")}]]]]]]]]]
+       {c x4, b x5, _table x6}
+       [:scan [c b {_table (= _table "bar")}]]]
+      [:project
+       [x8]
+       [:rename
+        {b x8, a x9, _table x10}
+        [:scan [b {a (= a ?x12)} {_table (= _table "foo")}]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
+++ b/test-resources/core2/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
@@ -2,17 +2,20 @@
  {x1 a}
  [:project
   [x1]
-  [:cross-join
-   [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
-   [:apply
-    :semi-join
-    {x5 ?x12, x4 ?x13}
-    [:rename
-     {c x4, b x5, _table x6}
-     [:scan [c b {_table (= _table "bar")}]]]
-    [:project
-     [x8]
+  [:mega-join
+   []
+   [[:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+    [:apply
+     :semi-join
+     {x5 ?x12, x4 ?x13}
      [:rename
-      {b x8, a x9, _table x10}
-      [:scan
-       [{b (= ?x13 b)} {a (= a ?x12)} {_table (= _table "foo")}]]]]]]]]
+      {c x4, b x5, _table x6}
+      [:scan [c b {_table (= _table "bar")}]]]
+     [:project
+      [x8]
+      [:rename
+       {b x8, a x9, _table x10}
+       [:scan
+        [{b (= ?x13 b)}
+         {a (= a ?x12)}
+         {_table (= _table "foo")}]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/subquery-in-join-uncorrelated-subquery.edn
+++ b/test-resources/core2/sql/plan_test_expectations/subquery-in-join-uncorrelated-subquery.edn
@@ -2,15 +2,16 @@
  {x1 a}
  [:project
   [x1]
-  [:cross-join
-   [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
-   [:select
-    (= x4 x7)
-    [:single-join
-     []
-     [:rename {c x4, _table x5} [:scan [c {_table (= _table "bar")}]]]
-     [:project
-      [x7]
-      [:rename
-       {b x7, _table x8}
-       [:scan [b {_table (= _table "foo")}]]]]]]]]]
+  [:mega-join
+   []
+   [[:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+    [:select
+     (= x4 x7)
+     [:single-join
+      []
+      [:rename {c x4, _table x5} [:scan [c {_table (= _table "bar")}]]]
+      [:project
+       [x7]
+       [:rename
+        {b x7, _table x8}
+        [:scan [b {_table (= _table "foo")}]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-array-subquery1.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-array-subquery1.edn
@@ -2,12 +2,13 @@
  {x8 $column_1$}
  [:project
   [x8]
-  [:cross-join
-   [:rename
-    {a x1, _table x2}
-    [:scan [{a (= a 42)} {_table (= _table "a")}]]]
-   [:group-by
-    [{x8 (array-agg x4)}]
-    [:rename
-     {b1 x4, b2 x5, _table x6}
-     [:scan [b1 {b2 (= b2 42)} {_table (= _table "b")}]]]]]]]
+  [:mega-join
+   []
+   [[:rename
+     {a x1, _table x2}
+     [:scan [{a (= a 42)} {_table (= _table "a")}]]]
+    [:group-by
+     [{x8 (array-agg x4)}]
+     [:rename
+      {b1 x4, b2 x5, _table x6}
+      [:scan [b1 {b2 (= b2 42)} {_table (= _table "b")}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-2.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-2.edn
@@ -2,12 +2,13 @@
  {x1 a}
  [:project
   [x1]
-  [:cross-join
-   [:rename
-    {a x1, b x2, c x3, _table x4}
-    [:scan [a {b (= b ?_1)} {c (= c ?_2)} {_table (= _table "foo")}]]]
-   [:project
-    [x6]
-    [:rename
-     {b x6, c x7, _table x8}
-     [:scan [b {c (= c ?_0)} {_table (= _table "bar")}]]]]]]]
+  [:mega-join
+   []
+   [[:rename
+     {a x1, b x2, c x3, _table x4}
+     [:scan [a {b (= b ?_1)} {c (= c ?_2)} {_table (= _table "foo")}]]]
+    [:project
+     [x6]
+     [:rename
+      {b x6, c x7, _table x8}
+      [:scan [b {c (= c ?_0)} {_table (= _table "bar")}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q2-minimum-cost-supplier.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q2-minimum-cost-supplier.edn
@@ -64,33 +64,6 @@
              n_nationkey
              n_regionkey
              {_table (= _table "nation")}]]]
-          [:cross-join
-           [:rename
-            {p_partkey x1, p_mfgr x2, p_size x3, p_type x4, _table x5}
-            [:scan
-             [p_partkey
-              p_mfgr
-              {p_size (= p_size 15)}
-              {p_type (like p_type "%BRASS")}
-              {_table (= _table "part")}]]]
-           [:rename
-            {s_acctbal x7,
-             s_name x8,
-             s_address x9,
-             s_phone x10,
-             s_comment x11,
-             s_suppkey x12,
-             s_nationkey x13,
-             _table x14}
-            [:scan
-             [s_acctbal
-              s_name
-              s_address
-              s_phone
-              s_comment
-              s_suppkey
-              s_nationkey
-              {_table (= _table "supplier")}]]]]
           [:rename
            {ps_partkey x16,
             ps_suppkey x17,
@@ -100,7 +73,33 @@
             [ps_partkey
              ps_suppkey
              ps_supplycost
-             {_table (= _table "partsupp")}]]]]]]
+             {_table (= _table "partsupp")}]]]
+          [:rename
+           {p_partkey x1, p_mfgr x2, p_size x3, p_type x4, _table x5}
+           [:scan
+            [p_partkey
+             p_mfgr
+             {p_size (= p_size 15)}
+             {p_type (like p_type "%BRASS")}
+             {_table (= _table "part")}]]]
+          [:rename
+           {s_acctbal x7,
+            s_name x8,
+            s_address x9,
+            s_phone x10,
+            s_comment x11,
+            s_suppkey x12,
+            s_nationkey x13,
+            _table x14}
+           [:scan
+            [s_acctbal
+             s_name
+             s_address
+             s_phone
+             s_comment
+             s_suppkey
+             s_nationkey
+             {_table (= _table "supplier")}]]]]]]
        [:mega-join
         [{x40 x43} {x36 x39} {x32 x35}]
         [[:rename

--- a/test-resources/core2/sql/plan_test_expectations/test-q8-national-market-share.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q8-national-market-share.edn
@@ -46,17 +46,6 @@
            o_orderkey
            o_custkey
            {_table (= _table "orders")}]]]
-        [:cross-join
-         [:rename
-          {p_partkey x1, p_type x2, _table x3}
-          [:scan
-           [p_partkey
-            {p_type (= p_type "ECONOMY ANODIZED STEEL")}
-            {_table (= _table "part")}]]]
-         [:rename
-          {s_suppkey x5, s_nationkey x6, _table x7}
-          [:scan
-           [s_suppkey s_nationkey {_table (= _table "supplier")}]]]]
         [:rename
          {l_extendedprice x9,
           l_discount x10,
@@ -70,4 +59,16 @@
            l_partkey
            l_suppkey
            l_orderkey
-           {_table (= _table "lineitem")}]]]]]]]]]]]
+           {_table (= _table "lineitem")}]]]
+        [:rename
+         {p_partkey x1, p_type x2, _table x3}
+         [:scan
+          [p_partkey
+           {p_type (= p_type "ECONOMY ANODIZED STEEL")}
+           {_table (= _table "part")}]]]
+        [:rename
+         {s_suppkey x5, s_nationkey x6, _table x7}
+         [:scan
+          [s_suppkey
+           s_nationkey
+           {_table (= _table "supplier")}]]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q9-product-type-profit-measure.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q9-product-type-profit-measure.edn
@@ -24,17 +24,6 @@
          ps_suppkey
          ps_partkey
          {_table (= _table "partsupp")}]]]
-      [:cross-join
-       [:rename
-        {p_partkey x1, p_name x2, _table x3}
-        [:scan
-         [p_partkey
-          {p_name (like p_name "%green%")}
-          {_table (= _table "part")}]]]
-       [:rename
-        {s_suppkey x5, s_nationkey x6, _table x7}
-        [:scan
-         [s_suppkey s_nationkey {_table (= _table "supplier")}]]]]
       [:rename
        {l_extendedprice x9,
         l_discount x10,
@@ -50,4 +39,14 @@
          l_suppkey
          l_partkey
          l_orderkey
-         {_table (= _table "lineitem")}]]]]]]]]]
+         {_table (= _table "lineitem")}]]]
+      [:rename
+       {p_partkey x1, p_name x2, _table x3}
+       [:scan
+        [p_partkey
+         {p_name (like p_name "%green%")}
+         {_table (= _table "part")}]]]
+      [:rename
+       {s_suppkey x5, s_nationkey x6, _table x7}
+       [:scan
+        [s_suppkey s_nationkey {_table (= _table "supplier")}]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-semi-and-anti-joins-are-pushed-down.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-semi-and-anti-joins-are-pushed-down.edn
@@ -2,22 +2,23 @@
  {x1 a1}
  [:project
   [x1]
-  [:cross-join
-   [:mega-join
-    [{x1 x6}]
-    [[:semi-join
-      [{x2 x12}]
-      [:rename
-       {a1 x1, b1 x2, _table x3}
-       [:scan [a1 b1 {_table (= _table "t1")}]]]
-      [:table [x12] [{x12 532} {x12 593}]]]
-     [:semi-join
-      [{x5 x15}]
-      [:rename
-       {b1 x5, a2 x6, _table x7}
-       [:scan [b1 a2 {_table (= _table "t2")}]]]
-      [:table [x15] [{x15 808} {x15 662}]]]]]
-   [:semi-join
-    [{x9 x18}]
-    [:rename {c1 x9, _table x10} [:scan [c1 {_table (= _table "t3")}]]]
-    [:table [x18] [{x18 792} {x18 14}]]]]]]
+  [:mega-join
+   [{x1 x6}]
+   [[:semi-join
+     [{x9 x18}]
+     [:rename
+      {c1 x9, _table x10}
+      [:scan [c1 {_table (= _table "t3")}]]]
+     [:table [x18] [{x18 792} {x18 14}]]]
+    [:semi-join
+     [{x2 x12}]
+     [:rename
+      {a1 x1, b1 x2, _table x3}
+      [:scan [a1 b1 {_table (= _table "t1")}]]]
+     [:table [x12] [{x12 532} {x12 593}]]]
+    [:semi-join
+     [{x5 x15}]
+     [:rename
+      {b1 x5, a2 x6, _table x7}
+      [:scan [b1 a2 {_table (= _table "t2")}]]]
+     [:table [x15] [{x15 808} {x15 662}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-with-clause.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-with-clause.edn
@@ -1,13 +1,14 @@
 [:rename
  {x1 id, x4 id_1}
- [:cross-join
-  [:project
-   [x1]
-   [:rename
-    {id x1, _table x2}
-    [:scan [{id (= id 5)} {_table (= _table "bar")}]]]]
-  [:project
-   [x4]
-   [:rename
-    {id x4, _table x5}
-    [:scan [{id (= id 5)} {_table (= _table "bar")}]]]]]]
+ [:mega-join
+  []
+  [[:project
+    [x1]
+    [:rename
+     {id x1, _table x2}
+     [:scan [{id (= id 5)} {_table (= _table "bar")}]]]]
+   [:project
+    [x4]
+    [:rename
+     {id x4, _table x5}
+     [:scan [{id (= id 5)} {_table (= _table "bar")}]]]]]]]

--- a/test/core2/operator/join_test.clj
+++ b/test/core2/operator/join_test.clj
@@ -786,6 +786,22 @@
                 [::tu/blocks [[{:x2 1}]]]
                 [::tu/blocks [[{:x3 1 :x4 3}]]]]])))
 
+  (t/testing "disconnected relations/sub-graphs"
+    (t/is (= [{:x1 1, :x2 1, :x4 3, :x3 1, :x5 5, :x6 10, :x7 10, :x8 8}]
+             (tu/query-ra
+               '[:mega-join
+                 [{x1 x2}
+                  (> (+ x1 10) (+ (+ x3 2) x4))
+                  {x1 x3}
+                  {x6 x7}]
+                 [[::tu/blocks [[{:x1 1}]]]
+                  [::tu/blocks [[{:x2 1}]]]
+                  [::tu/blocks [[{:x3 1 :x4 3}]]]
+                  [::tu/blocks [[{:x5 5}]]]
+                  [::tu/blocks [[{:x6 10}]]]
+                  [::tu/blocks [[{:x7 10}]]]
+                  [::tu/blocks [[{:x8 8}]]]]]))))
+
   (t/testing "params"
     (t/is (= [{:x1 1, :x2 1, :x4 3, :x3 1, :x5 2}]
              (tu/query-ra
@@ -800,16 +816,15 @@
                    [::tu/blocks [[{:x3 1 :x4 3}]]]]]]))))
 
   (t/is (thrown-with-msg? RuntimeException
-                          #"Unable to find join candidate"
+                          #"Unused Join Conditions Remain"
                           (tu/query-ra
                             '[:mega-join
-                             [{x1 x4}
-                              (> (+ x1 10) (+ (+ x3 2) x4))
-                              {x1 x3}]
+                             [{x1 x2}
+                              {x5 x6}]
                              [[::tu/blocks [[{:x1 1}]]]
                               [::tu/blocks [[{:x2 1}]]]
                               [::tu/blocks [[{:x3 1 :x4 3}]]]]]))
-        "throws if unable to find a valid join order")
+        "throws if after joining all relations there are still unused join conditions")
 
   (t/testing "empty input"
     (t/is (= []


### PR DESCRIPTION
This commit folds cross joins into the mega-join operator during the final step of the sql plan.

The mega-join operator handles cross joins by first planning out all connected subgraphs into their own sub-plans before joining them together with binary cross joins.