### PR TITLE
RFC: Datalog document-oriented graph-match syntax

### DIFF
--- a/test/core2/datalog/datalog_test.clj
+++ b/test/core2/datalog/datalog_test.clj
@@ -172,6 +172,17 @@
                   (into #{})))
           "multi-param join")
 
+    (t/is (= #{{:e 1, :e2 1, :n "Ivan"}
+               {:e 2, :e2 2, :n "Petr"}
+               {:e 3, :e2 3, :n "Ivan"}}
+             (->> (c2/plan-datalog tu/*node*
+                                   (-> '{:find [e e2 n]
+                                         :where [{:id e, :name n, :age a}
+                                                 (xt_docs {:id e2, :name n, :age a})]}
+                                       (assoc :basis {:tx tx})))
+                  (into #{})))
+          "multi-param join with match")
+
     (t/is (= #{{:e1 1, :e2 1, :a1 15, :a2 15}
                {:e1 1, :e2 3, :a1 15, :a2 37}
                {:e1 3, :e2 1, :a1 37, :a2 15}


### PR DESCRIPTION
Rather than a handful of triple clauses, given that we now have tables/'bags' available (and that we tend to call ourselves a document-graph database rather than a triple store), I've had a bit of a play with a graph-match syntax inspired by Cypher's [`MATCH`](https://neo4j.com/docs/cypher-manual/current/clauses/match/) and 'regular' (i.e. not EDN) Datalog relations.

Weekend hack - RFC! Mainly looking for feedback about the concept rather than i-dotting (although i-dotting feedback welcome too).

e.g. we could consider moving these match clauses under a separate top-level `:match` key à la Cypher (i.e. move them out of the `:where` - `:where` is likely associated with predicates for people coming from either Cypher or SQL). Eventually, we could even (my preference) have Hiccup-inspired syntax (e.g. `[:where [preds ..] [:match ...]]`) where every node in the tree would be a valid relation - a win for query composability.

Possible syntaxes: (all 4 are equivalent and supported in the PR)

* `:where [[e :table "xt_docs"], [e :foo "foo-v"], [e :bar bar], [e :baz baz]]` (existing triple syntax, included for comparison)
* `:where [{:id e, :foo "foo-v", :bar bar, :baz baz}]` (assuming `xt_docs` bag by default)
* `:where [(xt_docs {:id e, :foo "foo-v", :bar bar, :baz baz})]` (explicit table name)
* `:where [(xt_docs [{:id e, :foo "foo-v"}, bar baz])]` (shorthand for when the attr is the same as the logic-var, like Clojure `:keys`)

I've updated the first 10 TPC-H queries which pass our 0.01 result validation tests. I recommend the side-by-side diff in the changed files - but here's Q2:

```clojure
;; original

{:find [s_acctbal s_name n_name p p_mfgr s_address s_phone s_comment]
 :keys [s_acctbal s_name n_name p_partkey p_mfgr s_address s_phone s_comment]
 :where [[p :_table :part]
         [ps :_table :partsupp]
         [s :_table :supplier]
         [n :_table :nation]
         [r :_table :region]

         [p :p_mfgr p_mfgr]
         [p :p_size 15]
         [p :p_type p_type]
         [(like p_type "%BRASS")]

         [ps :ps_partkey p]
         [ps :ps_supplycost ps_supplycost]
         [ps :ps_suppkey s]

         (q {:find [(min ps_supplycost)]
             :keys [ps_supplycost]
             :in [p]
             :where [[ps :_table :partsupp]
                     [s :_table :supplier]
                     [n :_table :nation]
                     [r :_table :region]
                     [ps :ps_partkey p]
                     [ps :ps_supplycost ps_supplycost]
                     [ps :ps_suppkey s]
                     [s :s_nationkey n]
                     [n :n_regionkey r]
                     [r :r_name "EUROPE"]]})

         [s :s_acctbal s_acctbal]
         [s :s_address s_address]
         [s :s_name s_name]
         [s :s_phone s_phone]
         [s :s_comment s_comment]
         [s :s_nationkey n]

         [n :n_name n_name]
         [n :n_regionkey r]

         [r :r_name "EUROPE"]]

 :order-by [[s_acctbal :desc]
            [n_name :asc]
            [s_name :asc]
            [p :asc]]
 :limit 100}
```

```clojure
;; with graph-match syntax

{:find [s_acctbal s_name n_name p p_mfgr s_address s_phone s_comment]
 :keys [s_acctbal s_name n_name p_partkey p_mfgr s_address s_phone s_comment]

 :where [(part [{:id p} p_mfgr {:p_size 15} p_type])
         [(like p_type "%BRASS")]

         (partsupp [{:ps_partkey p, :ps_suppkey s} ps_supplycost])

         (supplier [{:id s, :s_nationkey n}
                    s_acctbal s_address s_name s_phone s_comment])

         (nation [{:id n, :n_regionkey r} n_name])
         (region {:id r, :r_name "EUROPE"})

         (q {:find [(min ps_supplycost)]
             :keys [ps_supplycost]
             :in [p]
             :where [(partsupp [{:ps_partkey p, :ps_suppkey s}
                                ps_supplycost])
                     (supplier {:id s, :s_nationkey n})
                     (nation {:id n, :n_regionkey r})
                     (region {:id r, :r_name "EUROPE"})]})]

 :order-by [[s_acctbal :desc] [n_name :asc] [s_name :asc] [p :asc]]
 :limit 100}
```