### PR TITLE
RFC: temporal++ Datalog - entity history and across-time queries

### DIFF
--- a/test/core2/datalog/datalog_test.clj
+++ b/test/core2/datalog/datalog_test.clj
@@ -172,6 +172,17 @@
                   (into #{})))
           "multi-param join")
 
+    (t/is (= #{{:e 1, :e2 1, :n "Ivan"}
+               {:e 2, :e2 2, :n "Petr"}
+               {:e 3, :e2 3, :n "Ivan"}}
+             (->> (c2/plan-datalog tu/*node*
+                                   (-> '{:find [e e2 n]
+                                         :where [{:id e, :name n, :age a}
+                                                 (xt_docs {:id e2, :name n, :age a})]}
+                                       (assoc :basis {:tx tx})))
+                  (into #{})))
+          "multi-param join with match")
+
     (t/is (= #{{:e1 1, :e2 1, :a1 15, :a2 15}
                {:e1 1, :e2 3, :a1 15, :a2 37}
                {:e1 3, :e2 1, :a1 37, :a2 15}


### PR DESCRIPTION
(this is based on #624 so only the [latter commit](https://github.com/xtdb/core2/pull/625/commits/90196ef8172a0daebb6ab56c188fd35bd2fdc582) is relevant here)

First pass - i.e. I'm _really_ not wedded to the syntax here, RFC!

Adds an extra optional map to the graph-match syntax to specify application and system time ranges for the table, similar to SQL:2011's `FOR SYSTEM_TIME AS OF`, `FOR SYSTEM_TIME BETWEEN ... AND ...` etc.

```clojure
{:find [id v]
 :where [(my-table [id {:value v}]
                   {:at-app-time #inst "..."
                    ;; or
                    :app-time-in [#inst "from-inst", #inst "to-inst"] ; closed/open
                    ;; or, for "all time"
                    :app-time-in [nil nil]})]}
```

This means you can (for example) query from two bags (or the same bag) at different valid times:

```clojure
{:find [id id2 v]
 :where [(my-table [id {:value v}]
                   {:at-app-time #inst "2023"})
         (my-table [id2 {:value v}]
                   {:at-app-time #inst "2018"})]}
```

or even 'who was here at the same time as Mark?'

```clojure
{:find [id],
 :where [(xt_docs [id {:application_time_start start, :application_time_end end}]
                  ;; this is probably common enough to warrant some "all-time" sugar?
                  {:app-time-in [nil nil]})
         (xt_docs [{:id :mark, :application_time_start m-start, :application_time_end m-end}]
                  {:app-time-in [nil nil]})

         ;; we'll likely want a built-in for 'overlaps' too?
         [(< start m-end)]
         [(> end m-start)]]}
```

Anyway, a starter-for-ten - hopefully this inspires some more ideas :slightly_smiling_face: 