### PR TITLE
Order mega-join using the row count of base tables

### DIFF
--- a/core/src/core2/logical_plan.clj
+++ b/core/src/core2/logical_plan.clj
@@ -74,7 +74,7 @@
 
 (defn unary-expr {:style/indent 2} [relation f]
   (let [{->inner-cursor :->cursor, inner-col-types :col-types} relation
-        {:keys [col-types ->cursor]} (f inner-col-types)]
+        {:keys [col-types ->cursor stats]} (f inner-col-types)]
     {:col-types col-types
      :->cursor (fn [opts]
                  (let [inner (->inner-cursor opts)]
@@ -82,12 +82,13 @@
                      (->cursor opts inner)
                      (catch Throwable e
                        (util/try-close inner)
-                       (throw e)))))}))
+                       (throw e)))))
+     :stats stats}))
 
 (defn binary-expr {:style/indent 3} [left right f]
   (let [{left-col-types :col-types, ->left-cursor :->cursor} left
         {right-col-types :col-types, ->right-cursor :->cursor} right
-        {:keys [col-types ->cursor]} (f left-col-types right-col-types)]
+        {:keys [col-types ->cursor stats]} (f left-col-types right-col-types)]
 
     {:col-types col-types
      :->cursor (fn [opts]
@@ -101,7 +102,8 @@
                            (throw e))))
                      (catch Throwable e
                        (util/try-close left)
-                       (throw e)))))}))
+                       (throw e)))))
+     :stats stats}))
 
 ;;;; Rewriting of logical plan.
 

--- a/modules/datasets/src/core2/datasets/tpch/datalog.clj
+++ b/modules/datasets/src/core2/datasets/tpch/datalog.clj
@@ -30,6 +30,7 @@
 
 (def q2
   '{:find [s_acctbal s_name n_name p p_mfgr s_address s_phone s_comment]
+    :keys [s_acctbal s_name n_name p_partkey p_mfgr s_address s_phone s_comment]
     :where [[p :_table :part]
             [ps :_table :partsupp]
             [s :_table :supplier]
@@ -233,6 +234,7 @@
   '{:find [nation o_year
            (sum (- (* l_extendedprice (- 1 l_discount))
                    (* ps_supplycost l_quantity)))]
+    :keys [nation o_year sum_profit]
     :where [[l :_table :lineitem]
             [ps :_table :partsupp]
             [s :_table :supplier]
@@ -265,7 +267,9 @@
 
 (def q10
   '{:find [c c_name (sum (* l_extendedprice (- 1 l_discount)))
-           c_acctbal n_name c_address c_phone c_comment]
+           c_acctbal c_phone n_name c_address c_comment]
+    :keys [c_custkey c_name revenue
+           c_acctbal c_phone n_name c_address c_comment]
     :where [[c :_table :customer]
             [l :_table :lineitem]
             [n :_table :nation]

--- a/modules/datasets/src/core2/datasets/tpch/datalog.clj
+++ b/modules/datasets/src/core2/datasets/tpch/datalog.clj
@@ -121,7 +121,7 @@
 (def q5
   (-> '{:find [n_name (sum (* l_extendedprice (- 1 l_discount)))]
         :keys [n_name revenue]
-        :in [?region]
+        :in [region]
         :where [[o :_table :orders]
                 [l :_table :lineitem]
                 [s :_table :supplier]
@@ -143,7 +143,7 @@
                 [c :c_nationkey n]
                 [n :n_name n_name]
                 [n :n_regionkey r]
-                [r :r_name ?region]]
+                [r :r_name region]]
         :order-by [[(sum (* l_extendedprice (- 1 l_discount))) :desc]]}
       (with-in-args ["ASIA"])))
 

--- a/test/core2/datalog/datalog_test.clj
+++ b/test/core2/datalog/datalog_test.clj
@@ -597,9 +597,9 @@
                        (assoc :basis {:tx tx})))
                   (into []))))
 
-    (t/is (= [{:e :petr, :first-name "Ivan", :last-name "Ivanov", :a "Petr", :b "Petrov"}
+    (t/is (= [{:e :ivan, :first-name "Petr", :last-name "Petrov", :a "Ivan", :b "Ivanov"}
+              {:e :petr, :first-name "Ivan", :last-name "Ivanov", :a "Petr", :b "Petrov"}
               {:e :sergei, :first-name "Ivan", :last-name "Ivanov", :a "Sergei", :b "Sergei"}
-              {:e :ivan, :first-name "Petr", :last-name "Petrov", :a "Ivan", :b "Ivanov"}
               {:e :sergei, :first-name "Petr", :last-name "Petrov", :a "Sergei", :b "Sergei"}]
              (->> (c2/plan-datalog
                    tu/*node*
@@ -614,7 +614,8 @@
                        (assoc :basis {:tx tx}))
                    [["Ivan" "Ivanov"]
                     ["Petr" "Petrov"]])
-                  (into []))))
+                  (into [])
+                  (sort-by :e))))
 
     (t/testing "apply anti-joins"
       (t/is (= [{:n 1, :e :ivan} {:n 1, :e :petr} {:n 1, :e :sergei}]

--- a/test/core2/stats_test.clj
+++ b/test/core2/stats_test.clj
@@ -1,0 +1,62 @@
+(ns core2.stats-test
+  (:require [clojure.test :as t :refer [deftest]]
+            [core2.api :as c2]
+            [core2.logical-plan :as lp]
+            [core2.node :as node]
+            [core2.test-util :as tu]))
+
+(t/use-fixtures :each tu/with-allocator)
+
+(deftest test-scan
+  (with-open [node (node/start-node {:core2/row-counts {:max-rows-per-chunk 2, :max-rows-per-block 2}})]
+    (let [_tx (-> (c2/submit-tx node [[:put {:id "foo1" :_table "foo"}]
+                                      [:put {:id "bar1" :_table "bar"}]])
+                  (tu/then-await-tx node))
+
+          _tx (-> (c2/submit-tx node [[:put {:id "foo2" :_table "foo"}]
+                                      [:put {:id "baz1" :_table "baz"}]])
+                  (tu/then-await-tx node))
+
+          _tx (-> (c2/submit-tx node [[:put {:id "foo3" :_table "foo"}]
+                                      [:put {:id "bar2" :_table "bar"}]])
+                  (tu/then-await-tx node))
+
+          db @(node/snapshot-async node)]
+
+      (t/is (= {:row-count 3}
+               (:stats
+                 (lp/emit-expr
+                   '{:op :scan, :table foo, :columns [[:column id]]}
+                   {:scan-col-types {['$ 'id] :utf8},
+                    :srcs {'$ db}}))))
+
+      (t/is (= {:row-count 2}
+               (:stats
+                 (lp/emit-expr
+                   '{:op :scan, :table bar, :columns [[:column id]]}
+                   {:scan-col-types {['$ 'id] :utf8},
+                    :srcs {'$ db}})))))))
+
+(deftest test-project
+  (t/is (= {:row-count 5}
+           (:stats
+             (lp/emit-expr
+               '{:op :project,
+                 :projections [[:column foo]],
+                 :relation
+                 {:op :core2.test-util/blocks,
+                  :stats {:row-count 5}
+                  :blocks [[{:foo 1}]]}}
+               {})))))
+
+(deftest test-rename
+  (t/is (= {:row-count 12}
+           (:stats
+             (lp/emit-expr
+               '{:op :rename,
+                 :columns {foo bar}
+                 :relation
+                 {:op :core2.test-util/blocks,
+                  :stats {:row-count 12}
+                  :blocks [[{:foo 1}]]}}
+               {})))))

--- a/test/core2/test_util.clj
+++ b/test/core2/test_util.clj
@@ -146,12 +146,13 @@
          :col-types (s/? (s/map-of simple-symbol? some?))
          :blocks vector?))
 
-(defmethod lp/emit-expr ::blocks [{:keys [col-types blocks]} _args]
+(defmethod lp/emit-expr ::blocks [{:keys [col-types blocks stats]} _args]
   (let [col-types (or col-types
                       (types/rows->col-types (into [] cat blocks)))
         ^Schema schema (Schema. (for [[col-name col-type] col-types]
                                   (types/col-type->field col-name col-type)))]
     {:col-types col-types
+     :stats stats
      :->cursor (fn [{:keys [allocator]}]
                  (->cursor allocator schema blocks))}))
 

--- a/test/core2/tpch_test.clj
+++ b/test/core2/tpch_test.clj
@@ -103,7 +103,8 @@
 (def ^:private ^:dynamic *datalog-qs*
   ;; replace with *qs* once these are all expected to work
   (-> (set (range 1 23))
-      (disj 2 3 5 8 9 10 21) ; TODO join-order planning
+      (disj 2) ; TODO extra row in results
+      (disj 21) ; TODO apply decorr
       (disj 7 20) ; TODO general fail
       (disj 13) ; TODO left-join
       (disj 15) ; TODO has a view, not sure how to represent this


### PR DESCRIPTION
By default operators don't forward stats. Scan is the only operator to generate stats, and project and rename pass this value to their parent.

Commit also exposes join order selected by mega-join to allow testing.

closes #608 