### PR TITLE
make datalog plans more friendly to decorr

### DIFF
--- a/core/src/core2/logical_plan.clj
+++ b/core/src/core2/logical_plan.clj
@@ -506,25 +506,27 @@
     (with-meta relation {:column->name smap
                          :add-projection-fn add-projection-fn})))
 
+(defn column? [x]
+  (and (symbol? x)
+       (:column? (meta x))))
+
+(defn correlated-column? [x]
+  (and (symbol? x)
+       (:correlated-column? (meta x))))
+
 (defn expr-symbols [expr]
   (set (for [x (flatten (if (coll? expr)
                           (seq expr)
                           [expr]))
-             :when (and (symbol? x)
-                        (:column? (meta x)))]
+             :when (column? x)]
          x)))
 
 (defn expr-correlated-symbols [expr]
   (set (for [x (flatten (if (coll? expr)
                           (seq expr)
                           [expr]))
-             :when (and (symbol? x)
-                        (:correlated-column? (meta x)))]
+             :when (correlated-column? x)]
          x)))
-
-(defn column? [x]
-  (and (symbol? x)
-       (:column? (meta x))))
 
 (defn equals-predicate? [predicate]
   (and (sequential? predicate)


### PR DESCRIPTION
Tests all pass, but not convinced the current implementation is robust. Mostly hacked stuff in as POC, probably wants a more clear relationship between apply params and the var/col metadata.

Also the inconstancy between subquery "like" things and how their params are represented/passed (subqueries using IN vs other forms not) may be adding some confusion/overhead.

That being said, this "spike" has given me enough confidence that this (or a similar approach) will allow us to decorrelate a good number more datalog queries.

TODO:

- pull-correlated-selection-up-towards-apply rule needs to work with rename style projects
- implictly `and`ing of unify predicates by datalog planner traps correlated preds with real join clauses #629 would fix this
- rule to take joins over no-col table and convert to a select over independent rel