### PR TITLE
Add table as required argument to scan operator

### DIFF
--- a/core/src/core2/datalog.clj
+++ b/core/src/core2/datalog.clj
@@ -202,7 +202,11 @@
          [:rename (->> cols
                        (into {} (comp (filter :value-arg)
                                       (map (juxt :col-name :value-arg)))))
-          [:scan src (-> (vec (for [{:keys [col-name col-pred]} cols]
+          [:scan
+           src
+           'xt_docs ;; assumes all docs put into system that
+           ;; want to be queried by datalog will be stored under xt_docs table
+           (-> (vec (for [{:keys [col-name col-pred]} cols]
                                 (if col-pred
                                   {col-name col-pred}
                                   col-name)))

--- a/core/src/core2/operator/rename.clj
+++ b/core/src/core2/operator/rename.clj
@@ -38,7 +38,7 @@
                                  :let [col-name (name (get col-name-mapping (symbol (.getName in-col))))]]
                            (.add out-cols (.withName in-col col-name)))
 
-                         (.accept c (iv/->indirect-rel out-cols))))))))
+                         (.accept c (iv/->indirect-rel out-cols (.rowCount in-rel)))))))))
 
   (close [_]
     (util/try-close in-cursor)))

--- a/test-resources/core2/sql/plan_test_expectations/all-as-expression-in-select.edn
+++ b/test-resources/core2/sql/plan_test_expectations/all-as-expression-in-select.edn
@@ -1,14 +1,10 @@
 [:rename
- {x9 $column_1$}
+ {x7 $column_1$}
  [:project
-  [x9]
+  [x7]
   [:map
-   [{x9 (not x8)}]
+   [{x7 (not x6)}]
    [:mark-join
-    {x8 [(> x1 x4)]}
-    [:rename {z x1, _table x2} [:scan [z {_table (= _table "x")}]]]
-    [:project
-     [x4]
-     [:rename
-      {z x4, _table x5}
-      [:scan [z {_table (= _table "y")}]]]]]]]]
+    {x6 [(> x1 x3)]}
+    [:rename {z x1} [:scan x [z]]]
+    [:rename {z x3} [:scan y [z]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/all-in-where.edn
+++ b/test-resources/core2/sql/plan_test_expectations/all-in-where.edn
@@ -3,8 +3,6 @@
  [:project
   [x1]
   [:anti-join
-   [(or (<= x2 x5) (nil? x2) (nil? x5))]
-   [:rename
-    {y x1, z x2, _table x3}
-    [:scan [y z {_table (= _table "x")}]]]
-   [:rename {z x5, _table x6} [:scan [z {_table (= _table "y")}]]]]]]
+   [(or (<= x2 x4) (nil? x2) (nil? x4))]
+   [:rename {y x1, z x2} [:scan x [y z]]]
+   [:rename {z x4} [:scan y [z]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/any-in-where.edn
+++ b/test-resources/core2/sql/plan_test_expectations/any-in-where.edn
@@ -3,8 +3,6 @@
  [:project
   [x1]
   [:semi-join
-   [(> (= x2 1) x5)]
-   [:rename
-    {y x1, z x2, _table x3}
-    [:scan [y z {_table (= _table "x")}]]]
-   [:rename {z x5, _table x6} [:scan [z {_table (= _table "y")}]]]]]]
+   [(> (= x2 1) x4)]
+   [:rename {y x1, z x2} [:scan x [y z]]]
+   [:rename {z x4} [:scan y [z]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/application-and-system-time-period-spec-between.edn
+++ b/test-resources/core2/sql/plan_test_expectations/application-and-system-time-period-spec-between.edn
@@ -1,13 +1,12 @@
 [:rename
- {x7 $column_1$}
+ {x6 $column_1$}
  [:project
-  [{x7 4}]
+  [{x6 4}]
   [:rename
    {system_time_start x1,
     system_time_end x2,
     application_time_start x3,
-    application_time_end x4,
-    _table x5}
+    application_time_end x4}
    [:select
     (and
      (<= #time/date "2000-01-01" #time/date "2001-01-01")
@@ -32,9 +31,9 @@
         application_time_end
         #time/zoned-date-time "3001-01-01T00:00Z"))))
     [:scan
+     t1
      [{system_time_start
        (<= system_time_start #time/date "2001-01-01")}
       {system_time_end (> system_time_end #time/date "2000-01-01")}
       application_time_start
-      application_time_end
-      {_table (= _table "t1")}]]]]]]
+      application_time_end]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/application-time-period-spec-as-of.edn
+++ b/test-resources/core2/sql/plan_test_expectations/application-time-period-spec-as-of.edn
@@ -3,14 +3,11 @@
  [:project
   [x3]
   [:rename
-   {application_time_start x1,
-    application_time_end x2,
-    bar x3,
-    _table x4}
+   {application_time_start x1, application_time_end x2, bar x3}
    [:scan
+    foo
     [{application_time_start
       (<= application_time_start #time/date-time "2999-01-01T00:00")}
      {application_time_end
       (> application_time_end #time/date-time "2999-01-01T00:00")}
-     bar
-     {_table (= _table "foo")}]]]]]
+     bar]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/application-time-period-spec-between-asym.edn
+++ b/test-resources/core2/sql/plan_test_expectations/application-time-period-spec-between-asym.edn
@@ -1,18 +1,18 @@
 [:rename
- {x5 $column_1$}
+ {x4 $column_1$}
  [:project
-  [{x5 4}]
+  [{x4 4}]
   [:rename
-   {application_time_start x1, application_time_end x2, _table x3}
+   {application_time_start x1, application_time_end x2}
    [:select
     (<=
      #time/zoned-date-time "3000-01-01T00:00Z"
      #time/date "3001-01-01")
     [:scan
+     t1
      [{application_time_start
        (<= application_time_start #time/date "3001-01-01")}
       {application_time_end
        (>
         application_time_end
-        #time/zoned-date-time "3000-01-01T00:00Z")}
-      {_table (= _table "t1")}]]]]]]
+        #time/zoned-date-time "3000-01-01T00:00Z")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/application-time-period-spec-between-sym-asc.edn
+++ b/test-resources/core2/sql/plan_test_expectations/application-time-period-spec-between-sym-asc.edn
@@ -1,9 +1,9 @@
 [:rename
- {x5 $column_1$}
+ {x4 $column_1$}
  [:project
-  [{x5 4}]
+  [{x4 4}]
   [:rename
-   {application_time_start x1, application_time_end x2, _table x3}
+   {application_time_start x1, application_time_end x2}
    [:select
     (if
      (>
@@ -25,7 +25,4 @@
       (>
        application_time_end
        #time/zoned-date-time "3000-01-01T00:00Z")))
-    [:scan
-     [application_time_start
-      application_time_end
-      {_table (= _table "t1")}]]]]]]
+    [:scan t1 [application_time_start application_time_end]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/application-time-period-spec-between-sym.edn
+++ b/test-resources/core2/sql/plan_test_expectations/application-time-period-spec-between-sym.edn
@@ -1,9 +1,9 @@
 [:rename
- {x5 $column_1$}
+ {x4 $column_1$}
  [:project
-  [{x5 4}]
+  [{x4 4}]
   [:rename
-   {application_time_start x1, application_time_end x2, _table x3}
+   {application_time_start x1, application_time_end x2}
    [:select
     (if
      (>
@@ -25,7 +25,4 @@
       (>
        application_time_end
        #time/zoned-date-time "3001-01-01T00:00Z")))
-    [:scan
-     [application_time_start
-      application_time_end
-      {_table (= _table "t1")}]]]]]]
+    [:scan t1 [application_time_start application_time_end]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/application-time-period-spec-between.edn
+++ b/test-resources/core2/sql/plan_test_expectations/application-time-period-spec-between.edn
@@ -1,18 +1,18 @@
 [:rename
- {x5 $column_1$}
+ {x4 $column_1$}
  [:project
-  [{x5 4}]
+  [{x4 4}]
   [:rename
-   {application_time_start x1, application_time_end x2, _table x3}
+   {application_time_start x1, application_time_end x2}
    [:select
     (<=
      #time/zoned-date-time "3000-01-01T00:00Z"
      #time/date "3001-01-01")
     [:scan
+     t1
      [{application_time_start
        (<= application_time_start #time/date "3001-01-01")}
       {application_time_end
        (>
         application_time_end
-        #time/zoned-date-time "3000-01-01T00:00Z")}
-      {_table (= _table "t1")}]]]]]]
+        #time/zoned-date-time "3000-01-01T00:00Z")}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/application-time-period-spec-from-to.edn
+++ b/test-resources/core2/sql/plan_test_expectations/application-time-period-spec-from-to.edn
@@ -3,20 +3,17 @@
  [:project
   [x3]
   [:rename
-   {application_time_start x1,
-    application_time_end x2,
-    bar x3,
-    _table x4}
+   {application_time_start x1, application_time_end x2, bar x3}
    [:select
     (<
      #time/date "2999-01-01"
      #time/zoned-date-time "3000-01-01T00:00Z")
     [:scan
+     foo
      [{application_time_start
        (<
         application_time_start
         #time/zoned-date-time "3000-01-01T00:00Z")}
       {application_time_end
        (> application_time_end #time/date "2999-01-01")}
-      bar
-      {_table (= _table "foo")}]]]]]]
+      bar]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-1.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-1.edn
@@ -3,13 +3,10 @@
  [:project
   [x1]
   [:mega-join
-   [{x2 x5}]
+   [{x2 x4}]
    [[:rename
-     {movietitle x1, starname x2, _table x3}
-     [:scan [movietitle starname {_table (= _table "starsin")}]]]
+     {movietitle x1, starname x2}
+     [:scan starsin [movietitle starname]]]
     [:rename
-     {name x5, birthdate x6, _table x7}
-     [:scan
-      [name
-       {birthdate (= birthdate 1960)}
-       {_table (= _table "moviestar")}]]]]]]]
+     {name x4, birthdate x5}
+     [:scan moviestar [name {birthdate (= birthdate 1960)}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-10.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-10.edn
@@ -1,7 +1,5 @@
 [:rename
- {x4 $column_1$}
+ {x3 $column_1$}
  [:group-by
-  [{x4 (sum x1)}]
-  [:rename
-   {length x1, _table x2}
-   [:scan [length {_table (= _table "movie")}]]]]]
+  [{x3 (sum x1)}]
+  [:rename {length x1} [:scan movie [length]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-11.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-11.edn
@@ -1,7 +1,1 @@
-[:rename
- {x1 name}
- [:project
-  [x1]
-  [:rename
-   {name x1, _table x2}
-   [:scan [name {_table (= _table "starsin")}]]]]]
+[:scan starsin [name]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-12.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-12.edn
@@ -1,7 +1,1 @@
-[:rename
- {x1 bar}
- [:project
-  [x1]
-  [:rename
-   {name x1, _table x2}
-   [:scan [name {_table (= _table "starsin")}]]]]]
+[:rename {x1 bar} [:rename {name x1} [:scan starsin [name]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-13.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-13.edn
@@ -1,9 +1,1 @@
-[:rename
- {x1 name, x2 lastname}
- [:project
-  [x1 x2]
-  [:rename
-   {name x1, lastname x2, _table x3}
-   [:select
-    (= name lastname)
-    [:scan [name lastname {_table (= _table "starsin")}]]]]]]
+[:select (= name lastname) [:scan starsin [name lastname]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-14.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-14.edn
@@ -1,8 +1,3 @@
 [:rename
  {x1 movietitle}
- [:distinct
-  [:project
-   [x1]
-   [:rename
-    {movietitle x1, _table x2}
-    [:scan [movietitle {_table (= _table "starsin")}]]]]]]
+ [:distinct [:rename {movietitle x1} [:scan starsin [movietitle]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-15.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-15.edn
@@ -1,15 +1,5 @@
 [:rename
  {x1 name}
  [:difference
-  [:distinct
-   [:project
-    [x1]
-    [:rename
-     {name x1, _table x2}
-     [:scan [name {_table (= _table "starsin")}]]]]]
-  [:distinct
-   [:project
-    [x1]
-    [:rename
-     {name x1, _table x5}
-     [:scan [name {_table (= _table "starsin")}]]]]]]]
+  [:distinct [:rename {name x1} [:scan starsin [name]]]]
+  [:distinct [:rename {name x1} [:scan starsin [name]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-16.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-16.edn
@@ -1,13 +1,5 @@
 [:rename
  {x1 name}
  [:union-all
-  [:project
-   [x1]
-   [:rename
-    {name x1, _table x2}
-    [:scan [name {_table (= _table "starsin")}]]]]
-  [:project
-   [x1]
-   [:rename
-    {name x1, _table x5}
-    [:scan [name {_table (= _table "starsin")}]]]]]]
+  [:rename {name x1} [:scan starsin [name]]]
+  [:rename {name x1} [:scan starsin [name]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-17.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-17.edn
@@ -2,13 +2,5 @@
  {x1 name}
  [:distinct
   [:intersect
-   [:project
-    [x1]
-    [:rename
-     {name x1, _table x2}
-     [:scan [name {_table (= _table "starsin")}]]]]
-   [:project
-    [x1]
-    [:rename
-     {name x1, _table x5}
-     [:scan [name {_table (= _table "starsin")}]]]]]]]
+   [:rename {name x1} [:scan starsin [name]]]
+   [:rename {name x1} [:scan starsin [name]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-18.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-18.edn
@@ -2,13 +2,5 @@
  {x1 movietitle}
  [:distinct
   [:union-all
-   [:project
-    [x1]
-    [:rename
-     {movietitle x1, _table x2}
-     [:scan [movietitle {_table (= _table "starsin")}]]]]
-   [:project
-    [x1]
-    [:rename
-     {name x1, _table x5}
-     [:scan [name {_table (= _table "starsin")}]]]]]]]
+   [:rename {movietitle x1} [:scan starsin [movietitle]]]
+   [:rename {name x1} [:scan starsin [name]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-19.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-19.edn
@@ -4,13 +4,5 @@
   [[x1 {:direction :asc, :null-ordering :nulls-last}]]
   [:distinct
    [:union-all
-    [:project
-     [x1]
-     [:rename
-      {name x1, _table x2}
-      [:scan [name {_table (= _table "starsin")}]]]]
-    [:project
-     [x1]
-     [:rename
-      {name x1, _table x5}
-      [:scan [name {_table (= _table "starsin")}]]]]]]]]
+    [:rename {name x1} [:scan starsin [name]]]
+    [:rename {name x1} [:scan starsin [name]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-2.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-2.edn
@@ -3,13 +3,13 @@
  [:project
   [x1]
   [:mega-join
-   [{x2 x5}]
+   [{x2 x4}]
    [[:rename
-     {movietitle x1, starname x2, _table x3}
-     [:scan [movietitle starname {_table (= _table "starsin")}]]]
+     {movietitle x1, starname x2}
+     [:scan starsin [movietitle starname]]]
     [:rename
-     {name x5, birthdate x6, _table x7}
+     {name x4, birthdate x5}
      [:scan
+      moviestar
       [name
-       {birthdate (and (< birthdate 1960) (> birthdate 1950))}
-       {_table (= _table "moviestar")}]]]]]]]
+       {birthdate (and (< birthdate 1960) (> birthdate 1950))}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-20.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-20.edn
@@ -2,8 +2,4 @@
  {x1 movietitle}
  [:top
   {:limit 10}
-  [:project
-   [x1]
-   [:rename
-    {movietitle x1, _table x2}
-    [:scan [movietitle {_table (= _table "starsin")}]]]]]]
+  [:rename {movietitle x1} [:scan starsin [movietitle]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-21.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-21.edn
@@ -2,8 +2,4 @@
  {x1 movietitle}
  [:top
   {:skip 5}
-  [:project
-   [x1]
-   [:rename
-    {movietitle x1, _table x2}
-    [:scan [movietitle {_table (= _table "starsin")}]]]]]]
+  [:rename {movietitle x1} [:scan starsin [movietitle]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-22.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-22.edn
@@ -2,8 +2,4 @@
  {x1 movietitle}
  [:top
   {:skip 5, :limit 10}
-  [:project
-   [x1]
-   [:rename
-    {movietitle x1, _table x2}
-    [:scan [movietitle {_table (= _table "starsin")}]]]]]]
+  [:rename {movietitle x1} [:scan starsin [movietitle]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-23.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-23.edn
@@ -2,8 +2,4 @@
  {x1 movietitle}
  [:order-by
   [[x1 {:direction :asc, :null-ordering :nulls-last}]]
-  [:project
-   [x1]
-   [:rename
-    {movietitle x1, _table x2}
-    [:scan [movietitle {_table (= _table "starsin")}]]]]]]
+  [:rename {movietitle x1} [:scan starsin [movietitle]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-24.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-24.edn
@@ -4,8 +4,4 @@
   {:skip 100}
   [:order-by
    [[x1 {:direction :asc, :null-ordering :nulls-last}]]
-   [:project
-    [x1]
-    [:rename
-     {movietitle x1, _table x2}
-     [:scan [movietitle {_table (= _table "starsin")}]]]]]]]
+   [:rename {movietitle x1} [:scan starsin [movietitle]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-25.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-25.edn
@@ -2,8 +2,4 @@
  {x1 movietitle}
  [:order-by
   [[x1 {:direction :desc, :null-ordering :nulls-last}]]
-  [:project
-   [x1]
-   [:rename
-    {movietitle x1, _table x2}
-    [:scan [movietitle {_table (= _table "starsin")}]]]]]]
+  [:rename {movietitle x1} [:scan starsin [movietitle]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-26.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-26.edn
@@ -3,12 +3,12 @@
  [:project
   [x1]
   [:order-by
-   [[x5 {:direction :desc, :null-ordering :nulls-last}]
+   [[x4 {:direction :desc, :null-ordering :nulls-last}]
     [x1 {:direction :asc, :null-ordering :nulls-last}]]
    [:project
-    [x1 x5]
+    [x1 x4]
     [:map
-     [{x5 (= x2 "foo")}]
+     [{x4 (= x2 "foo")}]
      [:rename
-      {movietitle x1, year x2, _table x3}
-      [:scan [movietitle year {_table (= _table "starsin")}]]]]]]]]
+      {movietitle x1, year x2}
+      [:scan starsin [movietitle year]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-27.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-27.edn
@@ -4,8 +4,6 @@
   [x1]
   [:order-by
    [[x2 {:direction :asc, :null-ordering :nulls-last}]]
-   [:project
-    [x1 x2]
-    [:rename
-     {movietitle x1, year x2, _table x3}
-     [:scan [movietitle year {_table (= _table "starsin")}]]]]]]]
+   [:rename
+    {movietitle x1, year x2}
+    [:scan starsin [movietitle year]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-28.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-28.edn
@@ -1,9 +1,7 @@
 [:rename
- {x4 $column_1$}
+ {x3 $column_1$}
  [:order-by
-  [[x4 {:direction :asc, :null-ordering :nulls-last}]]
+  [[x3 {:direction :asc, :null-ordering :nulls-last}]]
   [:project
-   [{x4 (= x1 "foo")}]
-   [:rename
-    {year x1, _table x2}
-    [:scan [year {_table (= _table "starsin")}]]]]]]
+   [{x3 (= x1 "foo")}]
+   [:rename {year x1} [:scan starsin [year]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-29.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-29.edn
@@ -1,10 +1,5 @@
 [:rename
- {x4 name}
+ {x3 name}
  [:project
-  [x4]
-  [:unwind
-   {x4 x1}
-   {}
-   [:rename
-    {films x1, _table x2}
-    [:scan [films {_table (= _table "starsin")}]]]]]]
+  [x3]
+  [:unwind {x3 x1} {} [:rename {films x1} [:scan starsin [films]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-3.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-3.edn
@@ -3,13 +3,12 @@
  [:project
   [x1]
   [:mega-join
-   [{x2 x5}]
+   [{x2 x4}]
    [[:rename
-     {movietitle x1, starname x2, _table x3}
-     [:scan [movietitle starname {_table (= _table "starsin")}]]]
+     {movietitle x1, starname x2}
+     [:scan starsin [movietitle starname]]]
     [:rename
-     {name x5, birthdate x6, _table x7}
+     {name x4, birthdate x5}
      [:scan
-      [{name (= name "Foo")}
-       {birthdate (< birthdate 1960)}
-       {_table (= _table "moviestar")}]]]]]]]
+      moviestar
+      [{name (= name "Foo")} {birthdate (< birthdate 1960)}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-30.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-30.edn
@@ -1,10 +1,5 @@
 [:rename
- {x1 films, x4 $column_2$}
+ {x1 films, x3 $column_2$}
  [:project
-  [x1 x4]
-  [:unwind
-   {x4 x1}
-   {}
-   [:rename
-    {films x1, _table x2}
-    [:scan [films {_table (= _table "starsin")}]]]]]]
+  [x1 x3]
+  [:unwind {x3 x1} {} [:rename {films x1} [:scan starsin [films]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-31.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-31.edn
@@ -1,10 +1,8 @@
 [:rename
- {x1 films, x4 $column_2$, x5 $column_3$}
+ {x1 films, x3 $column_2$, x4 $column_3$}
  [:project
-  [x1 x4 x5]
+  [x1 x3 x4]
   [:unwind
-   {x4 x1}
-   {:ordinality-column x5}
-   [:rename
-    {films x1, _table x2}
-    [:scan [films {_table (= _table "starsin")}]]]]]]
+   {x3 x1}
+   {:ordinality-column x4}
+   [:rename {films x1} [:scan starsin [films]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-34.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-34.edn
@@ -1,10 +1,8 @@
 [:rename
- {x8 $column_1$, x9 $column_2$, x10 $column_3$}
+ {x7 $column_1$, x8 $column_2$, x9 $column_3$}
  [:project
-  [{x8 (case (+ x1 1) x2 111 x3 222 x4 333 x5 444 555)}
-   {x9
+  [{x7 (case (+ x1 1) x2 111 x3 222 x4 333 x5 444 555)}
+   {x8
     (cond (< x1 (- x2 3)) 111 (<= x1 x2) 222 (< x1 (+ x2 3)) 333 444)}
-   {x10 (case (+ x1 1) x2 222 x3 222 x4 444 (+ x5 1) 444 555)}]
-  [:rename
-   {a x1, b x2, c x3, d x4, e x5, _table x6}
-   [:scan [a b c d e {_table (= _table "t1")}]]]]]
+   {x9 (case (+ x1 1) x2 222 x3 222 x4 444 (+ x5 1) 444 555)}]
+  [:rename {a x1, b x2, c x3, d x4, e x5} [:scan t1 [a b c d e]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-35.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-35.edn
@@ -1,7 +1,1 @@
-[:rename
- {x1 a}
- [:project
-  [x1]
-  [:rename
-   {a x1, _table x2}
-   [:scan [{a (nil? a)} {_table (= _table "t1")}]]]]]
+[:scan t1 [{a (nil? a)}]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-36.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-36.edn
@@ -1,7 +1,1 @@
-[:rename
- {x1 a}
- [:project
-  [x1]
-  [:rename
-   {a x1, _table x2}
-   [:scan [{a (not (nil? a))} {_table (= _table "t1")}]]]]]
+[:scan t1 [{a (not (nil? a))}]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-37.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-37.edn
@@ -1,7 +1,5 @@
 [:rename
- {x5 $column_1$}
+ {x4 $column_1$}
  [:project
-  [{x5 (nullif x1 x2)}]
-  [:rename
-   {a x1, b x2, _table x3}
-   [:scan [a b {_table (= _table "t1")}]]]]]
+  [{x4 (nullif x1 x2)}]
+  [:rename {a x1, b x2} [:scan t1 [a b]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-4.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-4.edn
@@ -3,15 +3,12 @@
  [:project
   [x1]
   [:mega-join
-   [{x2 x5}]
+   [{x2 x4}]
    [[:rename
-     {movietitle x1, starname x2, _table x3}
-     [:scan [movietitle starname {_table (= _table "starsin")}]]]
+     {movietitle x1, starname x2}
+     [:scan starsin [movietitle starname]]]
     [:project
-     [x5]
+     [x4]
      [:rename
-      {name x5, birthdate x6, _table x7}
-      [:scan
-       [name
-        {birthdate (= birthdate 1960)}
-        {_table (= _table "moviestar")}]]]]]]]]
+      {name x4, birthdate x5}
+      [:scan moviestar [name {birthdate (= birthdate 1960)}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-5.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-5.edn
@@ -1,12 +1,10 @@
 [:rename
- {x5 movietitle}
+ {x4 movietitle}
  [:project
-  [x5]
+  [x4]
   [:mega-join
-   [{x1 x5} {x2 x6}]
-   [[:rename
-     {title x1, movieyear x2, _table x3}
-     [:scan [title movieyear {_table (= _table "movie")}]]]
+   [{x1 x4} {x2 x5}]
+   [[:rename {title x1, movieyear x2} [:scan movie [title movieyear]]]
     [:rename
-     {movietitle x5, year x6, _table x7}
-     [:scan [movietitle year {_table (= _table "starsin")}]]]]]]]
+     {movietitle x4, year x5}
+     [:scan starsin [movietitle year]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-6.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-6.edn
@@ -1,12 +1,10 @@
 [:rename
- {x5 movietitle}
+ {x4 movietitle}
  [:project
-  [x5]
+  [x4]
   [:left-outer-join
-   [{x1 x5} {x2 x6}]
+   [{x1 x4} {x2 x5}]
+   [:rename {title x1, movieyear x2} [:scan movie [title movieyear]]]
    [:rename
-    {title x1, movieyear x2, _table x3}
-    [:scan [title movieyear {_table (= _table "movie")}]]]
-   [:rename
-    {movietitle x5, year x6, _table x7}
-    [:scan [movietitle year {_table (= _table "starsin")}]]]]]]
+    {movietitle x4, year x5}
+    [:scan starsin [movietitle year]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-7.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-7.edn
@@ -1,12 +1,8 @@
 [:rename
- {x4 title}
+ {x3 title}
  [:project
-  [x4]
+  [x3]
   [:mega-join
-   [{x1 x4}]
-   [[:rename
-     {title x1, _table x2}
-     [:scan [title {_table (= _table "movie")}]]]
-    [:rename
-     {title x4, _table x5}
-     [:scan [title {_table (= _table "starsin")}]]]]]]]
+   [{x1 x3}]
+   [[:rename {title x1} [:scan movie [title]]]
+    [:rename {title x3} [:scan starsin [title]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-8.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-8.edn
@@ -3,10 +3,6 @@
  [:project
   [x1]
   [:left-outer-join
-   [{x1 x4}]
-   [:rename
-    {title x1, _table x2}
-    [:scan [title {_table (= _table "starsin")}]]]
-   [:rename
-    {title x4, _table x5}
-    [:scan [title {_table (= _table "movie")}]]]]]]
+   [{x1 x3}]
+   [:rename {title x1} [:scan starsin [title]]]
+   [:rename {title x3} [:scan movie [title]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/basic-query-9.edn
+++ b/test-resources/core2/sql/plan_test_expectations/basic-query-9.edn
@@ -1,16 +1,14 @@
 [:rename
- {x1 name, x10 $column_2$}
+ {x1 name, x8 $column_2$}
  [:project
-  [x1 x10]
+  [x1 x8]
   [:select
-   (< x11 1930)
+   (< x9 1930)
    [:group-by
-    [x1 {x10 (sum x5)} {x11 (min x7)}]
+    [x1 {x8 (sum x4)} {x9 (min x6)}]
     [:mega-join
-     [{x2 x6}]
-     [[:rename
-       {name x1, cert x2, _table x3}
-       [:scan [name cert {_table (= _table "movieexec")}]]]
+     [{x2 x5}]
+     [[:rename {name x1, cert x2} [:scan movieexec [name cert]]]
       [:rename
-       {length x5, producer x6, year x7, _table x8}
-       [:scan [length producer year {_table (= _table "movie")}]]]]]]]]]
+       {length x4, producer x5, year x6}
+       [:scan movie [length producer year]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/correlated-scalar-subquery-in-select.edn
+++ b/test-resources/core2/sql/plan_test_expectations/correlated-scalar-subquery-in-select.edn
@@ -1,15 +1,9 @@
 [:rename
- {x9 some_column}
+ {x7 some_column}
  [:project
-  [{x9 (= 1 x7)}]
+  [{x7 (= 1 x5)}]
   [:apply
    :single-join
-   {x1 ?x8}
-   [:rename
-    {y x1, _table x2}
-    [:scan [{y (= y 1)} {_table (= _table "x")}]]]
-   [:project
-    [{x7 (= x4 ?x8)}]
-    [:rename
-     {bar x4, _table x5}
-     [:scan [bar {_table (= _table "foo")}]]]]]]]
+   {x1 ?x6}
+   [:rename {y x1} [:scan x [{y (= y 1)}]]]
+   [:project [{x5 (= x3 ?x6)}] [:rename {bar x3} [:scan foo [bar]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/decorrelation-1.edn
+++ b/test-resources/core2/sql/plan_test_expectations/decorrelation-1.edn
@@ -3,16 +3,14 @@
  [:project
   [x1]
   [:select
-   (< 1000000 x8)
+   (< 1000000 x6)
    [:group-by
-    [x1 x2 $row_number$ {x8 (sum x4)}]
+    [x1 $row_number$ {x6 (sum x3)}]
     [:left-outer-join
-     [{x1 x5}]
+     [{x1 x4}]
      [:map
       [{$row_number$ (row-number)}]
-      [:rename
-       {custkey x1, _table x2}
-       [:scan [custkey {_table (= _table "customer")}]]]]
+      [:rename {custkey x1} [:scan customer [custkey]]]]
      [:rename
-      {totalprice x4, custkey x5, _table x6}
-      [:scan [totalprice custkey {_table (= _table "orders")}]]]]]]]]
+      {totalprice x3, custkey x4}
+      [:scan orders [totalprice custkey]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/decorrelation-2.edn
+++ b/test-resources/core2/sql/plan_test_expectations/decorrelation-2.edn
@@ -1,15 +1,8 @@
 [:rename
  {x1 country, x2 custno}
- [:project
-  [x1 x2]
-  [:semi-join
-   [{x2 x5}]
-   [:rename
-    {country x1, custno x2, _table x3}
-    [:scan
-     [{country (= country "Mexico")}
-      custno
-      {_table (= _table "customers")}]]]
-   [:rename
-    {custno x5, _table x6}
-    [:scan [custno {_table (= _table "orders")}]]]]]]
+ [:semi-join
+  [{x2 x4}]
+  [:rename
+   {country x1, custno x2}
+   [:scan customers [{country (= country "Mexico")} custno]]]
+  [:rename {custno x4} [:scan orders [custno]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/decorrelation-3.edn
+++ b/test-resources/core2/sql/plan_test_expectations/decorrelation-3.edn
@@ -1,23 +1,17 @@
 [:rename
- {x1 name, x14 $column_2$}
+ {x1 name, x11 $column_2$}
  [:project
-  [x1 x14]
+  [x1 x11]
   [:group-by
-   [x1 x2 x3 x4 $row_number$ {x14 (count x13)}]
+   [x1 x2 x3 $row_number$ {x11 (count x10)}]
    [:left-outer-join
-    [{x2 x10}]
+    [{x2 x8}]
     [:map
      [{$row_number$ (row-number)}]
      [:anti-join
-      [(or (= x3 x6) (nil? x3) (nil? x6))]
+      [(or (= x3 x5) (nil? x3) (nil? x5))]
       [:rename
-       {name x1, custno x2, country x3, _table x4}
-       [:scan [name custno country {_table (= _table "customers")}]]]
-      [:rename
-       {country x6, _table x7}
-       [:scan [country {_table (= _table "salesp")}]]]]]
-    [:map
-     [{x13 1}]
-     [:rename
-      {custno x10, _table x11}
-      [:scan [custno {_table (= _table "orders")}]]]]]]]]
+       {name x1, custno x2, country x3}
+       [:scan customers [name custno country]]]
+      [:rename {country x5} [:scan salesp [country]]]]]
+    [:map [{x10 1}] [:rename {custno x8} [:scan orders [custno]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/decorrelation-4.edn
+++ b/test-resources/core2/sql/plan_test_expectations/decorrelation-4.edn
@@ -1,23 +1,19 @@
 [:rename
- {x1 name, x5 course}
+ {x1 name, x4 course}
  [:project
-  [x1 x5]
+  [x1 x4]
   [:select
-   (= x7 x14)
+   (= x6 x11)
    [:group-by
-    [x1 x2 x3 x5 x6 x7 x8 $row_number$ {x14 (min x10)}]
+    [x1 x2 x4 x5 x6 $row_number$ {x11 (min x8)}]
     [:left-outer-join
-     [{x2 x11}]
+     [{x2 x9}]
      [:map
       [{$row_number$ (row-number)}]
       [:mega-join
-       [{x2 x6}]
-       [[:rename
-         {name x1, id x2, _table x3}
-         [:scan [name id {_table (= _table "students")}]]]
+       [{x2 x5}]
+       [[:rename {name x1, id x2} [:scan students [name id]]]
         [:rename
-         {course x5, sid x6, grade x7, _table x8}
-         [:scan [course sid grade {_table (= _table "exams")}]]]]]]
-     [:rename
-      {grade x10, sid x11, _table x12}
-      [:scan [grade sid {_table (= _table "exams")}]]]]]]]]
+         {course x4, sid x5, grade x6}
+         [:scan exams [course sid grade]]]]]]
+     [:rename {grade x8, sid x9} [:scan exams [grade sid]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/decorrelation-5.edn
+++ b/test-resources/core2/sql/plan_test_expectations/decorrelation-5.edn
@@ -1,31 +1,30 @@
 [:rename
- {x1 name, x7 course}
+ {x1 name, x6 course}
  [:project
-  [x1 x7]
+  [x1 x6]
   [:select
-   (>= x9 x20)
+   (>= x8 x17)
    [:map
-    [{x20 (+ x18 1)}]
+    [{x17 (+ x15 1)}]
     [:group-by
-     [x1 x2 x3 x4 x5 x7 x8 x9 x10 $row_number$ {x18 (avg x12)}]
+     [x1 x2 x3 x4 x6 x7 x8 $row_number$ {x15 (avg x10)}]
      [:left-outer-join
-      [(or (= x2 x13) (and (= x14 x3) (> x4 x15)))]
+      [(or (= x2 x11) (and (= x12 x3) (> x4 x13)))]
       [:map
        [{$row_number$ (row-number)}]
        [:mega-join
-        [{x2 x8}]
+        [{x2 x7}]
         [[:rename
-          {name x1, id x2, major x3, year x4, _table x5}
+          {name x1, id x2, major x3, year x4}
           [:scan
+           students
            [name
             id
             {major (or (= major "CS") (= major "Games Eng"))}
-            year
-            {_table (= _table "students")}]]]
+            year]]]
          [:rename
-          {course x7, sid x8, grade x9, _table x10}
-          [:scan [course sid grade {_table (= _table "exams")}]]]]]]
+          {course x6, sid x7, grade x8}
+          [:scan exams [course sid grade]]]]]]
       [:rename
-       {grade x12, sid x13, curriculum x14, date x15, _table x16}
-       [:scan
-        [grade sid curriculum date {_table (= _table "exams")}]]]]]]]]]
+       {grade x10, sid x11, curriculum x12, date x13}
+       [:scan exams [grade sid curriculum date]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/deeply-nested-correlated-query.edn
+++ b/test-resources/core2/sql/plan_test_expectations/deeply-nested-correlated-query.edn
@@ -4,20 +4,12 @@
   [x1 x2]
   [:apply
    :semi-join
-   {x2 ?x17, x5 ?x18}
+   {x2 ?x13, x4 ?x14}
    [:mega-join
     []
-    [[:rename
-      {a x1, b x2, _table x3}
-      [:scan [a b {_table (= _table "r")}]]]
-     [:rename {c x5, _table x6} [:scan [c {_table (= _table "s")}]]]]]
-   [:project
-    [x8 x9]
-    [:semi-join
-     [{x9 x12} (= x13 ?x18)]
-     [:rename
-      {a x8, b x9, _table x10}
-      [:scan [{a (= a ?x17)} b {_table (= _table "r")}]]]
-     [:rename
-      {a x12, b x13, _table x14}
-      [:scan [a b {_table (= _table "r")}]]]]]]]]
+    [[:rename {a x1, b x2} [:scan r [a b]]]
+     [:rename {c x4} [:scan s [c]]]]]
+   [:semi-join
+    [(= x10 ?x14) {x7 x9}]
+    [:rename {a x6, b x7} [:scan r [{a (= a ?x13)} b]]]
+    [:rename {a x9, b x10} [:scan r [a b]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/exists-as-expression-in-select.edn
+++ b/test-resources/core2/sql/plan_test_expectations/exists-as-expression-in-select.edn
@@ -1,19 +1,13 @@
 [:rename
- {x8 $column_1$}
+ {x6 $column_1$}
  [:project
-  [x8]
+  [x6]
   [:apply
    :cross-join
-   {x1 ?x11}
-   [:rename
-    {y x1, z x2, _table x3}
-    [:scan [y {z (= z 10)} {_table (= _table "x")}]]]
+   {x1 ?x9}
+   [:rename {y x1, z x2} [:scan x [y {z (= z 10)}]]]
    [:top
     {:limit 1}
     [:union-all
-     [:project
-      [{x8 true}]
-      [:rename
-       {z x5, _table x6}
-       [:scan [{z (= z ?x11)} {_table (= _table "y")}]]]]
-     [:table [{x8 false}]]]]]]]
+     [:project [{x6 true}] [:rename {z x4} [:scan y [{z (= z ?x9)}]]]]
+     [:table [{x6 false}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/exists-in-where.edn
+++ b/test-resources/core2/sql/plan_test_expectations/exists-in-where.edn
@@ -3,8 +3,6 @@
  [:project
   [x1]
   [:semi-join
-   [{x1 x5}]
-   [:rename
-    {y x1, z x2, _table x3}
-    [:scan [y {z (= z 10.0)} {_table (= _table "x")}]]]
-   [:rename {z x5, _table x6} [:scan [z {_table (= _table "y")}]]]]]]
+   [{x1 x4}]
+   [:rename {y x1, z x2} [:scan x [y {z (= z 10.0)}]]]
+   [:rename {z x4} [:scan y [z]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/in-in-where-select.edn
+++ b/test-resources/core2/sql/plan_test_expectations/in-in-where-select.edn
@@ -3,8 +3,6 @@
  [:project
   [x1]
   [:semi-join
-   [{x2 x5}]
-   [:rename
-    {y x1, z x2, _table x3}
-    [:scan [y z {_table (= _table "x")}]]]
-   [:rename {z x5, _table x6} [:scan [z {_table (= _table "y")}]]]]]]
+   [{x2 x4}]
+   [:rename {y x1, z x2} [:scan x [y z]]]
+   [:rename {z x4} [:scan y [z]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/in-in-where-set.edn
+++ b/test-resources/core2/sql/plan_test_expectations/in-in-where-set.edn
@@ -3,8 +3,6 @@
  [:project
   [x1]
   [:semi-join
-   [{x2 x5}]
-   [:rename
-    {y x1, z x2, _table x3}
-    [:scan [y z {_table (= _table "x")}]]]
-   [:table [x5] [{x5 1} {x5 2}]]]]]
+   [{x2 x4}]
+   [:rename {y x1, z x2} [:scan x [y z]]]
+   [:table [x4] [{x4 1} {x4 2}]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/lateral-derived-table-1.edn
+++ b/test-resources/core2/sql/plan_test_expectations/lateral-derived-table-1.edn
@@ -1,12 +1,5 @@
 [:rename
- {x1 y, x4 z}
- [:project
-  [x1 x4]
-  [:mega-join
-   [{x1 x4}]
-   [[:rename {y x1, _table x2} [:scan [y {_table (= _table "x")}]]]
-    [:project
-     [x4]
-     [:rename
-      {z x4, _table x5}
-      [:scan [z {_table (= _table "z")}]]]]]]]]
+ {x1 y, x3 z}
+ [:mega-join
+  [{x1 x3}]
+  [[:rename {y x1} [:scan x [y]]] [:rename {z x3} [:scan z [z]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/lateral-derived-table-2.edn
+++ b/test-resources/core2/sql/plan_test_expectations/lateral-derived-table-2.edn
@@ -1,7 +1,1 @@
-[:rename
- {x1 z}
- [:project
-  [x1]
-  [:rename
-   {z x1, _table x2}
-   [:scan [{z (= z 1)} {_table (= _table "z")}]]]]]
+[:scan z [{z (= z 1)}]]

--- a/test-resources/core2/sql/plan_test_expectations/multiple-ins-in-where-clause.edn
+++ b/test-resources/core2/sql/plan_test_expectations/multiple-ins-in-where-clause.edn
@@ -3,11 +3,9 @@
  [:project
   [x1]
   [:semi-join
-   [{x2 x8}]
+   [{x2 x7}]
    [:semi-join
-    [{x1 x5}]
-    [:rename
-     {a x1, b x2, _table x3}
-     [:scan [{a (= a 42)} b {_table (= _table "foo")}]]]
-    [:table [x5] [{x5 1} {x5 2}]]]
-   [:table [x8] [{x8 3} {x8 4}]]]]]
+    [{x1 x4}]
+    [:rename {a x1, b x2} [:scan foo [{a (= a 42)} b]]]
+    [:table [x4] [{x4 1} {x4 2}]]]
+   [:table [x7] [{x7 3} {x7 4}]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/multiple-references-to-temporal-cols.edn
+++ b/test-resources/core2/sql/plan_test_expectations/multiple-references-to-temporal-cols.edn
@@ -9,11 +9,11 @@
    {system_time_start x1,
     system_time_end x2,
     application_time_start x3,
-    application_time_end x4,
-    _table x5}
+    application_time_end x4}
    [:select
     (< #time/date "2001-01-01" #time/date "2002-01-01")
     [:scan
+     foo
      [{system_time_start
        (and
         (< system_time_start #time/date "2002-01-01")
@@ -29,5 +29,4 @@
       {application_time_end
        (and
         (> application_time_end #time/date "2000-01-01")
-        (> application_time_end 10))}
-      {_table (= _table "foo")}]]]]]]
+        (> application_time_end 10))}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-1.edn
+++ b/test-resources/core2/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-1.edn
@@ -3,10 +3,8 @@
  [:project
   [x1]
   [:select
-   (or x8 (= x2 42))
+   (or x7 (= x2 42))
    [:mark-join
-    {x8 [{x1 x5}]}
-    [:rename
-     {a x1, b x2, _table x3}
-     [:scan [a b {_table (= _table "foo")}]]]
-    [:table [x5] [{x5 1} {x5 2}]]]]]]
+    {x7 [{x1 x4}]}
+    [:rename {a x1, b x2} [:scan foo [a b]]]
+    [:table [x4] [{x4 1} {x4 2}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-2.edn
+++ b/test-resources/core2/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-2.edn
@@ -4,15 +4,11 @@
   [x1]
   [:mega-join
    []
-   [[:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+   [[:rename {a x1} [:scan foo [a]]]
     [:select
-     (= true x7)
+     (= true x5)
      [:top
       {:limit 1}
       [:union-all
-       [:project
-        [{x7 true}]
-        [:rename
-         {c x4, _table x5}
-         [:scan [c {_table (= _table "foo")}]]]]
-       [:table [{x7 false}]]]]]]]]]
+       [:project [{x5 true}] [:rename {c x3} [:scan foo [c]]]]
+       [:table [{x5 false}]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/not-exists-in-where.edn
+++ b/test-resources/core2/sql/plan_test_expectations/not-exists-in-where.edn
@@ -3,8 +3,6 @@
  [:project
   [x1]
   [:anti-join
-   [{x1 x5}]
-   [:rename
-    {y x1, z x2, _table x3}
-    [:scan [y {z (= z 10)} {_table (= _table "x")}]]]
-   [:rename {z x5, _table x6} [:scan [z {_table (= _table "y")}]]]]]]
+   [{x1 x4}]
+   [:rename {y x1, z x2} [:scan x [y {z (= z 10)}]]]
+   [:rename {z x4} [:scan y [z]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/not-in-in-where.edn
+++ b/test-resources/core2/sql/plan_test_expectations/not-in-in-where.edn
@@ -3,8 +3,6 @@
  [:project
   [x1]
   [:anti-join
-   [(or (= x2 x5) (nil? x2) (nil? x5))]
-   [:rename
-    {y x1, z x2, _table x3}
-    [:scan [y z {_table (= _table "x")}]]]
-   [:rename {z x5, _table x6} [:scan [z {_table (= _table "y")}]]]]]]
+   [(or (= x2 x4) (nil? x2) (nil? x4))]
+   [:rename {y x1, z x2} [:scan x [y z]]]
+   [:rename {z x4} [:scan y [z]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/projects-that-matter-are-maintained.edn
+++ b/test-resources/core2/sql/plan_test_expectations/projects-that-matter-are-maintained.edn
@@ -2,13 +2,7 @@
  {x1 id}
  [:distinct
   [:union-all
+   [:rename {id x1} [:scan customers [id]]]
    [:project
     [x1]
-    [:rename
-     {id x1, _table x2}
-     [:scan [id {_table (= _table "customers")}]]]]
-   [:project
-    [x1]
-    [:rename
-     {id x1, product x5, _table x6}
-     [:scan [id product {_table (= _table "orders")}]]]]]]]
+    [:rename {id x1, product x4} [:scan orders [id product]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/push-semi-and-anti-joins-down.edn
+++ b/test-resources/core2/sql/plan_test_expectations/push-semi-and-anti-joins-down.edn
@@ -3,15 +3,9 @@
  [:project
   [x1]
   [:semi-join
-   [{x1 x7} {x4 x8}]
+   [{x1 x5} {x3 x6}]
    [:mega-join
     []
-    [[:rename
-      {foo x1, _table x2}
-      [:scan [foo {_table (= _table "x")}]]]
-     [:rename
-      {biz x4, _table x5}
-      [:scan [biz {_table (= _table "y")}]]]]]
-   [:rename
-    {bar x7, baz x8, _table x9}
-    [:scan [bar baz {_table (= _table "z")}]]]]]]
+    [[:rename {foo x1} [:scan x [foo]]]
+     [:rename {biz x3} [:scan y [biz]]]]]
+   [:rename {bar x5, baz x6} [:scan z [bar baz]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/scalar-subquery-in-select.edn
+++ b/test-resources/core2/sql/plan_test_expectations/scalar-subquery-in-select.edn
@@ -1,14 +1,8 @@
 [:rename
- {x9 some_column}
+ {x7 some_column}
  [:project
-  [{x9 (= 1 x7)}]
+  [{x7 (= 1 x5)}]
   [:single-join
    []
-   [:rename
-    {y x1, _table x2}
-    [:scan [{y (= y 1)} {_table (= _table "x")}]]]
-   [:group-by
-    [{x7 (max x4)}]
-    [:rename
-     {bar x4, _table x5}
-     [:scan [bar {_table (= _table "foo")}]]]]]]]
+   [:rename {y x1} [:scan x [{y (= y 1)}]]]
+   [:group-by [{x5 (max x3)}] [:rename {bar x3} [:scan foo [bar]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/scalar-subquery-in-where.edn
+++ b/test-resources/core2/sql/plan_test_expectations/scalar-subquery-in-where.edn
@@ -3,12 +3,8 @@
  [:project
   [x1]
   [:select
-   (= x1 x7)
+   (= x1 x5)
    [:single-join
     []
-    [:rename {y x1, _table x2} [:scan [y {_table (= _table "x")}]]]
-    [:group-by
-     [{x7 (max x4)}]
-     [:rename
-      {bar x4, _table x5}
-      [:scan [bar {_table (= _table "foo")}]]]]]]]]
+    [:rename {y x1} [:scan x [y]]]
+    [:group-by [{x5 (max x3)}] [:rename {bar x3} [:scan foo [bar]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
+++ b/test-resources/core2/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
@@ -4,17 +4,13 @@
   [x1]
   [:mega-join
    []
-   [[:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+   [[:rename {a x1} [:scan foo [a]]]
     [:select
-     (= x4 x8)
+     (= x3 x6)
      [:apply
       :single-join
-      {x5 ?x12}
-      [:rename
-       {c x4, b x5, _table x6}
-       [:scan [c b {_table (= _table "bar")}]]]
+      {x4 ?x9}
+      [:rename {c x3, b x4} [:scan bar [c b]]]
       [:project
-       [x8]
-       [:rename
-        {b x8, a x9, _table x10}
-        [:scan [b {a (= a ?x12)} {_table (= _table "foo")}]]]]]]]]]]
+       [x6]
+       [:rename {b x6, a x7} [:scan foo [b {a (= a ?x9)}]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
+++ b/test-resources/core2/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
@@ -4,18 +4,13 @@
   [x1]
   [:mega-join
    []
-   [[:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+   [[:rename {a x1} [:scan foo [a]]]
     [:apply
      :semi-join
-     {x5 ?x12, x4 ?x13}
-     [:rename
-      {c x4, b x5, _table x6}
-      [:scan [c b {_table (= _table "bar")}]]]
+     {x4 ?x9, x3 ?x10}
+     [:rename {c x3, b x4} [:scan bar [c b]]]
      [:project
-      [x8]
+      [x6]
       [:rename
-       {b x8, a x9, _table x10}
-       [:scan
-        [{b (= ?x13 b)}
-         {a (= a ?x12)}
-         {_table (= _table "foo")}]]]]]]]]]
+       {b x6, a x7}
+       [:scan foo [{b (= ?x10 b)} {a (= a ?x9)}]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/subquery-in-join-uncorrelated-subquery.edn
+++ b/test-resources/core2/sql/plan_test_expectations/subquery-in-join-uncorrelated-subquery.edn
@@ -4,14 +4,10 @@
   [x1]
   [:mega-join
    []
-   [[:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]
+   [[:rename {a x1} [:scan foo [a]]]
     [:select
-     (= x4 x7)
+     (= x3 x5)
      [:single-join
       []
-      [:rename {c x4, _table x5} [:scan [c {_table (= _table "bar")}]]]
-      [:project
-       [x7]
-       [:rename
-        {b x7, _table x8}
-        [:scan [b {_table (= _table "foo")}]]]]]]]]]]
+      [:rename {c x3} [:scan bar [c]]]
+      [:rename {b x5} [:scan foo [b]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/system-time-as-of.edn
+++ b/test-resources/core2/sql/plan_test_expectations/system-time-as-of.edn
@@ -3,11 +3,11 @@
  [:project
   [x3]
   [:rename
-   {system_time_start x1, system_time_end x2, bar x3, _table x4}
+   {system_time_start x1, system_time_end x2, bar x3}
    [:scan
+    foo
     [{system_time_start
       (<= system_time_start #time/date-time "2999-01-01T00:00")}
      {system_time_end
       (> system_time_end #time/date-time "2999-01-01T00:00")}
-     bar
-     {_table (= _table "foo")}]]]]]
+     bar]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/system-time-between-asymmetric-subquery.edn
+++ b/test-resources/core2/sql/plan_test_expectations/system-time-between-asymmetric-subquery.edn
@@ -1,22 +1,21 @@
 [:rename
- {x7 $column_1$}
- [:project
-  [x7]
-  [:single-join
-   []
-   [:rename {_table x1} [:scan [{_table (= _table "t2")}]]]
-   [:project
-    [{x7 4}]
-    [:rename
-     {system_time_start x3, system_time_end x4, _table x5}
-     [:select
-      (<=
-       #time/date "3001-01-01"
-       #time/zoned-date-time "3002-01-01T00:00Z")
-      [:scan
-       [{system_time_start
-         (<=
-          system_time_start
-          #time/zoned-date-time "3002-01-01T00:00Z")}
-        {system_time_end (> system_time_end #time/date "3001-01-01")}
-        {_table (= _table "t1")}]]]]]]]]
+ {x5 $column_1$}
+ [:single-join
+  []
+  [:rename {} [:scan t2 []]]
+  [:project
+   [{x5 4}]
+   [:rename
+    {system_time_start x2, system_time_end x3}
+    [:select
+     (<=
+      #time/date "3001-01-01"
+      #time/zoned-date-time "3002-01-01T00:00Z")
+     [:scan
+      t1
+      [{system_time_start
+        (<=
+         system_time_start
+         #time/zoned-date-time "3002-01-01T00:00Z")}
+       {system_time_end
+        (> system_time_end #time/date "3001-01-01")}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/system-time-between-lateraly-derived-table.edn
+++ b/test-resources/core2/sql/plan_test_expectations/system-time-between-lateraly-derived-table.edn
@@ -1,28 +1,28 @@
 [:rename
- {x3 y, x8 z}
+ {x3 y, x7 z}
  [:project
-  [x3 x8]
+  [x3 x7]
   [:mega-join
-   [{x3 x8}]
+   [{x3 x7}]
    [[:rename
-     {system_time_start x1, system_time_end x2, y x3, _table x4}
+     {system_time_start x1, system_time_end x2, y x3}
      [:scan
+      x
       [{system_time_start
         (<= system_time_start #time/date "3001-01-01")}
        {system_time_end (> system_time_end #time/date "3001-01-01")}
-       y
-       {_table (= _table "x")}]]]
+       y]]]
     [:project
-     [x8]
+     [x7]
      [:rename
-      {system_time_start x6, system_time_end x7, z x8, _table x9}
+      {system_time_start x5, system_time_end x6, z x7}
       [:select
        (< "3001-01-01" #time/zoned-date-time "3002-01-01T00:00Z")
        [:scan
+        z
         [{system_time_start
           (<
            system_time_start
            #time/zoned-date-time "3002-01-01T00:00Z")}
          {system_time_end (> system_time_end "3001-01-01")}
-         z
-         {_table (= _table "z")}]]]]]]]]]
+         z]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/system-time-between-symmetric-local-table-literals.edn
+++ b/test-resources/core2/sql/plan_test_expectations/system-time-between-symmetric-local-table-literals.edn
@@ -1,9 +1,9 @@
 [:rename
- {x5 $column_1$}
+ {x4 $column_1$}
  [:project
-  [{x5 4}]
+  [{x4 4}]
   [:rename
-   {system_time_start x1, system_time_end x2, _table x3}
+   {system_time_start x1, system_time_end x2}
    [:select
     (if
      (>
@@ -21,5 +21,4 @@
        #time/date "3001-01-01")
       (<= system_time_start #time/date "3001-01-01")
       (> system_time_end #time/zoned-date-time "3002-01-01T00:00Z")))
-    [:scan
-     [system_time_start system_time_end {_table (= _table "t1")}]]]]]]
+    [:scan t1 [system_time_start system_time_end]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/system-time-from-a-to-b.edn
+++ b/test-resources/core2/sql/plan_test_expectations/system-time-from-a-to-b.edn
@@ -3,14 +3,14 @@
  [:project
   [x3]
   [:rename
-   {system_time_start x1, system_time_end x2, bar x3, _table x4}
+   {system_time_start x1, system_time_end x2, bar x3}
    [:select
     (<
      #time/date "2999-01-01"
      #time/zoned-date-time "3000-01-01T00:00Z")
     [:scan
+     foo
      [{system_time_start
        (< system_time_start #time/zoned-date-time "3000-01-01T00:00Z")}
       {system_time_end (> system_time_end #time/date "2999-01-01")}
-      bar
-      {_table (= _table "foo")}]]]]]]
+      bar]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-app-time-correlated-subquery-projection.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-app-time-correlated-subquery-projection.edn
@@ -1,21 +1,15 @@
 [:rename
- {x9 $column_1$}
+ {x7 $column_1$}
  [:project
-  [x9]
+  [x7]
   [:apply
    :single-join
-   {x1 ?x10, x2 ?x11}
+   {x1 ?x8, x2 ?x9}
    [:rename
-    {application_time_start x1, application_time_end x2, _table x3}
-    [:scan
-     [application_time_start
-      application_time_end
-      {_table (= _table "bar")}]]]
+    {application_time_start x1, application_time_end x2}
+    [:scan bar [application_time_start application_time_end]]]
    [:project
-    [{x9 (and (< x5 ?x11) (> x6 ?x10))}]
+    [{x7 (and (< x4 ?x9) (> x5 ?x8))}]
     [:rename
-     {application_time_start x5, application_time_end x6, _table x7}
-     [:scan
-      [application_time_start
-       application_time_end
-       {_table (= _table "foo")}]]]]]]]
+     {application_time_start x4, application_time_end x5}
+     [:scan foo [application_time_start application_time_end]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-app-time-correlated-subquery-where.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-app-time-correlated-subquery-where.edn
@@ -1,25 +1,19 @@
 [:rename
- {x5 name}
+ {x4 name}
  [:project
-  [x5]
+  [x4]
   [:apply
    :single-join
-   {x1 ?x10, x2 ?x11}
+   {x1 ?x8, x2 ?x9}
    [:rename
-    {application_time_start x1, application_time_end x2, _table x3}
-    [:scan
-     [application_time_start
-      application_time_end
-      {_table (= _table "bar")}]]]
+    {application_time_start x1, application_time_end x2}
+    [:scan bar [application_time_start application_time_end]]]
    [:project
-    [x5]
+    [x4]
     [:rename
-     {name x5,
-      application_time_start x6,
-      application_time_end x7,
-      _table x8}
+     {name x4, application_time_start x5, application_time_end x6}
      [:scan
+      foo
       [name
-       {application_time_start (< application_time_start ?x11)}
-       {application_time_end (> application_time_end ?x10)}
-       {_table (= _table "foo")}]]]]]]]
+       {application_time_start (< application_time_start ?x9)}
+       {application_time_end (> application_time_end ?x8)}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-application-and-app-time-from-same-table.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-application-and-app-time-from-same-table.edn
@@ -3,16 +3,9 @@
  [:project
   [x1]
   [:rename
-   {name x1,
-    application_time_start x2,
-    application_time_end x3,
-    _table x4}
+   {name x1, application_time_start x2, application_time_end x3}
    [:select
     (and
      (< application_time_start application_time_end)
      (> application_time_end application_time_start))
-    [:scan
-     [name
-      application_time_start
-      application_time_end
-      {_table (= _table "foo")}]]]]]]
+    [:scan foo [name application_time_start application_time_end]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-array-element-reference-107-1.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-array-element-reference-107-1.edn
@@ -1,5 +1,3 @@
 [:rename
- {x4 first_el}
- [:project
-  [{x4 (nth x1 (- 1 1))}]
-  [:rename {a x1, _table x2} [:scan [a {_table (= _table "u")}]]]]]
+ {x3 first_el}
+ [:project [{x3 (nth x1 (- 1 1))}] [:rename {a x1} [:scan u [a]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-array-element-reference-107-2.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-array-element-reference-107-2.edn
@@ -1,7 +1,5 @@
 [:rename
- {x5 dyn_idx}
+ {x4 dyn_idx}
  [:project
-  [{x5 (nth x1 (- (nth x2 (- 1 1)) 1))}]
-  [:rename
-   {b x1, a x2, _table x3}
-   [:scan [b a {_table (= _table "u")}]]]]]
+  [{x4 (nth x1 (- (nth x2 (- 1 1)) 1))}]
+  [:rename {b x1, a x2} [:scan u [b a]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-array-subquery1.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-array-subquery1.edn
@@ -1,14 +1,10 @@
 [:rename
- {x8 $column_1$}
+ {x6 $column_1$}
  [:project
-  [x8]
+  [x6]
   [:mega-join
    []
-   [[:rename
-     {a x1, _table x2}
-     [:scan [{a (= a 42)} {_table (= _table "a")}]]]
+   [[:rename {a x1} [:scan a [{a (= a 42)}]]]
     [:group-by
-     [{x8 (array-agg x4)}]
-     [:rename
-      {b1 x4, b2 x5, _table x6}
-      [:scan [b1 {b2 (= b2 42)} {_table (= _table "b")}]]]]]]]]
+     [{x6 (array-agg x3)}]
+     [:rename {b1 x3, b2 x4} [:scan b [b1 {b2 (= b2 42)}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-array-subquery2.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-array-subquery2.edn
@@ -1,16 +1,12 @@
 [:rename
- {x9 $column_1$}
+ {x7 $column_1$}
  [:project
-  [x9]
+  [x7]
   [:group-by
-   [x1 x2 x3 $row_number$ {x9 (array-agg x5)}]
+   [x1 x2 $row_number$ {x7 (array-agg x4)}]
    [:mega-join
-    [{x1 x6}]
+    [{x1 x5}]
     [[:map
       [{$row_number$ (row-number)}]
-      [:rename
-       {b x1, a x2, _table x3}
-       [:scan [b {a (= a 42)} {_table (= _table "a")}]]]]
-     [:rename
-      {b1 x5, b2 x6, _table x7}
-      [:scan [b1 b2 {_table (= _table "b")}]]]]]]]]
+      [:rename {b x1, a x2} [:scan a [b {a (= a 42)}]]]]
+     [:rename {b1 x4, b2 x5} [:scan b [b1 b2]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-current-time-111.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-current-time-111.edn
@@ -1,27 +1,27 @@
 [:rename
  {x1 a,
-  x8 $column_6$,
-  x13 $column_11$,
-  x5 $column_3$,
-  x9 $column_7$,
-  x12 $column_10$,
-  x14 $column_12$,
-  x10 $column_8$,
-  x4 $column_2$,
-  x6 $column_4$,
-  x11 $column_9$,
-  x7 $column_5$}
+  x8 $column_7$,
+  x13 $column_12$,
+  x5 $column_4$,
+  x9 $column_8$,
+  x12 $column_11$,
+  x10 $column_9$,
+  x4 $column_3$,
+  x6 $column_5$,
+  x11 $column_10$,
+  x7 $column_6$,
+  x3 $column_2$}
  [:project
   [x1
-   {x4 (current-time)}
-   {x5 (current-time 2)}
-   {x6 (current-date)}
-   {x7 (current-timestamp)}
-   {x8 (current-timestamp 4)}
-   {x9 (local-time)}
-   {x10 (local-time 6)}
-   {x11 (local-timestamp)}
-   {x12 (local-timestamp 9)}
-   {x13 core2/end-of-time}
-   {x14 core2/end-of-time}]
-  [:rename {a x1, _table x2} [:scan [a {_table (= _table "u")}]]]]]
+   {x3 (current-time)}
+   {x4 (current-time 2)}
+   {x5 (current-date)}
+   {x6 (current-timestamp)}
+   {x7 (current-timestamp 4)}
+   {x8 (local-time)}
+   {x9 (local-time 6)}
+   {x10 (local-timestamp)}
+   {x11 (local-timestamp 9)}
+   {x12 core2/end-of-time}
+   {x13 core2/end-of-time}]
+  [:rename {a x1} [:scan u [a]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-derived-columns-with-periods-period-predicate.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-derived-columns-with-periods-period-predicate.edn
@@ -1,16 +1,15 @@
 [:rename
- {x7 $column_1$}
+ {x6 $column_1$}
  [:project
-  [{x7 (and (< x3 x2) (> x4 x1))}]
+  [{x6 (and (< x3 x2) (> x4 x1))}]
   [:rename
    {system_time_start x1,
     system_time_end x2,
     application_time_start x3,
-    application_time_end x4,
-    _table x5}
+    application_time_end x4}
    [:scan
+    foo
     [system_time_start
      system_time_end
      application_time_start
-     application_time_end
-     {_table (= _table "foo")}]]]]]
+     application_time_end]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-derived-columns-with-periods-period-specs.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-derived-columns-with-periods-period-specs.edn
@@ -7,14 +7,13 @@
     system_time_end x2,
     application_time_start x3,
     application_time_end x4,
-    bar x5,
-    _table x6}
+    bar x5}
    [:scan
+    foo
     [{system_time_start (<= system_time_start (current-timestamp))}
      {system_time_end (> system_time_end (current-timestamp))}
      {application_time_start
       (<= application_time_start (current-timestamp))}
      {application_time_end
       (> application_time_end (current-timestamp))}
-     bar
-     {_table (= _table "foo")}]]]]]
+     bar]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-1.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-1.edn
@@ -3,5 +3,5 @@
  [:project
   [x1]
   [:rename
-   {a x1, b x2, c x3, _table x4}
-   [:scan [a {b (= b ?_0)} {c (= c ?_1)} {_table (= _table "foo")}]]]]]
+   {a x1, b x2, c x3}
+   [:scan foo [a {b (= b ?_0)} {c (= c ?_1)}]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-2.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-2.edn
@@ -5,10 +5,8 @@
   [:mega-join
    []
    [[:rename
-     {a x1, b x2, c x3, _table x4}
-     [:scan [a {b (= b ?_1)} {c (= c ?_2)} {_table (= _table "foo")}]]]
+     {a x1, b x2, c x3}
+     [:scan foo [a {b (= b ?_1)} {c (= c ?_2)}]]]
     [:project
-     [x6]
-     [:rename
-      {b x6, c x7, _table x8}
-      [:scan [b {c (= c ?_0)} {_table (= _table "bar")}]]]]]]]]
+     [x5]
+     [:rename {b x5, c x6} [:scan bar [b {c (= c ?_0)}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-subquery-project.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-subquery-project.edn
@@ -1,14 +1,8 @@
 [:rename
- {x1 col1, x7 $column_2$}
- [:project
-  [x1 x7]
-  [:single-join
-   []
-   [:rename
-    {col1 x1, _table x2}
-    [:scan [col1 {_table (= _table "t1")}]]]
-   [:project
-    [{x7 ?_0}]
-    [:rename
-     {col1 x4, _table x5}
-     [:scan [{col1 (= col1 4)} {_table (= _table "bar")}]]]]]]]
+ {x1 col1, x5 $column_2$}
+ [:single-join
+  []
+  [:rename {col1 x1} [:scan t1 [col1]]]
+  [:project
+   [{x5 ?_0}]
+   [:rename {col1 x3} [:scan bar [{col1 (= col1 4)}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-top-level-project.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-top-level-project.edn
@@ -1,7 +1,3 @@
 [:rename
- {x1 col1, x4 $column_2$}
- [:project
-  [x1 {x4 ?_0}]
-  [:rename
-   {col1 x1, _table x2}
-   [:scan [col1 {_table (= _table "t1")}]]]]]
+ {x1 col1, x3 $column_2$}
+ [:project [x1 {x3 ?_0}] [:rename {col1 x1} [:scan t1 [col1]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
@@ -1,33 +1,32 @@
 [:update
  {:table "users"}
  [:rename
-  {x3 _iid,
-   x4 _row-id,
-   x7 system_time_start,
-   x8 system_time_end,
-   x10 first_name,
-   x11 application_time_start,
-   x12 application_time_end}
+  {x2 _iid,
+   x3 _row-id,
+   x6 system_time_start,
+   x7 system_time_end,
+   x9 first_name,
+   x10 application_time_start,
+   x11 application_time_end}
   [:project
-   [x3
-    x4
+   [x2
+    x3
+    x6
     x7
-    x8
-    {x10 ?_2}
-    {x11 (cast-tstz (max x5 ?_0))}
-    {x12 (cast-tstz (min x6 ?_1))}]
+    {x9 ?_2}
+    {x10 (cast-tstz (max x4 ?_0))}
+    {x11 (cast-tstz (min x5 ?_1))}]
    [:rename
-    {_table x1,
-     id x2,
-     _iid x3,
-     _row-id x4,
-     application_time_start x5,
-     application_time_end x6,
-     system_time_start x7,
-     system_time_end x8}
+    {id x1,
+     _iid x2,
+     _row-id x3,
+     application_time_start x4,
+     application_time_end x5,
+     system_time_start x6,
+     system_time_end x7}
     [:scan
-     [{_table (= _table "users")}
-      {id (= id ?_3)}
+     users
+     [{id (= id ?_3)}
       _iid
       _row-id
       {application_time_start (<= application_time_start ?_1)}

--- a/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-update-set-value.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-update-set-value.edn
@@ -1,28 +1,27 @@
 [:update
  {:table "t1"}
  [:rename
-  {x2 _iid,
-   x3 _row-id,
-   x6 system_time_start,
-   x7 system_time_end,
-   x9 col1,
-   x10 application_time_start,
-   x11 application_time_end}
+  {x1 _iid,
+   x2 _row-id,
+   x5 system_time_start,
+   x6 system_time_end,
+   x8 col1,
+   x9 application_time_start,
+   x10 application_time_end}
   [:project
-   [x2 x3 x6 x7 {x9 ?_0} {x10 (cast-tstz x4)} {x11 (cast-tstz x5)}]
+   [x1 x2 x5 x6 {x8 ?_0} {x9 (cast-tstz x3)} {x10 (cast-tstz x4)}]
    [:rename
-    {_table x1,
-     _iid x2,
-     _row-id x3,
-     application_time_start x4,
-     application_time_end x5,
-     system_time_start x6,
-     system_time_end x7}
+    {_iid x1,
+     _row-id x2,
+     application_time_start x3,
+     application_time_end x4,
+     system_time_start x5,
+     system_time_end x6}
     [:scan
-     [{_table (= _table "t1")}
-      _iid
+     t1
+     (_iid
       _row-id
       application_time_start
       application_time_end
       system_time_start
-      system_time_end]]]]]]
+      system_time_end)]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-expr-in-equi-join-1.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-expr-in-equi-join-1.edn
@@ -3,8 +3,5 @@
  [:project
   [x1]
   [:mega-join
-   [{(+ x1 1) (+ x4 1)}]
-   [[:rename {a x1, _table x2} [:scan [a {_table (= _table "a")}]]]
-    [:rename
-     {b x4, _table x5}
-     [:scan [b {_table (= _table "bar")}]]]]]]]
+   [{(+ x1 1) (+ x3 1)}]
+   [[:rename {a x1} [:scan a [a]]] [:rename {b x3} [:scan bar [b]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-expr-in-equi-join-2.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-expr-in-equi-join-2.edn
@@ -3,8 +3,5 @@
  [:project
   [x1]
   [:mega-join
-   [{x1 (+ x4 1)}]
-   [[:rename {a x1, _table x2} [:scan [a {_table (= _table "a")}]]]
-    [:rename
-     {b x4, _table x5}
-     [:scan [b {_table (= _table "bar")}]]]]]]]
+   [{x1 (+ x3 1)}]
+   [[:rename {a x1} [:scan a [a]]] [:rename {b x3} [:scan bar [b]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-for-all-application-time-387-delete.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-for-all-application-time-387-delete.edn
@@ -1,27 +1,26 @@
 [:delete
  {:table "users"}
  [:rename
-  {x2 _iid,
-   x3 _row-id,
-   x6 system_time_start,
-   x7 system_time_end,
-   x9 application_time_start,
-   x10 application_time_end}
+  {x1 _iid,
+   x2 _row-id,
+   x5 system_time_start,
+   x6 system_time_end,
+   x8 application_time_start,
+   x9 application_time_end}
   [:project
-   [x2 x3 x6 x7 {x9 (cast-tstz x4)} {x10 (cast-tstz x5)}]
+   [x1 x2 x5 x6 {x8 (cast-tstz x3)} {x9 (cast-tstz x4)}]
    [:rename
-    {_table x1,
-     _iid x2,
-     _row-id x3,
-     application_time_start x4,
-     application_time_end x5,
-     system_time_start x6,
-     system_time_end x7}
+    {_iid x1,
+     _row-id x2,
+     application_time_start x3,
+     application_time_end x4,
+     system_time_start x5,
+     system_time_end x6}
     [:scan
-     [{_table (= _table "users")}
-      _iid
+     users
+     (_iid
       _row-id
       application_time_start
       application_time_end
       system_time_start
-      system_time_end]]]]]]
+      system_time_end)]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-for-all-application-time-387-query.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-for-all-application-time-387-query.edn
@@ -1,7 +1,1 @@
-[:rename
- {x1 bar}
- [:project
-  [x1]
-  [:rename
-   {bar x1, _table x2}
-   [:scan [bar {_table (= _table "foo")}]]]]]
+[:scan foo [bar]]

--- a/test-resources/core2/sql/plan_test_expectations/test-for-all-application-time-387-update.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-for-all-application-time-387-update.edn
@@ -1,28 +1,27 @@
 [:update
  {:table "users"}
  [:rename
-  {x2 _iid,
-   x3 _row-id,
-   x6 system_time_start,
-   x7 system_time_end,
-   x9 first_name,
-   x10 application_time_start,
-   x11 application_time_end}
+  {x1 _iid,
+   x2 _row-id,
+   x5 system_time_start,
+   x6 system_time_end,
+   x8 first_name,
+   x9 application_time_start,
+   x10 application_time_end}
   [:project
-   [x2 x3 x6 x7 {x9 "Sue"} {x10 (cast-tstz x4)} {x11 (cast-tstz x5)}]
+   [x1 x2 x5 x6 {x8 "Sue"} {x9 (cast-tstz x3)} {x10 (cast-tstz x4)}]
    [:rename
-    {_table x1,
-     _iid x2,
-     _row-id x3,
-     application_time_start x4,
-     application_time_end x5,
-     system_time_start x6,
-     system_time_end x7}
+    {_iid x1,
+     _row-id x2,
+     application_time_start x3,
+     application_time_end x4,
+     system_time_start x5,
+     system_time_end x6}
     [:scan
-     [{_table (= _table "users")}
-      _iid
+     users
+     (_iid
       _row-id
       application_time_start
       application_time_end
       system_time_start
-      system_time_end]]]]]]
+      system_time_end)]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-for-all-application-time-404.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-for-all-application-time-404.edn
@@ -3,9 +3,9 @@
  [:project
   [x3]
   [:rename
-   {system_time_start x1, system_time_end x2, bar x3, _table x4}
+   {system_time_start x1, system_time_end x2, bar x3}
    [:scan
+    foo
     [{system_time_start (<= system_time_start core2/end-of-time)}
      system_time_end
-     bar
-     {_table (= _table "foo")}]]]]]
+     bar]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-group-by-with-projected-column-in-expr.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-group-by-with-projected-column-in-expr.edn
@@ -1,7 +1,5 @@
 [:rename
- {x5 bar}
+ {x4 bar}
  [:project
-  [{x5 (- x1 4)}]
-  [:group-by
-   [x1]
-   [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]]]]
+  [{x4 (- x1 4)}]
+  [:group-by [x1] [:rename {a x1} [:scan foo [a]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-order-by-null-handling-159-1.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-order-by-null-handling-159-1.edn
@@ -2,6 +2,4 @@
  {x1 a}
  [:order-by
   [[x1 {:direction :asc, :null-ordering :nulls-first}]]
-  [:project
-   [x1]
-   [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]]]]
+  [:rename {a x1} [:scan foo [a]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-order-by-null-handling-159-2.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-order-by-null-handling-159-2.edn
@@ -2,6 +2,4 @@
  {x1 a}
  [:order-by
   [[x1 {:direction :asc, :null-ordering :nulls-last}]]
-  [:project
-   [x1]
-   [:rename {a x1, _table x2} [:scan [a {_table (= _table "foo")}]]]]]]
+  [:rename {a x1} [:scan foo [a]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-period-specs-with-dml-subqueries-and-defaults-407.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-period-specs-with-dml-subqueries-and-defaults-407.edn
@@ -1,30 +1,29 @@
 [:insert
  {:table "prop_owner"}
  [:rename
-  {x10 id,
-   x11 customer_number,
-   x12 property_number,
-   x14 application_time_start,
-   x15 application_time_end}
+  {x9 id,
+   x10 customer_number,
+   x11 property_number,
+   x13 application_time_start,
+   x14 application_time_end}
   [:project
-   [x10 x11 x12 {x14 (cast-tstz x13)} {x15 (cast-tstz x8)}]
+   [x9 x10 x11 {x13 (cast-tstz x12)} {x14 (cast-tstz x7)}]
    [:project
-    [{x10 1} {x11 145} {x12 7797} {x13 #time/date "1998-01-03"} x8]
+    [{x9 1} {x10 145} {x11 7797} {x12 #time/date "1998-01-03"} x7]
     [:group-by
-     [{x8 (min x1)}]
+     [{x7 (min x1)}]
      [:rename
       {system_time_start x1,
        system_time_end x2,
        application_time_start x3,
        application_time_end x4,
-       id x5,
-       _table x6}
+       id x5}
       [:scan
+       prop_owner
        [{system_time_start (<= system_time_start core2/end-of-time)}
         system_time_end
         {application_time_start
          (<= application_time_start (current-timestamp))}
         {application_time_end
          (> application_time_end (current-timestamp))}
-        {id (= id 1)}
-        {_table (= _table "prop_owner")}]]]]]]]]
+        {id (= id 1)}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-period-specs-with-subqueries-407-app-time.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-period-specs-with-subqueries-407-app-time.edn
@@ -1,16 +1,13 @@
 [:rename
- {x6 $column_1$}
+ {x5 $column_1$}
  [:project
-  [{x6 1}]
+  [{x5 1}]
   [:rename
-   {application_time_start x1,
-    application_time_end x2,
-    bar x3,
-    _table x4}
+   {application_time_start x1, application_time_end x2, bar x3}
    [:scan
+    foo
     [{application_time_start
       (<= application_time_start (current-timestamp))}
      {application_time_end
       (> application_time_end (current-timestamp))}
-     bar
-     {_table (= _table "foo")}]]]]]
+     bar]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-period-specs-with-subqueries-407-sys-time.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-period-specs-with-subqueries-407-sys-time.edn
@@ -1,11 +1,11 @@
 [:rename
- {x6 $column_1$}
+ {x5 $column_1$}
  [:project
-  [{x6 1}]
+  [{x5 1}]
   [:rename
-   {system_time_start x1, system_time_end x2, bar x3, _table x4}
+   {system_time_start x1, system_time_end x2, bar x3}
    [:scan
+    foo
     [{system_time_start (<= system_time_start core2/end-of-time)}
      system_time_end
-     bar
-     {_table (= _table "foo")}]]]]]
+     bar]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q1-pricing-summary-report.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q1-pricing-summary-report.edn
@@ -1,30 +1,30 @@
 [:rename
  {x1 l_returnflag,
-  x13 sum_qty,
+  x13 sum_base_price,
   x2 l_linestatus,
-  x20 count_order,
-  x14 sum_base_price,
-  x17 avg_qty,
-  x15 sum_disc_price,
-  x16 sum_charge,
-  x18 avg_price,
-  x19 avg_disc}
+  x12 sum_qty,
+  x14 sum_disc_price,
+  x17 avg_price,
+  x15 sum_charge,
+  x16 avg_qty,
+  x18 avg_disc,
+  x19 count_order}
  [:order-by
   [[x1 {:direction :asc, :null-ordering :nulls-last}]
    [x2 {:direction :asc, :null-ordering :nulls-last}]]
   [:group-by
    [x1
     x2
-    {x13 (sum x3)}
-    {x14 (sum x4)}
+    {x12 (sum x3)}
+    {x13 (sum x4)}
+    {x14 (sum x9)}
     {x15 (sum x10)}
-    {x16 (sum x11)}
-    {x17 (avg x3)}
-    {x18 (avg x4)}
-    {x19 (avg x5)}
-    {x20 (count x12)}]
+    {x16 (avg x3)}
+    {x17 (avg x4)}
+    {x18 (avg x5)}
+    {x19 (count x11)}]
    [:map
-    [{x10 (* x4 (- 1 x5))} {x11 (* (* x4 (- 1 x5)) (+ 1 x6))} {x12 1}]
+    [{x9 (* x4 (- 1 x5))} {x10 (* (* x4 (- 1 x5)) (+ 1 x6))} {x11 1}]
     [:rename
      {l_returnflag x1,
       l_linestatus x2,
@@ -32,9 +32,9 @@
       l_extendedprice x4,
       l_discount x5,
       l_tax x6,
-      l_shipdate x7,
-      _table x8}
+      l_shipdate x7}
      [:scan
+      lineitem
       [l_returnflag
        l_linestatus
        l_quantity
@@ -46,5 +46,4 @@
          l_shipdate
          (-
           #time/date "1998-12-01"
-          (single-field-interval "90" "DAY" 2 0)))}
-       {_table (= _table "lineitem")}]]]]]]]
+          (single-field-interval "90" "DAY" 2 0)))}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q10-returned-item-reporting.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q10-returned-item-reporting.edn
@@ -1,39 +1,38 @@
 [:rename
  {x1 c_custkey,
   x2 c_name,
-  x26 revenue,
+  x22 revenue,
   x3 c_acctbal,
-  x21 n_name,
+  x18 n_name,
   x4 c_address,
   x5 c_phone,
   x6 c_comment}
  [:project
-  [x1 x2 x26 x3 x21 x4 x5 x6]
+  [x1 x2 x22 x3 x18 x4 x5 x6]
   [:top
    {:limit 20}
    [:order-by
-    [[x26 {:direction :desc, :null-ordering :nulls-last}]]
+    [[x22 {:direction :desc, :null-ordering :nulls-last}]]
     [:group-by
-     [x1 x2 x3 x5 x21 x4 x6 {x26 (sum x25)}]
+     [x1 x2 x3 x5 x18 x4 x6 {x22 (sum x21)}]
      [:map
-      [{x25 (* x15 (- 1 x16))}]
+      [{x21 (* x13 (- 1 x14))}]
       [:mega-join
-       [{x7 x22} {x11 x17} {x1 x10}]
+       [{x7 x19} {x10 x15} {x1 x9}]
        [[:rename
-         {n_name x21, n_nationkey x22, _table x23}
-         [:scan [n_name n_nationkey {_table (= _table "nation")}]]]
+         {n_name x18, n_nationkey x19}
+         [:scan nation [n_name n_nationkey]]]
         [:rename
-         {l_extendedprice x15,
-          l_discount x16,
-          l_orderkey x17,
-          l_returnflag x18,
-          _table x19}
+         {l_extendedprice x13,
+          l_discount x14,
+          l_orderkey x15,
+          l_returnflag x16}
          [:scan
+          lineitem
           [l_extendedprice
            l_discount
            l_orderkey
-           {l_returnflag (= l_returnflag "R")}
-           {_table (= _table "lineitem")}]]]
+           {l_returnflag (= l_returnflag "R")}]]]
         [:rename
          {c_custkey x1,
           c_name x2,
@@ -41,20 +40,20 @@
           c_address x4,
           c_phone x5,
           c_comment x6,
-          c_nationkey x7,
-          _table x8}
+          c_nationkey x7}
          [:scan
+          customer
           [c_custkey
            c_name
            c_acctbal
            c_address
            c_phone
            c_comment
-           c_nationkey
-           {_table (= _table "customer")}]]]
+           c_nationkey]]]
         [:rename
-         {o_custkey x10, o_orderkey x11, o_orderdate x12, _table x13}
+         {o_custkey x9, o_orderkey x10, o_orderdate x11}
          [:scan
+          orders
           [o_custkey
            o_orderkey
            {o_orderdate
@@ -64,5 +63,4 @@
               (+
                #time/date "1993-10-01"
                (single-field-interval "3" "MONTH" 2 0)))
-             (>= o_orderdate #time/date "1993-10-01"))}
-           {_table (= _table "orders")}]]]]]]]]]]]
+             (>= o_orderdate #time/date "1993-10-01"))}]]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q11-important-stock-identification.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q11-important-stock-identification.edn
@@ -1,68 +1,47 @@
 [:rename
- {x1 ps_partkey, x17 value}
+ {x1 ps_partkey, x14 value}
  [:order-by
-  [[x17 {:direction :desc, :null-ordering :nulls-last}]]
+  [[x14 {:direction :desc, :null-ordering :nulls-last}]]
   [:project
-   [x1 x17]
+   [x1 x14]
    [:select
-    (> x18 x36)
+    (> x15 x30)
     [:single-join
      []
      [:group-by
-      [x1 {x17 (sum x15)} {x18 (sum x16)}]
+      [x1 {x14 (sum x12)} {x15 (sum x13)}]
       [:map
-       [{x15 (* x2 x3)} {x16 (* x2 x3)}]
+       [{x12 (* x2 x3)} {x13 (* x2 x3)}]
        [:mega-join
-        ({x8 x11} {x4 x7})
+        [{x7 x9} {x4 x6}]
         [[:rename
-          {n_nationkey x11, n_name x12, _table x13}
-          [:scan
-           [n_nationkey
-            {n_name (= n_name "GERMANY")}
-            {_table (= _table "nation")}]]]
+          {n_nationkey x9, n_name x10}
+          [:scan nation [n_nationkey {n_name (= n_name "GERMANY")}]]]
          [:rename
           {ps_partkey x1,
            ps_supplycost x2,
            ps_availqty x3,
-           ps_suppkey x4,
-           _table x5}
+           ps_suppkey x4}
           [:scan
-           [ps_partkey
-            ps_supplycost
-            ps_availqty
-            ps_suppkey
-            {_table (= _table "partsupp")}]]]
+           partsupp
+           [ps_partkey ps_supplycost ps_availqty ps_suppkey]]]
          [:rename
-          {s_suppkey x7, s_nationkey x8, _table x9}
-          [:scan
-           [s_suppkey s_nationkey {_table (= _table "supplier")}]]]]]]]
+          {s_suppkey x6, s_nationkey x7}
+          [:scan supplier [s_suppkey s_nationkey]]]]]]]
      [:project
-      [{x36 (* x34 1.0E-4)}]
+      [{x30 (* x28 1.0E-4)}]
       [:group-by
-       [{x34 (sum x33)}]
+       [{x28 (sum x27)}]
        [:map
-        [{x33 (* x20 x21)}]
+        [{x27 (* x17 x18)}]
         [:mega-join
-         ({x26 x29} {x22 x25})
+         [{x22 x24} {x19 x21}]
          [[:rename
-           {n_nationkey x29, n_name x30, _table x31}
-           [:scan
-            [n_nationkey
-             {n_name (= n_name "GERMANY")}
-             {_table (= _table "nation")}]]]
+           {n_nationkey x24, n_name x25}
+           [:scan nation [n_nationkey {n_name (= n_name "GERMANY")}]]]
           [:rename
-           {ps_supplycost x20,
-            ps_availqty x21,
-            ps_suppkey x22,
-            _table x23}
-           [:scan
-            [ps_supplycost
-             ps_availqty
-             ps_suppkey
-             {_table (= _table "partsupp")}]]]
+           {ps_supplycost x17, ps_availqty x18, ps_suppkey x19}
+           [:scan partsupp [ps_supplycost ps_availqty ps_suppkey]]]
           [:rename
-           {s_suppkey x25, s_nationkey x26, _table x27}
-           [:scan
-            [s_suppkey
-             s_nationkey
-             {_table (= _table "supplier")}]]]]]]]]]]]]]
+           {s_suppkey x21, s_nationkey x22}
+           [:scan supplier [s_suppkey s_nationkey]]]]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q12-shipping-modes-and-order-priority.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q12-shipping-modes-and-order-priority.edn
@@ -1,32 +1,31 @@
 [:rename
- {x5 l_shipmode, x17 high_line_count, x18 low_line_count}
+ {x4 l_shipmode, x15 high_line_count, x16 low_line_count}
  [:order-by
-  [[x5 {:direction :asc, :null-ordering :nulls-last}]]
+  [[x4 {:direction :asc, :null-ordering :nulls-last}]]
   [:group-by
-   [x5 {x17 (sum x15)} {x18 (sum x16)}]
+   [x4 {x15 (sum x13)} {x16 (sum x14)}]
    [:map
-    [{x15 (cond (or (= x1 "1-URGENT") (= x1 "2-HIGH")) 1 0)}
-     {x16 (cond (and (<> x1 "1-URGENT") (<> x1 "2-HIGH")) 1 0)}]
+    [{x13 (cond (or (= x1 "1-URGENT") (= x1 "2-HIGH")) 1 0)}
+     {x14 (cond (and (<> x1 "1-URGENT") (<> x1 "2-HIGH")) 1 0)}]
     [:mega-join
-     [{x2 x6}]
+     [{x2 x5}]
      [[:rename
-       {o_orderpriority x1, o_orderkey x2, _table x3}
-       [:scan
-        [o_orderpriority o_orderkey {_table (= _table "orders")}]]]
+       {o_orderpriority x1, o_orderkey x2}
+       [:scan orders [o_orderpriority o_orderkey]]]
       [:semi-join
-       [{x5 x12}]
+       [{x4 x10}]
        [:rename
-        {l_shipmode x5,
-         l_orderkey x6,
-         l_commitdate x7,
-         l_receiptdate x8,
-         l_shipdate x9,
-         _table x10}
+        {l_shipmode x4,
+         l_orderkey x5,
+         l_commitdate x6,
+         l_receiptdate x7,
+         l_shipdate x8}
         [:select
          (and
           (< l_commitdate l_receiptdate)
           (< l_shipdate l_commitdate))
          [:scan
+          lineitem
           [l_shipmode
            l_orderkey
            l_commitdate
@@ -38,6 +37,5 @@
                #time/date "1994-01-01"
                (single-field-interval "1" "YEAR" 2 0)))
              (>= l_receiptdate #time/date "1994-01-01"))}
-           l_shipdate
-           {_table (= _table "lineitem")}]]]]
-       [:table [x12] [{x12 "MAIL"} {x12 "SHIP"}]]]]]]]]]
+           l_shipdate]]]]
+       [:table [x10] [{x10 "MAIL"} {x10 "SHIP"}]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q13-customer-distribution.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q13-customer-distribution.edn
@@ -1,23 +1,22 @@
 [:rename
- {x10 c_count, x13 custdist}
+ {x8 c_count, x11 custdist}
  [:order-by
-  [[x13 {:direction :desc, :null-ordering :nulls-last}]
-   [x10 {:direction :desc, :null-ordering :nulls-last}]]
+  [[x11 {:direction :desc, :null-ordering :nulls-last}]
+   [x8 {:direction :desc, :null-ordering :nulls-last}]]
   [:group-by
-   [x10 {x13 (count x12)}]
+   [x8 {x11 (count x10)}]
    [:map
-    [{x12 1}]
+    [{x10 1}]
     [:group-by
-     [x1 {x10 (count x4)}]
+     [x1 {x8 (count x3)}]
      [:left-outer-join
-      [{x1 x5}]
+      [{x1 x4}]
+      [:rename {c_custkey x1} [:scan customer [c_custkey]]]
       [:rename
-       {c_custkey x1, _table x2}
-       [:scan [c_custkey {_table (= _table "customer")}]]]
-      [:rename
-       {o_orderkey x4, o_custkey x5, o_comment x6, _table x7}
+       {o_orderkey x3, o_custkey x4, o_comment x5}
        [:scan
+        orders
         [o_orderkey
          o_custkey
-         {o_comment (not (like o_comment "%special%requests%"))}
-         {_table (= _table "orders")}]]]]]]]]]
+         {o_comment
+          (not (like o_comment "%special%requests%"))}]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q14-promotion-effect.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q14-promotion-effect.edn
@@ -1,21 +1,18 @@
 [:rename
- {x16 promo_revenue}
+ {x14 promo_revenue}
  [:project
-  [{x16 (/ (* 100.0 x13) x14)}]
+  [{x14 (/ (* 100.0 x11) x12)}]
   [:group-by
-   [{x13 (sum x11)} {x14 (sum x12)}]
+   [{x11 (sum x9)} {x12 (sum x10)}]
    [:map
-    [{x11 (cond (like x7 "PROMO%") (* x1 (- 1 x2)) 0)}
-     {x12 (* x1 (- 1 x2))}]
+    [{x9 (cond (like x6 "PROMO%") (* x1 (- 1 x2)) 0)}
+     {x10 (* x1 (- 1 x2))}]
     [:mega-join
-     [{x3 x8}]
+     [{x3 x7}]
      [[:rename
-       {l_extendedprice x1,
-        l_discount x2,
-        l_partkey x3,
-        l_shipdate x4,
-        _table x5}
+       {l_extendedprice x1, l_discount x2, l_partkey x3, l_shipdate x4}
        [:scan
+        lineitem
         [l_extendedprice
          l_discount
          l_partkey
@@ -26,8 +23,7 @@
             (+
              #time/date "1995-09-01"
              (single-field-interval "1" "MONTH" 2 0)))
-           (>= l_shipdate #time/date "1995-09-01"))}
-         {_table (= _table "lineitem")}]]]
+           (>= l_shipdate #time/date "1995-09-01"))}]]]
       [:rename
-       {p_type x7, p_partkey x8, _table x9}
-       [:scan [p_type p_partkey {_table (= _table "part")}]]]]]]]]]
+       {p_type x6, p_partkey x7}
+       [:scan part [p_type p_partkey]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q15-top-supplier.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q15-top-supplier.edn
@@ -1,34 +1,29 @@
 [:rename
- {x1 s_suppkey, x2 s_name, x3 s_address, x4 s_phone, x14 total_revenue}
+ {x1 s_suppkey, x2 s_name, x3 s_address, x4 s_phone, x12 total_revenue}
  [:order-by
   [[x1 {:direction :asc, :null-ordering :nulls-last}]]
   [:project
-   [x1 x2 x3 x4 x14]
+   [x1 x2 x3 x4 x12]
    [:select
-    (= x14 x25)
+    (= x12 x22)
     [:single-join
      []
      [:mega-join
-      [{x1 x7}]
+      [{x1 x6}]
       [[:rename
-        {s_suppkey x1, s_name x2, s_address x3, s_phone x4, _table x5}
-        [:scan
-         [s_suppkey
-          s_name
-          s_address
-          s_phone
-          {_table (= _table "supplier")}]]]
+        {s_suppkey x1, s_name x2, s_address x3, s_phone x4}
+        [:scan supplier [s_suppkey s_name s_address s_phone]]]
        [:group-by
-        [x7 {x14 (sum x13)}]
+        [x6 {x12 (sum x11)}]
         [:map
-         [{x13 (* x8 (- 1 x9))}]
+         [{x11 (* x7 (- 1 x8))}]
          [:rename
-          {l_suppkey x7,
-           l_extendedprice x8,
-           l_discount x9,
-           l_shipdate x10,
-           _table x11}
+          {l_suppkey x6,
+           l_extendedprice x7,
+           l_discount x8,
+           l_shipdate x9}
           [:scan
+           lineitem
            [l_suppkey
             l_extendedprice
             l_discount
@@ -39,21 +34,20 @@
                (+
                 #time/date "1996-01-01"
                 (single-field-interval "3" "MONTH" 2 0)))
-              (>= l_shipdate #time/date "1996-01-01"))}
-            {_table (= _table "lineitem")}]]]]]]]
+              (>= l_shipdate #time/date "1996-01-01"))}]]]]]]]
      [:group-by
-      [{x25 (max x23)}]
+      [{x22 (max x20)}]
       [:group-by
-       [x16 {x23 (sum x22)}]
+       [x14 {x20 (sum x19)}]
        [:map
-        [{x22 (* x17 (- 1 x18))}]
+        [{x19 (* x15 (- 1 x16))}]
         [:rename
-         {l_suppkey x16,
-          l_extendedprice x17,
-          l_discount x18,
-          l_shipdate x19,
-          _table x20}
+         {l_suppkey x14,
+          l_extendedprice x15,
+          l_discount x16,
+          l_shipdate x17}
          [:scan
+          lineitem
           [l_suppkey
            l_extendedprice
            l_discount
@@ -64,5 +58,4 @@
               (+
                #time/date "1996-01-01"
                (single-field-interval "3" "MONTH" 2 0)))
-             (>= l_shipdate #time/date "1996-01-01"))}
-           {_table (= _table "lineitem")}]]]]]]]]]]]
+             (>= l_shipdate #time/date "1996-01-01"))}]]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q16-part-supplier-relationship.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q16-part-supplier-relationship.edn
@@ -1,42 +1,42 @@
 [:rename
- {x5 p_brand, x6 p_type, x7 p_size, x19 supplier_cnt}
+ {x4 p_brand, x5 p_type, x6 p_size, x16 supplier_cnt}
  [:order-by
-  [[x19 {:direction :desc, :null-ordering :nulls-last}]
+  [[x16 {:direction :desc, :null-ordering :nulls-last}]
+   [x4 {:direction :asc, :null-ordering :nulls-last}]
    [x5 {:direction :asc, :null-ordering :nulls-last}]
-   [x6 {:direction :asc, :null-ordering :nulls-last}]
-   [x7 {:direction :asc, :null-ordering :nulls-last}]]
+   [x6 {:direction :asc, :null-ordering :nulls-last}]]
   [:group-by
-   [x5 x6 x7 {x19 (count-distinct x1)}]
+   [x4 x5 x6 {x16 (count-distinct x1)}]
    [:mega-join
-    [{x2 x8}]
+    [{x2 x7}]
     [[:anti-join
-      [(or (= x1 x14) (nil? x1) (nil? x14))]
+      [(or (= x1 x12) (nil? x1) (nil? x12))]
       [:rename
-       {ps_suppkey x1, ps_partkey x2, _table x3}
-       [:scan [ps_suppkey ps_partkey {_table (= _table "partsupp")}]]]
+       {ps_suppkey x1, ps_partkey x2}
+       [:scan partsupp [ps_suppkey ps_partkey]]]
       [:rename
-       {s_suppkey x14, s_comment x15, _table x16}
+       {s_suppkey x12, s_comment x13}
        [:scan
+        supplier
         [s_suppkey
-         {s_comment (like s_comment "%Customer%Complaints%")}
-         {_table (= _table "supplier")}]]]]
+         {s_comment (like s_comment "%Customer%Complaints%")}]]]]
      [:semi-join
-      [{x7 x11}]
+      [{x6 x9}]
       [:rename
-       {p_brand x5, p_type x6, p_size x7, p_partkey x8, _table x9}
+       {p_brand x4, p_type x5, p_size x6, p_partkey x7}
        [:scan
+        part
         [{p_brand (<> p_brand "Brand#45")}
          {p_type (not (like p_type "MEDIUM POLISHED%"))}
          p_size
-         p_partkey
-         {_table (= _table "part")}]]]
+         p_partkey]]]
       [:table
-       [x11]
-       [{x11 49}
-        {x11 14}
-        {x11 23}
-        {x11 45}
-        {x11 19}
-        {x11 3}
-        {x11 36}
-        {x11 9}]]]]]]]]
+       [x9]
+       [{x9 49}
+        {x9 14}
+        {x9 23}
+        {x9 45}
+        {x9 19}
+        {x9 3}
+        {x9 36}
+        {x9 9}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q17-small-quantity-order-revenue.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q17-small-quantity-order-revenue.edn
@@ -1,36 +1,31 @@
 [:rename
- {x21 avg_yearly}
+ {x18 avg_yearly}
  [:project
-  [{x21 (/ x19 7.0)}]
+  [{x18 (/ x16 7.0)}]
   [:group-by
-   [{x19 (sum x1)}]
+   [{x16 (sum x1)}]
    [:select
-    (< x3 x17)
+    (< x3 x14)
     [:map
-     [{x17 (* 0.2 x15)}]
+     [{x14 (* 0.2 x12)}]
      [:group-by
-      [x1 x2 x3 x4 x6 x7 x8 x9 $row_number$ {x15 (avg x11)}]
+      [x1 x2 x3 x5 x6 x7 $row_number$ {x12 (avg x9)}]
       [:left-outer-join
-       [{x6 x12}]
+       [{x5 x10}]
        [:map
         [{$row_number$ (row-number)}]
         [:mega-join
-         [{x2 x6}]
+         [{x2 x5}]
          [[:rename
-           {l_extendedprice x1, l_partkey x2, l_quantity x3, _table x4}
-           [:scan
-            [l_extendedprice
-             l_partkey
-             l_quantity
-             {_table (= _table "lineitem")}]]]
+           {l_extendedprice x1, l_partkey x2, l_quantity x3}
+           [:scan lineitem [l_extendedprice l_partkey l_quantity]]]
           [:rename
-           {p_partkey x6, p_brand x7, p_container x8, _table x9}
+           {p_partkey x5, p_brand x6, p_container x7}
            [:scan
+            part
             [p_partkey
              {p_brand (= p_brand "Brand#23")}
-             {p_container (= p_container "MED BOX")}
-             {_table (= _table "part")}]]]]]]
+             {p_container (= p_container "MED BOX")}]]]]]]
        [:rename
-        {l_quantity x11, l_partkey x12, _table x13}
-        [:scan
-         [l_quantity l_partkey {_table (= _table "lineitem")}]]]]]]]]]]
+        {l_quantity x9, l_partkey x10}
+        [:scan lineitem [l_quantity l_partkey]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q18-large-volume-customer.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q18-large-volume-customer.edn
@@ -1,46 +1,34 @@
 [:rename
  {x1 c_name,
   x2 c_custkey,
-  x5 o_orderkey,
-  x6 o_orderdate,
-  x7 o_totalprice,
-  x22 sum_qty}
+  x4 o_orderkey,
+  x5 o_orderdate,
+  x6 o_totalprice,
+  x18 sum_qty}
  [:top
   {:limit 100}
   [:order-by
-   [[x7 {:direction :desc, :null-ordering :nulls-last}]
-    [x6 {:direction :asc, :null-ordering :nulls-last}]]
+   [[x6 {:direction :desc, :null-ordering :nulls-last}]
+    [x5 {:direction :asc, :null-ordering :nulls-last}]]
    [:group-by
-    [x1 x2 x5 x6 x7 {x22 (sum x11)}]
+    [x1 x2 x4 x5 x6 {x18 (sum x9)}]
     [:mega-join
-     ({x5 x12} {x2 x8})
+     [{x4 x10} {x2 x7}]
      [[:rename
-       {l_quantity x11, l_orderkey x12, _table x13}
-       [:scan [l_quantity l_orderkey {_table (= _table "lineitem")}]]]
+       {l_quantity x9, l_orderkey x10}
+       [:scan lineitem [l_quantity l_orderkey]]]
       [:rename
-       {c_name x1, c_custkey x2, _table x3}
-       [:scan [c_name c_custkey {_table (= _table "customer")}]]]
+       {c_name x1, c_custkey x2}
+       [:scan customer [c_name c_custkey]]]
       [:semi-join
-       [{x5 x15}]
+       [{x4 x12}]
        [:rename
-        {o_orderkey x5,
-         o_orderdate x6,
-         o_totalprice x7,
-         o_custkey x8,
-         _table x9}
-        [:scan
-         [o_orderkey
-          o_orderdate
-          o_totalprice
-          o_custkey
-          {_table (= _table "orders")}]]]
+        {o_orderkey x4, o_orderdate x5, o_totalprice x6, o_custkey x7}
+        [:scan orders [o_orderkey o_orderdate o_totalprice o_custkey]]]
        [:select
-        (> x19 300)
+        (> x15 300)
         [:group-by
-         [x15 {x19 (sum x16)}]
+         [x12 {x15 (sum x13)}]
          [:rename
-          {l_orderkey x15, l_quantity x16, _table x17}
-          [:scan
-           [l_orderkey
-            l_quantity
-            {_table (= _table "lineitem")}]]]]]]]]]]]]
+          {l_orderkey x12, l_quantity x13}
+          [:scan lineitem [l_orderkey l_quantity]]]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q19-discounted-revenue.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q19-discounted-revenue.edn
@@ -1,92 +1,83 @@
 [:rename
- {x40 revenue}
+ {x38 revenue}
  [:group-by
-  [{x40 (sum x39)}]
+  [{x38 (sum x37)}]
   [:map
-   [{x39 (* x1 (- 1 x2))}]
+   [{x37 (* x1 (- 1 x2))}]
    [:select
     (or
      (and
-      (= x10 "Brand#12")
-      x18
+      (= x9 "Brand#12")
+      x16
       (>= x4 1)
       (<= x4 (+ 1 10))
-      (between x12 1 5)
-      x22)
+      (between x11 1 5)
+      x20)
      (and
-      (= x10 "Brand#23")
-      x26
+      (= x9 "Brand#23")
+      x24
       (>= x4 10)
       (<= x4 (+ 10 10))
-      (between x12 1 10)
-      x30)
+      (between x11 1 10)
+      x28)
      (and
-      (= x10 "Brand#34")
-      x34
+      (= x9 "Brand#34")
+      x32
       (>= x4 20)
       (<= x4 (+ 20 10))
-      (between x12 1 15)
-      x38))
+      (between x11 1 15)
+      x36))
     [:mark-join
-     {x38 [{x5 x35}]}
+     {x36 [{x5 x33}]}
      [:mark-join
-      {x34 [{x11 x31}]}
+      {x32 [{x10 x29}]}
       [:mark-join
-       {x30 [{x5 x27}]}
+       {x28 [{x5 x25}]}
        [:mark-join
-        {x26 [{x11 x23}]}
+        {x24 [{x10 x21}]}
         [:mark-join
-         {x22 [{x5 x19}]}
+         {x20 [{x5 x17}]}
          [:mark-join
-          {x18 [{x11 x15}]}
+          {x16 [{x10 x13}]}
           [:mega-join
-           [{x3 x9}]
+           [{x3 x8}]
            [[:rename
              {l_extendedprice x1,
               l_discount x2,
               l_partkey x3,
               l_quantity x4,
               l_shipmode x5,
-              l_shipinstruct x6,
-              _table x7}
+              l_shipinstruct x6}
              [:scan
+              lineitem
               [l_extendedprice
                l_discount
                l_partkey
                l_quantity
                l_shipmode
-               {l_shipinstruct (= l_shipinstruct "DELIVER IN PERSON")}
-               {_table (= _table "lineitem")}]]]
+               {l_shipinstruct
+                (= l_shipinstruct "DELIVER IN PERSON")}]]]
             [:rename
-             {p_partkey x9,
-              p_brand x10,
-              p_container x11,
-              p_size x12,
-              _table x13}
-             [:scan
-              [p_partkey
-               p_brand
-               p_container
-               p_size
-               {_table (= _table "part")}]]]]]
+             {p_partkey x8, p_brand x9, p_container x10, p_size x11}
+             [:scan part [p_partkey p_brand p_container p_size]]]]]
           [:table
-           [x15]
-           [{x15 "SM CASE"}
-            {x15 "SM BOX"}
-            {x15 "SM PACK"}
-            {x15 "SM PKG"}]]]
-         [:table [x19] [{x19 "AIR"} {x19 "AIR REG"}]]]
+           [x13]
+           [{x13 "SM CASE"}
+            {x13 "SM BOX"}
+            {x13 "SM PACK"}
+            {x13 "SM PKG"}]]]
+         [:table [x17] [{x17 "AIR"} {x17 "AIR REG"}]]]
         [:table
-         [x23]
-         [{x23 "MED BAG"}
-          {x23 "MED BOX"}
-          {x23 "MED PKG"}
-          {x23 "MED PACK"}]]]
-       [:table [x27] [{x27 "AIR"} {x27 "AIR REG"}]]]
+         [x21]
+         [{x21 "MED BAG"}
+          {x21 "MED BOX"}
+          {x21 "MED PKG"}
+          {x21 "MED PACK"}]]]
+       [:table [x25] [{x25 "AIR"} {x25 "AIR REG"}]]]
       [:table
-       [x31]
-       [{x31 "LG CASE"}
-        {x31 "LG BOX"}
-        {x31 "LG PACK"}
-        {x31 "LG PKG"}]]]
-     [:table [x35] [{x35 "AIR"} {x35 "AIR REG"}]]]]]]]
+       [x29]
+       [{x29 "LG CASE"}
+        {x29 "LG BOX"}
+        {x29 "LG PACK"}
+        {x29 "LG PKG"}]]]
+     [:table [x33] [{x33 "AIR"} {x33 "AIR REG"}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q2-minimum-cost-supplier.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q2-minimum-cost-supplier.edn
@@ -1,130 +1,96 @@
 [:rename
- {x7 s_acctbal,
-  x8 s_name,
-  x21 n_name,
+ {x6 s_acctbal,
+  x7 s_name,
+  x18 n_name,
   x1 p_partkey,
   x2 p_mfgr,
-  x9 s_address,
-  x10 s_phone,
-  x11 s_comment}
+  x8 s_address,
+  x9 s_phone,
+  x10 s_comment}
  [:top
   {:limit 100}
   [:order-by
-   [[x7 {:direction :desc, :null-ordering :nulls-last}]
-    [x21 {:direction :asc, :null-ordering :nulls-last}]
-    [x8 {:direction :asc, :null-ordering :nulls-last}]
+   [[x6 {:direction :desc, :null-ordering :nulls-last}]
+    [x18 {:direction :asc, :null-ordering :nulls-last}]
+    [x7 {:direction :asc, :null-ordering :nulls-last}]
     [x1 {:direction :asc, :null-ordering :nulls-last}]]
    [:project
-    [x7 x8 x21 x1 x2 x9 x10 x11]
+    [x6 x7 x18 x1 x2 x8 x9 x10]
     [:select
-     (= x18 x47)
+     (= x16 x38)
      [:group-by
       [x1
        x2
        x3
        x4
-       x5
+       x6
        x7
        x8
        x9
        x10
        x11
        x12
-       x13
        x14
+       x15
        x16
-       x17
        x18
        x19
-       x21
+       x20
        x22
        x23
-       x24
-       x26
-       x27
-       x28
        $row_number$
-       {x47 (min x30)}]
+       {x38 (min x25)}]
       [:left-outer-join
-       [{x1 x31}]
+       [{x1 x26}]
        [:map
         [{$row_number$ (row-number)}]
         [:mega-join
-         [{x23 x26} {x13 x22} {x1 x16} {x12 x17}]
+         [{x20 x22} {x12 x19} {x1 x14} {x11 x15}]
          [[:rename
-           {r_regionkey x26, r_name x27, _table x28}
-           [:scan
-            [r_regionkey
-             {r_name (= r_name "EUROPE")}
-             {_table (= _table "region")}]]]
+           {r_regionkey x22, r_name x23}
+           [:scan region [r_regionkey {r_name (= r_name "EUROPE")}]]]
           [:rename
-           {n_name x21, n_nationkey x22, n_regionkey x23, _table x24}
-           [:scan
-            [n_name
-             n_nationkey
-             n_regionkey
-             {_table (= _table "nation")}]]]
+           {n_name x18, n_nationkey x19, n_regionkey x20}
+           [:scan nation [n_name n_nationkey n_regionkey]]]
           [:rename
-           {ps_partkey x16,
-            ps_suppkey x17,
-            ps_supplycost x18,
-            _table x19}
-           [:scan
-            [ps_partkey
-             ps_suppkey
-             ps_supplycost
-             {_table (= _table "partsupp")}]]]
+           {ps_partkey x14, ps_suppkey x15, ps_supplycost x16}
+           [:scan partsupp [ps_partkey ps_suppkey ps_supplycost]]]
           [:rename
-           {p_partkey x1, p_mfgr x2, p_size x3, p_type x4, _table x5}
+           {p_partkey x1, p_mfgr x2, p_size x3, p_type x4}
            [:scan
+            part
             [p_partkey
              p_mfgr
              {p_size (= p_size 15)}
-             {p_type (like p_type "%BRASS")}
-             {_table (= _table "part")}]]]
+             {p_type (like p_type "%BRASS")}]]]
           [:rename
-           {s_acctbal x7,
-            s_name x8,
-            s_address x9,
-            s_phone x10,
-            s_comment x11,
-            s_suppkey x12,
-            s_nationkey x13,
-            _table x14}
+           {s_acctbal x6,
+            s_name x7,
+            s_address x8,
+            s_phone x9,
+            s_comment x10,
+            s_suppkey x11,
+            s_nationkey x12}
            [:scan
+            supplier
             [s_acctbal
              s_name
              s_address
              s_phone
              s_comment
              s_suppkey
-             s_nationkey
-             {_table (= _table "supplier")}]]]]]]
+             s_nationkey]]]]]]
        [:mega-join
-        [{x40 x43} {x36 x39} {x32 x35}]
+        [{x33 x35} {x30 x32} {x27 x29}]
         [[:rename
-          {r_regionkey x43, r_name x44, _table x45}
-          [:scan
-           [r_regionkey
-            {r_name (= r_name "EUROPE")}
-            {_table (= _table "region")}]]]
+          {r_regionkey x35, r_name x36}
+          [:scan region [r_regionkey {r_name (= r_name "EUROPE")}]]]
          [:rename
-          {n_nationkey x39, n_regionkey x40, _table x41}
-          [:scan
-           [n_nationkey n_regionkey {_table (= _table "nation")}]]]
+          {n_nationkey x32, n_regionkey x33}
+          [:scan nation [n_nationkey n_regionkey]]]
          [:rename
-          {ps_supplycost x30,
-           ps_partkey x31,
-           ps_suppkey x32,
-           _table x33}
-          [:scan
-           [ps_supplycost
-            ps_partkey
-            ps_suppkey
-            {_table (= _table "partsupp")}]]]
+          {ps_supplycost x25, ps_partkey x26, ps_suppkey x27}
+          [:scan partsupp [ps_supplycost ps_partkey ps_suppkey]]]
          [:rename
-          {s_suppkey x35, s_nationkey x36, _table x37}
-          [:scan
-           [s_suppkey
-            s_nationkey
-            {_table (= _table "supplier")}]]]]]]]]]]]]
+          {s_suppkey x29, s_nationkey x30}
+          [:scan supplier [s_suppkey s_nationkey]]]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q20-potential-part-promotion.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q20-potential-part-promotion.edn
@@ -5,56 +5,39 @@
   [:project
    [x1 x2]
    [:mega-join
-    [{x4 x7}]
+    [{x4 x6}]
     [[:semi-join
-      [{x3 x11}]
+      [{x3 x9}]
       [:rename
-       {s_name x1,
-        s_address x2,
-        s_suppkey x3,
-        s_nationkey x4,
-        _table x5}
-       [:scan
-        [s_name
-         s_address
-         s_suppkey
-         s_nationkey
-         {_table (= _table "supplier")}]]]
+       {s_name x1, s_address x2, s_suppkey x3, s_nationkey x4}
+       [:scan supplier [s_name s_address s_suppkey s_nationkey]]]
       [:select
-       (> x13 x29)
+       (> x11 x24)
        [:map
-        [{x29 (* 0.5 x27)}]
+        [{x24 (* 0.5 x22)}]
         [:group-by
-         [x11 x12 x13 x14 $row_number$ {x27 (sum x21)}]
+         [x9 x10 x11 $row_number$ {x22 (sum x17)}]
          [:left-outer-join
-          [{x12 x22} {x11 x23}]
+          [{x10 x18} {x9 x19}]
           [:map
            [{$row_number$ (row-number)}]
            [:semi-join
-            [{x12 x16}]
+            [{x10 x13}]
             [:rename
-             {ps_suppkey x11,
-              ps_partkey x12,
-              ps_availqty x13,
-              _table x14}
-             [:scan
-              [ps_suppkey
-               ps_partkey
-               ps_availqty
-               {_table (= _table "partsupp")}]]]
+             {ps_suppkey x9, ps_partkey x10, ps_availqty x11}
+             [:scan partsupp [ps_suppkey ps_partkey ps_availqty]]]
             [:rename
-             {p_partkey x16, p_name x17, _table x18}
+             {p_partkey x13, p_name x14}
              [:scan
-              [p_partkey
-               {p_name (like p_name "forest%")}
-               {_table (= _table "part")}]]]]]
+              part
+              [p_partkey {p_name (like p_name "forest%")}]]]]]
           [:rename
-           {l_quantity x21,
-            l_partkey x22,
-            l_suppkey x23,
-            l_shipdate x24,
-            _table x25}
+           {l_quantity x17,
+            l_partkey x18,
+            l_suppkey x19,
+            l_shipdate x20}
            [:scan
+            lineitem
             [l_quantity
              l_partkey
              l_suppkey
@@ -65,11 +48,7 @@
                 (+
                  #time/date "1994-01-01"
                  (single-field-interval "1" "YEAR" 2 0)))
-               (>= l_shipdate #time/date "1994-01-01"))}
-             {_table (= _table "lineitem")}]]]]]]]]
+               (>= l_shipdate #time/date "1994-01-01"))}]]]]]]]]
      [:rename
-      {n_nationkey x7, n_name x8, _table x9}
-      [:scan
-       [n_nationkey
-        {n_name (= n_name "CANADA")}
-        {_table (= _table "nation")}]]]]]]]]
+      {n_nationkey x6, n_name x7}
+      [:scan nation [n_nationkey {n_name (= n_name "CANADA")}]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q21-suppliers-who-kept-orders-waiting.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q21-suppliers-who-kept-orders-waiting.edn
@@ -1,68 +1,53 @@
 [:rename
- {x1 s_name, x35 numwait}
+ {x1 s_name, x29 numwait}
  [:top
   {:limit 100}
   [:order-by
-   [[x35 {:direction :desc, :null-ordering :nulls-last}]
+   [[x29 {:direction :desc, :null-ordering :nulls-last}]
     [x1 {:direction :asc, :null-ordering :nulls-last}]]
    [:group-by
-    [x1 {x35 (count x34)}]
+    [x1 {x29 (count x28)}]
     [:map
-     [{x34 1}]
+     [{x28 1}]
      [:mega-join
-      [{x3 x16} {x7 x12} {x2 x6}]
+      [{x3 x13} {x6 x10} {x2 x5}]
       [[:rename
-        {n_nationkey x16, n_name x17, _table x18}
+        {n_nationkey x13, n_name x14}
         [:scan
-         [n_nationkey
-          {n_name (= n_name "SAUDI ARABIA")}
-          {_table (= _table "nation")}]]]
+         nation
+         [n_nationkey {n_name (= n_name "SAUDI ARABIA")}]]]
        [:rename
-        {o_orderkey x12, o_orderstatus x13, _table x14}
+        {o_orderkey x10, o_orderstatus x11}
         [:scan
-         [o_orderkey
-          {o_orderstatus (= o_orderstatus "F")}
-          {_table (= _table "orders")}]]]
+         orders
+         [o_orderkey {o_orderstatus (= o_orderstatus "F")}]]]
        [:rename
-        {s_name x1, s_suppkey x2, s_nationkey x3, _table x4}
-        [:scan
-         [s_name
-          s_suppkey
-          s_nationkey
-          {_table (= _table "supplier")}]]]
+        {s_name x1, s_suppkey x2, s_nationkey x3}
+        [:scan supplier [s_name s_suppkey s_nationkey]]]
        [:anti-join
-        [(<> x27 x6) {x7 x26}]
+        [(<> x22 x5) {x6 x21}]
         [:semi-join
-         [(<> x21 x6) {x7 x20}]
+         [(<> x17 x5) {x6 x16}]
          [:rename
-          {l_suppkey x6,
-           l_orderkey x7,
-           l_receiptdate x8,
-           l_commitdate x9,
-           _table x10}
+          {l_suppkey x5,
+           l_orderkey x6,
+           l_receiptdate x7,
+           l_commitdate x8}
           [:select
            (> l_receiptdate l_commitdate)
            [:scan
-            [l_suppkey
-             l_orderkey
-             l_receiptdate
-             l_commitdate
-             {_table (= _table "lineitem")}]]]]
+            lineitem
+            [l_suppkey l_orderkey l_receiptdate l_commitdate]]]]
          [:rename
-          {l_orderkey x20, l_suppkey x21, _table x22}
-          [:scan
-           [l_orderkey l_suppkey {_table (= _table "lineitem")}]]]]
+          {l_orderkey x16, l_suppkey x17}
+          [:scan lineitem [l_orderkey l_suppkey]]]]
         [:rename
-         {l_orderkey x26,
-          l_suppkey x27,
-          l_receiptdate x28,
-          l_commitdate x29,
-          _table x30}
+         {l_orderkey x21,
+          l_suppkey x22,
+          l_receiptdate x23,
+          l_commitdate x24}
          [:select
           (> l_receiptdate l_commitdate)
           [:scan
-           [l_orderkey
-            l_suppkey
-            l_receiptdate
-            l_commitdate
-            {_table (= _table "lineitem")}]]]]]]]]]]]]
+           lineitem
+           [l_orderkey l_suppkey l_receiptdate l_commitdate]]]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q22-global-sales-opportunity.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q22-global-sales-opportunity.edn
@@ -1,56 +1,47 @@
 [:rename
- {x22 cntrycode, x24 numcust, x25 totacctbal}
+ {x19 cntrycode, x21 numcust, x22 totacctbal}
  [:order-by
-  [[x22 {:direction :asc, :null-ordering :nulls-last}]]
+  [[x19 {:direction :asc, :null-ordering :nulls-last}]]
   [:group-by
-   [x22 {x24 (count x23)} {x25 (sum x2)}]
+   [x19 {x21 (count x20)} {x22 (sum x2)}]
    [:map
-    [{x23 1}]
+    [{x20 1}]
     [:project
-     [{x22 (substring x1 1 2 true)} x2]
+     [{x19 (substring x1 1 2 true)} x2]
      [:anti-join
-      [{x3 x18}]
+      [{x3 x16}]
       [:select
-       (> x2 x16)
+       (> x2 x14)
        [:single-join
         []
         [:semi-join
-         [{(substring x1 1 2 true) x6}]
+         [{(substring x1 1 2 true) x5}]
          [:rename
-          {c_phone x1, c_acctbal x2, c_custkey x3, _table x4}
-          [:scan
-           [c_phone
-            c_acctbal
-            c_custkey
-            {_table (= _table "customer")}]]]
+          {c_phone x1, c_acctbal x2, c_custkey x3}
+          [:scan customer [c_phone c_acctbal c_custkey]]]
          [:table
-          [x6]
-          [{x6 "13"}
-           {x6 "31"}
-           {x6 "23"}
-           {x6 "29"}
-           {x6 "30"}
-           {x6 "18"}
-           {x6 "17"}]]]
+          [x5]
+          [{x5 "13"}
+           {x5 "31"}
+           {x5 "23"}
+           {x5 "29"}
+           {x5 "30"}
+           {x5 "18"}
+           {x5 "17"}]]]
         [:group-by
-         [{x16 (avg x9)}]
+         [{x14 (avg x8)}]
          [:semi-join
-          [{(substring x10 1 2 true) x13}]
+          [{(substring x9 1 2 true) x11}]
           [:rename
-           {c_acctbal x9, c_phone x10, _table x11}
-           [:scan
-            [{c_acctbal (> c_acctbal 0.0)}
-             c_phone
-             {_table (= _table "customer")}]]]
+           {c_acctbal x8, c_phone x9}
+           [:scan customer [{c_acctbal (> c_acctbal 0.0)} c_phone]]]
           [:table
-           [x13]
-           [{x13 "13"}
-            {x13 "31"}
-            {x13 "23"}
-            {x13 "29"}
-            {x13 "30"}
-            {x13 "18"}
-            {x13 "17"}]]]]]]
-      [:rename
-       {o_custkey x18, _table x19}
-       [:scan [o_custkey {_table (= _table "orders")}]]]]]]]]]
+           [x11]
+           [{x11 "13"}
+            {x11 "31"}
+            {x11 "23"}
+            {x11 "29"}
+            {x11 "30"}
+            {x11 "18"}
+            {x11 "17"}]]]]]]
+      [:rename {o_custkey x16} [:scan orders [o_custkey]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q3-shipping-priority.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q3-shipping-priority.edn
@@ -1,45 +1,42 @@
 [:rename
- {x11 l_orderkey, x18 revenue, x5 o_orderdate, x6 o_shippriority}
+ {x9 l_orderkey, x15 revenue, x4 o_orderdate, x5 o_shippriority}
  [:project
-  [x11 x18 x5 x6]
+  [x9 x15 x4 x5]
   [:top
    {:limit 10}
    [:order-by
-    [[x18 {:direction :desc, :null-ordering :nulls-last}]
-     [x5 {:direction :asc, :null-ordering :nulls-last}]]
+    [[x15 {:direction :desc, :null-ordering :nulls-last}]
+     [x4 {:direction :asc, :null-ordering :nulls-last}]]
     [:group-by
-     [x11 x5 x6 {x18 (sum x17)}]
+     [x9 x4 x5 {x15 (sum x14)}]
      [:map
-      [{x17 (* x12 (- 1 x13))}]
+      [{x14 (* x10 (- 1 x11))}]
       [:mega-join
-       ({x8 x11} {x2 x7})
+       [{x7 x9} {x2 x6}]
        [[:rename
-         {l_orderkey x11,
-          l_extendedprice x12,
-          l_discount x13,
-          l_shipdate x14,
-          _table x15}
+         {l_orderkey x9,
+          l_extendedprice x10,
+          l_discount x11,
+          l_shipdate x12}
          [:scan
+          lineitem
           [l_orderkey
            l_extendedprice
            l_discount
-           {l_shipdate (> l_shipdate #time/date "1995-03-15")}
-           {_table (= _table "lineitem")}]]]
+           {l_shipdate (> l_shipdate #time/date "1995-03-15")}]]]
         [:rename
-         {c_mktsegment x1, c_custkey x2, _table x3}
+         {c_mktsegment x1, c_custkey x2}
          [:scan
-          [{c_mktsegment (= c_mktsegment "BUILDING")}
-           c_custkey
-           {_table (= _table "customer")}]]]
+          customer
+          [{c_mktsegment (= c_mktsegment "BUILDING")} c_custkey]]]
         [:rename
-         {o_orderdate x5,
-          o_shippriority x6,
-          o_custkey x7,
-          o_orderkey x8,
-          _table x9}
+         {o_orderdate x4,
+          o_shippriority x5,
+          o_custkey x6,
+          o_orderkey x7}
          [:scan
+          orders
           [{o_orderdate (< o_orderdate #time/date "1995-03-15")}
            o_shippriority
            o_custkey
-           o_orderkey
-           {_table (= _table "orders")}]]]]]]]]]]]
+           o_orderkey]]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q4-order-priority-checking.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q4-order-priority-checking.edn
@@ -1,16 +1,17 @@
 [:rename
- {x1 o_orderpriority, x13 order_count}
+ {x1 o_orderpriority, x11 order_count}
  [:order-by
   [[x1 {:direction :asc, :null-ordering :nulls-last}]]
   [:group-by
-   [x1 {x13 (count x12)}]
+   [x1 {x11 (count x10)}]
    [:map
-    [{x12 1}]
+    [{x10 1}]
     [:semi-join
-     [{x3 x6}]
+     [{x3 x5}]
      [:rename
-      {o_orderpriority x1, o_orderdate x2, o_orderkey x3, _table x4}
+      {o_orderpriority x1, o_orderdate x2, o_orderkey x3}
       [:scan
+       orders
        [o_orderpriority
         {o_orderdate
          (and
@@ -20,14 +21,9 @@
             #time/date "1993-07-01"
             (single-field-interval "3" "MONTH" 2 0)))
           (>= o_orderdate #time/date "1993-07-01"))}
-        o_orderkey
-        {_table (= _table "orders")}]]]
+        o_orderkey]]]
      [:rename
-      {l_orderkey x6, l_commitdate x7, l_receiptdate x8, _table x9}
+      {l_orderkey x5, l_commitdate x6, l_receiptdate x7}
       [:select
        (< l_commitdate l_receiptdate)
-       [:scan
-        [l_orderkey
-         l_commitdate
-         l_receiptdate
-         {_table (= _table "lineitem")}]]]]]]]]]
+       [:scan lineitem [l_orderkey l_commitdate l_receiptdate]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q5-local-supplier-volume.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q5-local-supplier-volume.edn
@@ -1,44 +1,37 @@
 [:rename
- {x20 n_name, x30 revenue}
+ {x16 n_name, x24 revenue}
  [:order-by
-  [[x30 {:direction :desc, :null-ordering :nulls-last}]]
+  [[x24 {:direction :desc, :null-ordering :nulls-last}]]
   [:group-by
-   [x20 {x30 (sum x29)}]
+   [x16 {x24 (sum x23)}]
    [:map
-    [{x29 (* x10 (- 1 x11))}]
+    [{x23 (* x8 (- 1 x9))}]
     [:mega-join
-     [{x22 x25} {x17 x21} {x13 x16} {x2 x17} {x6 x12} {x1 x5}]
+     [{x18 x20} {x14 x17} {x11 x13} {x2 x14} {x5 x10} {x1 x4}]
      [[:rename
-       {r_regionkey x25, r_name x26, _table x27}
+       {r_regionkey x20, r_name x21}
+       [:scan region [r_regionkey {r_name (= r_name "ASIA")}]]]
+      [:rename
+       {n_name x16, n_nationkey x17, n_regionkey x18}
+       [:scan nation [n_name n_nationkey n_regionkey]]]
+      [:rename
+       {s_suppkey x13, s_nationkey x14}
+       [:scan supplier [s_suppkey s_nationkey]]]
+      [:rename
+       {l_extendedprice x8,
+        l_discount x9,
+        l_orderkey x10,
+        l_suppkey x11}
        [:scan
-        [r_regionkey
-         {r_name (= r_name "ASIA")}
-         {_table (= _table "region")}]]]
+        lineitem
+        [l_extendedprice l_discount l_orderkey l_suppkey]]]
       [:rename
-       {n_name x20, n_nationkey x21, n_regionkey x22, _table x23}
+       {c_custkey x1, c_nationkey x2}
+       [:scan customer [c_custkey c_nationkey]]]
+      [:rename
+       {o_custkey x4, o_orderkey x5, o_orderdate x6}
        [:scan
-        [n_name n_nationkey n_regionkey {_table (= _table "nation")}]]]
-      [:rename
-       {s_suppkey x16, s_nationkey x17, _table x18}
-       [:scan [s_suppkey s_nationkey {_table (= _table "supplier")}]]]
-      [:rename
-       {l_extendedprice x10,
-        l_discount x11,
-        l_orderkey x12,
-        l_suppkey x13,
-        _table x14}
-       [:scan
-        [l_extendedprice
-         l_discount
-         l_orderkey
-         l_suppkey
-         {_table (= _table "lineitem")}]]]
-      [:rename
-       {c_custkey x1, c_nationkey x2, _table x3}
-       [:scan [c_custkey c_nationkey {_table (= _table "customer")}]]]
-      [:rename
-       {o_custkey x5, o_orderkey x6, o_orderdate x7, _table x8}
-       [:scan
+        orders
         [o_custkey
          o_orderkey
          {o_orderdate
@@ -48,5 +41,4 @@
             (+
              #time/date "1994-01-01"
              (single-field-interval "1" "YEAR" 2 0)))
-           (>= o_orderdate #time/date "1994-01-01"))}
-         {_table (= _table "orders")}]]]]]]]]]
+           (>= o_orderdate #time/date "1994-01-01"))}]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q6-forecasting-revenue-change.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q6-forecasting-revenue-change.edn
@@ -1,16 +1,13 @@
 [:rename
- {x8 revenue}
+ {x7 revenue}
  [:group-by
-  [{x8 (sum x7)}]
+  [{x7 (sum x6)}]
   [:map
-   [{x7 (* x1 x2)}]
+   [{x6 (* x1 x2)}]
    [:rename
-    {l_extendedprice x1,
-     l_discount x2,
-     l_shipdate x3,
-     l_quantity x4,
-     _table x5}
+    {l_extendedprice x1, l_discount x2, l_shipdate x3, l_quantity x4}
     [:scan
+     lineitem
      [l_extendedprice
       {l_discount (between l_discount 0.05 0.07)}
       {l_shipdate
@@ -21,5 +18,4 @@
           #time/date "1994-01-01"
           (single-field-interval "1" "YEAR" 2 0)))
         (>= l_shipdate #time/date "1994-01-01"))}
-      {l_quantity (< l_quantity 24)}
-      {_table (= _table "lineitem")}]]]]]]
+      {l_quantity (< l_quantity 24)}]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q7-volume-shipping.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q7-volume-shipping.edn
@@ -1,45 +1,45 @@
 [:rename
- {x20 supp_nation, x24 cust_nation, x28 l_year, x30 revenue}
+ {x16 supp_nation, x19 cust_nation, x22 l_year, x24 revenue}
  [:order-by
-  [[x20 {:direction :asc, :null-ordering :nulls-last}]
-   [x24 {:direction :asc, :null-ordering :nulls-last}]
-   [x28 {:direction :asc, :null-ordering :nulls-last}]]
+  [[x16 {:direction :asc, :null-ordering :nulls-last}]
+   [x19 {:direction :asc, :null-ordering :nulls-last}]
+   [x22 {:direction :asc, :null-ordering :nulls-last}]]
   [:group-by
-   [x20 x24 x28 {x30 (sum x29)}]
+   [x16 x19 x22 {x24 (sum x23)}]
    [:project
-    [x20 x24 {x28 (extract "YEAR" x5)} {x29 (* x6 (- 1 x7))}]
+    [x16 x19 {x22 (extract "YEAR" x4)} {x23 (* x5 (- 1 x6))}]
     [:mega-join
-     [{x17 x25}
+     [{x14 x20}
       (or
-       (and (= x20 "FRANCE") (= x24 "GERMANY"))
-       (and (= x20 "GERMANY") (= x24 "FRANCE")))
-      {x2 x21}
-      {x13 x16}
-      {x9 x12}
-      {x1 x8}]
+       (and (= x16 "FRANCE") (= x19 "GERMANY"))
+       (and (= x16 "GERMANY") (= x19 "FRANCE")))
+      {x2 x17}
+      {x11 x13}
+      {x8 x10}
+      {x1 x7}]
      [[:rename
-       {n_name x24, n_nationkey x25, _table x26}
-       [:scan [n_name n_nationkey {_table (= _table "nation")}]]]
+       {n_name x19, n_nationkey x20}
+       [:scan nation [n_name n_nationkey]]]
       [:rename
-       {n_name x20, n_nationkey x21, _table x22}
-       [:scan [n_name n_nationkey {_table (= _table "nation")}]]]
+       {n_name x16, n_nationkey x17}
+       [:scan nation [n_name n_nationkey]]]
       [:rename
-       {c_custkey x16, c_nationkey x17, _table x18}
-       [:scan [c_custkey c_nationkey {_table (= _table "customer")}]]]
+       {c_custkey x13, c_nationkey x14}
+       [:scan customer [c_custkey c_nationkey]]]
       [:rename
-       {o_orderkey x12, o_custkey x13, _table x14}
-       [:scan [o_orderkey o_custkey {_table (= _table "orders")}]]]
+       {o_orderkey x10, o_custkey x11}
+       [:scan orders [o_orderkey o_custkey]]]
       [:rename
-       {s_suppkey x1, s_nationkey x2, _table x3}
-       [:scan [s_suppkey s_nationkey {_table (= _table "supplier")}]]]
+       {s_suppkey x1, s_nationkey x2}
+       [:scan supplier [s_suppkey s_nationkey]]]
       [:rename
-       {l_shipdate x5,
-        l_extendedprice x6,
-        l_discount x7,
-        l_suppkey x8,
-        l_orderkey x9,
-        _table x10}
+       {l_shipdate x4,
+        l_extendedprice x5,
+        l_discount x6,
+        l_suppkey x7,
+        l_orderkey x8}
        [:scan
+        lineitem
         [{l_shipdate
           (between
            l_shipdate
@@ -48,5 +48,4 @@
          l_extendedprice
          l_discount
          l_suppkey
-         l_orderkey
-         {_table (= _table "lineitem")}]]]]]]]]]
+         l_orderkey]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q8-national-market-share.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q8-national-market-share.edn
@@ -1,74 +1,60 @@
 [:rename
- {x37 o_year, x43 mkt_share}
+ {x29 o_year, x35 mkt_share}
  [:order-by
-  [[x37 {:direction :asc, :null-ordering :nulls-last}]]
+  [[x29 {:direction :asc, :null-ordering :nulls-last}]]
   [:project
-   [x37 {x43 (/ x40 x41)}]
+   [x29 {x35 (/ x32 x33)}]
    [:group-by
-    [x37 {x40 (sum x39)} {x41 (sum x38)}]
+    [x29 {x32 (sum x31)} {x33 (sum x30)}]
     [:map
-     [{x39 (cond (= x29 "BRAZIL") x38 0)}]
+     [{x31 (cond (= x23 "BRAZIL") x30 0)}]
      [:project
-      [{x37 (extract "YEAR" x16)} {x38 (* x9 (- 1 x10))} x29]
+      [{x29 (extract "YEAR" x13)} {x30 (* x7 (- 1 x8))} x23]
       [:mega-join
-       [{x26 x33}
-        {x6 x30}
-        {x22 x25}
-        {x18 x21}
-        {x13 x17}
-        {x1 x11}
-        {x5 x12}]
+       [{x21 x26}
+        {x5 x24}
+        {x18 x20}
+        {x15 x17}
+        {x11 x14}
+        {x1 x9}
+        {x4 x10}]
        [[:rename
-         {r_regionkey x33, r_name x34, _table x35}
-         [:scan
-          [r_regionkey
-           {r_name (= r_name "AMERICA")}
-           {_table (= _table "region")}]]]
+         {r_regionkey x26, r_name x27}
+         [:scan region [r_regionkey {r_name (= r_name "AMERICA")}]]]
         [:rename
-         {n_name x29, n_nationkey x30, _table x31}
-         [:scan [n_name n_nationkey {_table (= _table "nation")}]]]
+         {n_name x23, n_nationkey x24}
+         [:scan nation [n_name n_nationkey]]]
         [:rename
-         {n_nationkey x25, n_regionkey x26, _table x27}
-         [:scan
-          [n_nationkey n_regionkey {_table (= _table "nation")}]]]
+         {n_nationkey x20, n_regionkey x21}
+         [:scan nation [n_nationkey n_regionkey]]]
         [:rename
-         {c_custkey x21, c_nationkey x22, _table x23}
-         [:scan
-          [c_custkey c_nationkey {_table (= _table "customer")}]]]
+         {c_custkey x17, c_nationkey x18}
+         [:scan customer [c_custkey c_nationkey]]]
         [:rename
-         {o_orderdate x16, o_orderkey x17, o_custkey x18, _table x19}
+         {o_orderdate x13, o_orderkey x14, o_custkey x15}
          [:scan
+          orders
           [{o_orderdate
             (between
              o_orderdate
              #time/date "1995-01-01"
              #time/date "1996-12-31")}
            o_orderkey
-           o_custkey
-           {_table (= _table "orders")}]]]
+           o_custkey]]]
         [:rename
-         {l_extendedprice x9,
-          l_discount x10,
-          l_partkey x11,
-          l_suppkey x12,
-          l_orderkey x13,
-          _table x14}
+         {l_extendedprice x7,
+          l_discount x8,
+          l_partkey x9,
+          l_suppkey x10,
+          l_orderkey x11}
          [:scan
-          [l_extendedprice
-           l_discount
-           l_partkey
-           l_suppkey
-           l_orderkey
-           {_table (= _table "lineitem")}]]]
+          lineitem
+          [l_extendedprice l_discount l_partkey l_suppkey l_orderkey]]]
         [:rename
-         {p_partkey x1, p_type x2, _table x3}
+         {p_partkey x1, p_type x2}
          [:scan
-          [p_partkey
-           {p_type (= p_type "ECONOMY ANODIZED STEEL")}
-           {_table (= _table "part")}]]]
+          part
+          [p_partkey {p_type (= p_type "ECONOMY ANODIZED STEEL")}]]]
         [:rename
-         {s_suppkey x5, s_nationkey x6, _table x7}
-         [:scan
-          [s_suppkey
-           s_nationkey
-           {_table (= _table "supplier")}]]]]]]]]]]]
+         {s_suppkey x4, s_nationkey x5}
+         [:scan supplier [s_suppkey s_nationkey]]]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-q9-product-type-profit-measure.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-q9-product-type-profit-measure.edn
@@ -1,52 +1,43 @@
 [:rename
- {x26 nation, x30 o_year, x32 sum_profit}
+ {x21 nation, x24 o_year, x26 sum_profit}
  [:order-by
-  [[x26 {:direction :asc, :null-ordering :nulls-last}]
-   [x30 {:direction :desc, :null-ordering :nulls-last}]]
+  [[x21 {:direction :asc, :null-ordering :nulls-last}]
+   [x24 {:direction :desc, :null-ordering :nulls-last}]]
   [:group-by
-   [x26 x30 {x32 (sum x31)}]
+   [x21 x24 {x26 (sum x25)}]
    [:project
-    [x26
-     {x30 (extract "YEAR" x22)}
-     {x31 (- (* x9 (- 1 x10)) (* x17 x11))}]
+    [x21
+     {x24 (extract "YEAR" x18)}
+     {x25 (- (* x7 (- 1 x8)) (* x14 x9))}]
     [:mega-join
-     [{x6 x27} {x14 x23} {x12 x18} {x13 x19} {x5 x12} {x1 x13}]
+     [{x5 x22} {x12 x19} {x10 x15} {x11 x16} {x4 x10} {x1 x11}]
      [[:rename
-       {n_name x26, n_nationkey x27, _table x28}
-       [:scan [n_name n_nationkey {_table (= _table "nation")}]]]
+       {n_name x21, n_nationkey x22}
+       [:scan nation [n_name n_nationkey]]]
       [:rename
-       {o_orderdate x22, o_orderkey x23, _table x24}
-       [:scan [o_orderdate o_orderkey {_table (= _table "orders")}]]]
+       {o_orderdate x18, o_orderkey x19}
+       [:scan orders [o_orderdate o_orderkey]]]
       [:rename
-       {ps_supplycost x17, ps_suppkey x18, ps_partkey x19, _table x20}
+       {ps_supplycost x14, ps_suppkey x15, ps_partkey x16}
+       [:scan partsupp [ps_supplycost ps_suppkey ps_partkey]]]
+      [:rename
+       {l_extendedprice x7,
+        l_discount x8,
+        l_quantity x9,
+        l_suppkey x10,
+        l_partkey x11,
+        l_orderkey x12}
        [:scan
-        [ps_supplycost
-         ps_suppkey
-         ps_partkey
-         {_table (= _table "partsupp")}]]]
-      [:rename
-       {l_extendedprice x9,
-        l_discount x10,
-        l_quantity x11,
-        l_suppkey x12,
-        l_partkey x13,
-        l_orderkey x14,
-        _table x15}
-       [:scan
+        lineitem
         [l_extendedprice
          l_discount
          l_quantity
          l_suppkey
          l_partkey
-         l_orderkey
-         {_table (= _table "lineitem")}]]]
+         l_orderkey]]]
       [:rename
-       {p_partkey x1, p_name x2, _table x3}
-       [:scan
-        [p_partkey
-         {p_name (like p_name "%green%")}
-         {_table (= _table "part")}]]]
+       {p_partkey x1, p_name x2}
+       [:scan part [p_partkey {p_name (like p_name "%green%")}]]]
       [:rename
-       {s_suppkey x5, s_nationkey x6, _table x7}
-       [:scan
-        [s_suppkey s_nationkey {_table (= _table "supplier")}]]]]]]]]]
+       {s_suppkey x4, s_nationkey x5}
+       [:scan supplier [s_suppkey s_nationkey]]]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-remove-names-359-multiple-ref.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-remove-names-359-multiple-ref.edn
@@ -1,13 +1,11 @@
 [:rename
- {x7 bar}
+ {x5 bar}
  [:project
-  [x7]
+  [x5]
   [:apply
    :single-join
-   {x1 ?x8}
-   [:rename {bar x1, _table x2} [:scan [bar {_table (= _table "x")}]]]
+   {x1 ?x6}
+   [:rename {bar x1} [:scan x [bar]]]
    [:project
-    [{x7 ?x8}]
-    [:project
-     [{x6 ?x8}]
-     [:rename {_table x4} [:scan [{_table (= _table "z")}]]]]]]]]
+    [{x5 ?x6}]
+    [:project [{x4 ?x6}] [:rename {} [:scan z []]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-remove-names-359-single-ref.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-remove-names-359-single-ref.edn
@@ -1,11 +1,9 @@
 [:rename
- {x6 bar}
+ {x4 bar}
  [:project
-  [x6]
+  [x4]
   [:apply
    :single-join
-   {x1 ?x7}
-   [:rename {bar x1, _table x2} [:scan [bar {_table (= _table "x")}]]]
-   [:project
-    [{x6 ?x7}]
-    [:rename {_table x4} [:scan [{_table (= _table "z")}]]]]]]]
+   {x1 ?x5}
+   [:rename {bar x1} [:scan x [bar]]]
+   [:project [{x4 ?x5}] [:rename {} [:scan z []]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-semi-and-anti-joins-are-pushed-down.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-semi-and-anti-joins-are-pushed-down.edn
@@ -3,22 +3,16 @@
  [:project
   [x1]
   [:mega-join
-   [{x1 x6}]
+   [{x1 x5}]
    [[:semi-join
-     [{x9 x18}]
-     [:rename
-      {c1 x9, _table x10}
-      [:scan [c1 {_table (= _table "t3")}]]]
-     [:table [x18] [{x18 792} {x18 14}]]]
+     [{x7 x15}]
+     [:rename {c1 x7} [:scan t3 [c1]]]
+     [:table [x15] [{x15 792} {x15 14}]]]
     [:semi-join
-     [{x2 x12}]
-     [:rename
-      {a1 x1, b1 x2, _table x3}
-      [:scan [a1 b1 {_table (= _table "t1")}]]]
-     [:table [x12] [{x12 532} {x12 593}]]]
+     [{x2 x9}]
+     [:rename {a1 x1, b1 x2} [:scan t1 [a1 b1]]]
+     [:table [x9] [{x9 532} {x9 593}]]]
     [:semi-join
-     [{x5 x15}]
-     [:rename
-      {b1 x5, a2 x6, _table x7}
-      [:scan [b1 a2 {_table (= _table "t2")}]]]
-     [:table [x15] [{x15 808} {x15 662}]]]]]]]
+     [{x4 x12}]
+     [:rename {b1 x4, a2 x5} [:scan t2 [b1 a2]]]
+     [:table [x12] [{x12 808} {x12 662}]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-sql-delete-plan.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-sql-delete-plan.edn
@@ -1,31 +1,30 @@
 [:delete
  {:table "users"}
  [:rename
-  {x3 _iid,
-   x4 _row-id,
-   x7 system_time_start,
-   x8 system_time_end,
-   x10 application_time_start,
-   x11 application_time_end}
+  {x2 _iid,
+   x3 _row-id,
+   x6 system_time_start,
+   x7 system_time_end,
+   x9 application_time_start,
+   x10 application_time_end}
   [:project
-   [x3
-    x4
+   [x2
+    x3
+    x6
     x7
-    x8
-    {x10 (cast-tstz (max x5 #time/date "2020-05-01"))}
-    {x11 (cast-tstz (min x6 #time/date "9999-12-31"))}]
+    {x9 (cast-tstz (max x4 #time/date "2020-05-01"))}
+    {x10 (cast-tstz (min x5 #time/date "9999-12-31"))}]
    [:rename
-    {_table x1,
-     id x2,
-     _iid x3,
-     _row-id x4,
-     application_time_start x5,
-     application_time_end x6,
-     system_time_start x7,
-     system_time_end x8}
+    {id x1,
+     _iid x2,
+     _row-id x3,
+     application_time_start x4,
+     application_time_end x5,
+     system_time_start x6,
+     system_time_end x7}
     [:scan
-     [{_table (= _table "users")}
-      {id (= id ?_0)}
+     users
+     [{id (= id ?_0)}
       _iid
       _row-id
       {application_time_start

--- a/test-resources/core2/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
@@ -1,30 +1,29 @@
 [:update
  {:table "foo"}
  [:rename
-  {x3 _iid,
-   x4 _row-id,
-   x7 system_time_start,
-   x8 system_time_end,
-   x2 bar,
-   x10 application_time_start,
-   x11 application_time_end}
+  {x2 _iid,
+   x3 _row-id,
+   x6 system_time_start,
+   x7 system_time_end,
+   x1 bar,
+   x9 application_time_start,
+   x10 application_time_end}
   [:project
-   [x3 x4 x7 x8 x2 {x10 (cast-tstz x5)} {x11 (cast-tstz x6)}]
+   [x2 x3 x6 x7 x1 {x9 (cast-tstz x4)} {x10 (cast-tstz x5)}]
    [:rename
-    {_table x1,
-     baz x2,
-     _iid x3,
-     _row-id x4,
-     application_time_start x5,
-     application_time_end x6,
-     system_time_start x7,
-     system_time_end x8}
+    {baz x1,
+     _iid x2,
+     _row-id x3,
+     application_time_start x4,
+     application_time_end x5,
+     system_time_start x6,
+     system_time_end x7}
     [:scan
-     [{_table (= _table "foo")}
-      baz
+     foo
+     (baz
       _iid
       _row-id
       application_time_start
       application_time_end
       system_time_start
-      system_time_end]]]]]]
+      system_time_end)]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
@@ -1,34 +1,33 @@
 [:update
  {:table "foo"}
  [:rename
-  {x6 _iid,
-   x7 _row-id,
-   x2 system_time_start,
-   x3 system_time_end,
-   x9 bar,
-   x10 application_time_start,
-   x11 application_time_end}
+  {x5 _iid,
+   x6 _row-id,
+   x1 system_time_start,
+   x2 system_time_end,
+   x8 bar,
+   x9 application_time_start,
+   x10 application_time_end}
   [:project
-   [x6
-    x7
+   [x5
+    x6
+    x1
     x2
-    x3
-    {x9 (and (< x2 x5) (> x3 x4))}
-    {x10 (cast-tstz x4)}
-    {x11 (cast-tstz x5)}]
+    {x8 (and (< x1 x4) (> x2 x3))}
+    {x9 (cast-tstz x3)}
+    {x10 (cast-tstz x4)}]
    [:rename
-    {_table x1,
-     system_time_start x2,
-     system_time_end x3,
-     application_time_start x4,
-     application_time_end x5,
-     _iid x6,
-     _row-id x7}
+    {system_time_start x1,
+     system_time_end x2,
+     application_time_start x3,
+     application_time_end x4,
+     _iid x5,
+     _row-id x6}
     [:scan
-     [{_table (= _table "foo")}
-      system_time_start
+     foo
+     (system_time_start
       system_time_end
       application_time_start
       application_time_end
       _iid
-      _row-id]]]]]]
+      _row-id)]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-sql-update-plan.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-sql-update-plan.edn
@@ -1,33 +1,32 @@
 [:update
  {:table "users"}
  [:rename
-  {x3 _iid,
-   x4 _row-id,
-   x7 system_time_start,
-   x8 system_time_end,
-   x10 first_name,
-   x11 application_time_start,
-   x12 application_time_end}
+  {x2 _iid,
+   x3 _row-id,
+   x6 system_time_start,
+   x7 system_time_end,
+   x9 first_name,
+   x10 application_time_start,
+   x11 application_time_end}
   [:project
-   [x3
-    x4
+   [x2
+    x3
+    x6
     x7
-    x8
-    {x10 "Sue"}
-    {x11 (cast-tstz (max x5 #time/date "2021-07-01"))}
-    {x12 (cast-tstz (min x6 #time/date "9999-12-31"))}]
+    {x9 "Sue"}
+    {x10 (cast-tstz (max x4 #time/date "2021-07-01"))}
+    {x11 (cast-tstz (min x5 #time/date "9999-12-31"))}]
    [:rename
-    {_table x1,
-     id x2,
-     _iid x3,
-     _row-id x4,
-     application_time_start x5,
-     application_time_end x6,
-     system_time_start x7,
-     system_time_end x8}
+    {id x1,
+     _iid x2,
+     _row-id x3,
+     application_time_start x4,
+     application_time_end x5,
+     system_time_start x6,
+     system_time_end x7}
     [:scan
-     [{_table (= _table "users")}
-      {id (= id ?_0)}
+     users
+     [{id (= id ?_0)}
       _iid
       _row-id
       {application_time_start

--- a/test-resources/core2/sql/plan_test_expectations/test-system-time-period-predicate-full-plan.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-system-time-period-predicate-full-plan.edn
@@ -1,20 +1,12 @@
 [:rename
- {x1 name, x6 name_1}
+ {x1 name, x5 name_1}
  [:project
-  [x1 x6]
+  [x1 x5]
   [:mega-join
-   [(< x2 x8) (> x3 x7)]
+   [(< x2 x7) (> x3 x6)]
    [[:rename
-     {name x1, system_time_start x2, system_time_end x3, _table x4}
-     [:scan
-      [name
-       system_time_start
-       system_time_end
-       {_table (= _table "foo")}]]]
+     {name x1, system_time_start x2, system_time_end x3}
+     [:scan foo [name system_time_start system_time_end]]]
     [:rename
-     {name x6, system_time_start x7, system_time_end x8, _table x9}
-     [:scan
-      [name
-       system_time_start
-       system_time_end
-       {_table (= _table "bar")}]]]]]]]
+     {name x5, system_time_start x6, system_time_end x7}
+     [:scan bar [name system_time_start system_time_end]]]]]]]

--- a/test-resources/core2/sql/plan_test_expectations/test-with-clause.edn
+++ b/test-resources/core2/sql/plan_test_expectations/test-with-clause.edn
@@ -1,14 +1,6 @@
 [:rename
- {x1 id, x4 id_1}
+ {x1 id, x3 id_1}
  [:mega-join
   []
-  [[:project
-    [x1]
-    [:rename
-     {id x1, _table x2}
-     [:scan [{id (= id 5)} {_table (= _table "bar")}]]]]
-   [:project
-    [x4]
-    [:rename
-     {id x4, _table x5}
-     [:scan [{id (= id 5)} {_table (= _table "bar")}]]]]]]]
+  [[:rename {id x1} [:scan bar [{id (= id 5)}]]]
+   [:rename {id x3} [:scan bar [{id (= id 5)}]]]]]]

--- a/test/core2/api_test.clj
+++ b/test/core2/api_test.clj
@@ -43,8 +43,8 @@
                      (throw (.getCause e)))))))
 
 (t/deftest round-trips-lists
-  (let [!tx (c2/submit-tx *node* [[:put {:id :foo, :list [1 2 ["foo" "bar"]] :_table "bar"}]
-                                  [:sql "INSERT INTO bar (id, list) VALUES ('bar', ARRAY[?, 2, 3 + 5])"
+  (let [!tx (c2/submit-tx *node* [[:put {:id :foo, :list [1 2 ["foo" "bar"]]}]
+                                  [:sql "INSERT INTO xt_docs (id, list) VALUES ('bar', ARRAY[?, 2, 3 + 5])"
                                    [[4]]]])]
     (t/is (= (c2/map->TransactionInstant {:tx-id 0, :sys-time (util/->instant #inst "2020-01-01")}) @!tx))
 
@@ -59,7 +59,7 @@
     (t/is (= [{:id :foo, :list [1 2 ["foo" "bar"]]}
               {:id "bar", :list [4 2 8]}]
              (c2/sql-query *node*
-                           "SELECT b.id, b.list FROM bar b"
+                           "SELECT b.id, b.list FROM xt_docs b"
                            {:basis {:tx !tx}
                             :basis-timeout (Duration/ofSeconds 1)})))))
 

--- a/test/core2/sql/logic_test/direct-sql/no-projected-cols.test
+++ b/test/core2/sql/logic_test/direct-sql/no-projected-cols.test
@@ -1,0 +1,19 @@
+hash-threshold 100
+
+statement ok
+INSERT INTO foo (id) VALUES (1), (2)
+
+statement ok
+INSERT INTO bar (id) VALUES (3)
+
+query I
+SELECT 4 FROM foo
+----
+4
+4
+
+query I
+SELECT (SELECT foo.id FROM bar) FROM foo
+----
+1
+2

--- a/test/core2/sql/logic_test/direct_sql_test.clj
+++ b/test/core2/sql/logic_test/direct_sql_test.clj
@@ -16,6 +16,7 @@
 (slt/def-slt-test direct-sql--sl-a5 {:direct-sql true})
 (slt/def-slt-test direct-sql--slt-variables {:direct-sql true})
 (slt/def-slt-test direct-sql--sl-demo {:direct-sql true})
+(slt/def-slt-test direct-sql--no-projected-cols {:direct-sql true})
 
 (slt/def-slt-test direct-sql--qualified_joins {:direct-sql true})
 (slt/def-slt-test direct-sql--qualified_joins-correlated {:direct-sql true, :decorrelate? false} "direct-sql/qualified_joins.test")

--- a/test/core2/sql/logic_test/runner.clj
+++ b/test/core2/sql/logic_test/runner.clj
@@ -467,7 +467,7 @@
 
   (time (-main "--verify" "--db" "sqlite" "test/core2/sql/logic_test/sqlite_test/select4.test"))
 
-  (time (-main "--verify" "--direct-sql" "--dirs" "--db" "xtdb" "test/core2/sql/logic_test/direct-sql/"))
+  (time (-main "--verify" "--direct-sql" "--db" "xtdb" "test/core2/sql/logic_test/direct-sql/no-projected-cols.test"))
 
  (= (time
       (with-out-str


### PR DESCRIPTION
Scan operator now takes table as symbol, which it uses to build a scan predicate, after which it removes the table col from the relation.

This PR also changes datalog queries to implicitly scan the xt_docs table.