### PR TITLE
Fix select to return no-col rel if pred is true

### DIFF
--- a/core/src/core2/vector/indirect.clj
+++ b/core/src/core2/vector/indirect.clj
@@ -270,7 +270,8 @@
 
 (defn select ^core2.vector.IIndirectRelation [^IIndirectRelation in-rel, ^ints idxs]
   (->indirect-rel (for [^IIndirectVector in-col in-rel]
-                    (.select in-col idxs))))
+                    (.select in-col idxs))
+                  (alength idxs)))
 
 (defn copy ^core2.vector.IIndirectRelation [^IIndirectRelation in-rel, ^BufferAllocator allocator]
   (->indirect-rel (for [^IIndirectVector in-col in-rel]

--- a/test/core2/operator/select_test.clj
+++ b/test/core2/operator/select_test.clj
@@ -1,5 +1,5 @@
 (ns core2.operator.select-test
-  (:require [clojure.test :as t]
+  (:require [clojure.test :as t :refer [deftest]]
             [core2.test-util :as tu]))
 
 (t/use-fixtures :each tu/with-allocator)
@@ -26,3 +26,17 @@
                              [{:a 83, :b 100}]]]]
                           {:params {'?b 50}
                            :preserve-blocks? true})))))
+
+(deftest test-no-column-relation
+  (t/is (= [{}]
+           (tu/query-ra '[:select true
+                          [:table [{}]]])))
+  (t/is (= []
+           (tu/query-ra
+            '[:select false
+              [:table [{}]]])))
+
+  (t/is (= [{} {} {}]
+           (tu/query-ra '[:select (= ?ap_n 2)
+                          [:table [{} {} {}]]]
+                        {:params {'?ap_n 2}}))))


### PR DESCRIPTION
Not sure this is the best way to detect the no-col-rel case

Also not sure if it needs pushing down to the IV select/copy level. I put it there as a saw lots of calls to them, however stuff like join already seems to get this correct (pre fix) so it may be a select only issue (in which case this can be hoisted up a level easily)