### PR TITLE
Rename min/max functions to least/greatest

### DIFF
--- a/core/src/main/clojure/core2/expression.clj
+++ b/core/src/main/clojure/core2/expression.clj
@@ -818,11 +818,11 @@
                        (/ l# r#))))})
 
 ;; TODO extend min/max to variable width
-(defmethod codegen-call [:max :num :num] [{:keys [arg-types]}]
+(defmethod codegen-call [:greatest :num :num] [{:keys [arg-types]}]
   {:return-type (types/least-upper-bound arg-types)
    :->call-code #(do `(Math/max ~@%))})
 
-(defmethod codegen-call [:min :num :num] [{:keys [arg-types]}]
+(defmethod codegen-call [:least :num :num] [{:keys [arg-types]}]
   {:return-type (types/least-upper-bound arg-types)
    :->call-code #(do `(Math/min ~@%))})
 

--- a/core/src/main/clojure/core2/expression/macro.clj
+++ b/core/src/main/clojure/core2/expression/macro.clj
@@ -27,7 +27,7 @@
 (doseq [f #{:+ :- :* :/}]
   (defmethod macroexpand1-call f [expr] (macroexpand1l-call expr)))
 
-(doseq [[f cmp-f] [[:max :>] [:min :<]]]
+(doseq [[f cmp-f] [[:greatest :>] [:least :<]]]
   (defmethod macroexpand1-call f [{:keys [f args] :as expr}]
     (case (count args)
       0 {:op :literal, :literal nil}

--- a/core/src/main/clojure/core2/sql/plan.clj
+++ b/core/src/main/clojure/core2/sql/plan.clj
@@ -231,10 +231,10 @@
          (cons 'case))
 
     :least_function
-    (list* 'min (map expr (r/right-zips (r/$ z 2))))
+    (list* 'least (map expr (r/right-zips (r/$ z 2))))
 
     :greatest_function
-    (list* 'max (map expr (r/right-zips (r/$ z 2))))
+    (list* 'greatest (map expr (r/right-zips (r/$ z 2))))
 
     (throw (err/illegal-arg :core2.sql/parse-error
                             {::err/message (str "Cannot build expression for: "  (pr-str (r/node z)))
@@ -1619,13 +1619,13 @@
 
                             [{'application_time_start `(~'cast-tstz ~(cond
                                                                        (= :all-application-time app-time-extents) app-start-sym
-                                                                       app-from-expr `(~'max ~app-start-sym ~app-from-expr)
-                                                                       app-time-as-of-now? `(~'max ~app-start-sym (~'current-timestamp))
+                                                                       app-from-expr `(~'greatest ~app-start-sym ~app-from-expr)
+                                                                       app-time-as-of-now? `(~'greatest ~app-start-sym (~'current-timestamp))
                                                                        :else app-start-sym))}
                              {'application_time_end `(~'cast-tstz ~(cond
                                                                      (= :all-application-time app-time-extents) app-end-sym
-                                                                     app-to-expr `(~'min ~app-end-sym ~app-to-expr)
-                                                                     app-time-as-of-now? `(~'min ~app-end-sym ~'core2/end-of-time)
+                                                                     app-to-expr `(~'least ~app-end-sym ~app-to-expr)
+                                                                     app-time-as-of-now? `(~'least ~app-end-sym ~'core2/end-of-time)
                                                                      :else app-end-sym))}]))
           (if (and app-to app-from)
             [:select `(~'and

--- a/src/test/clojure/core2/expression_test.clj
+++ b/src/test/clojure/core2/expression_test.clj
@@ -1080,25 +1080,25 @@
   (t/is (= [2.772588722239781 nil]
            (project '(ln x) [{:x 16} {:x nil}]))))
 
-(t/deftest test-min-max
+(t/deftest test-least-greatest
   (letfn [(run-test [form x y]
             (with-open [rel (tu/open-rel [(tu/open-vec "x" [x])
                                           (tu/open-vec "y" [y])])]
               (-> (run-projection rel form)
                   :res first)))]
-    (t/is (= 9 (run-test '(max x y) 1 9)))
-    (t/is (= 1.0 (run-test '(min x y) 1.0 9.0)))
+    (t/is (= 9 (run-test '(greatest x y) 1 9)))
+    (t/is (= 1.0 (run-test '(least x y) 1.0 9.0)))
 
-    (t/is (= nil (run-test '(min x y) nil 9.0)))
+    (t/is (= nil (run-test '(least x y) nil 9.0)))
 
-    (t/is (= nil (run-test '(max x y) 1.0 nil)))
+    (t/is (= nil (run-test '(greatest x y) 1.0 nil)))
 
     (t/testing "mixed temporal types"
       (t/is (= #time/date "2020-08-02"
-               (run-test '(min x y) #time/date-time "2020-08-02T15:09:00" #time/date "2020-08-02")))
+               (run-test '(least x y) #time/date-time "2020-08-02T15:09:00" #time/date "2020-08-02")))
 
       (t/is (= #time/date-time "2020-08-01T15:09:00"
-               (run-test '(min x y) #time/date-time "2020-08-01T15:09:00" #time/date "2020-08-02"))))))
+               (run-test '(least x y) #time/date-time "2020-08-01T15:09:00" #time/date "2020-08-02"))))))
 
 (t/deftest can-return-string-multiple-times
   (with-open [rel (tu/open-rel [(tu/open-vec "x" [1 2 3])])]

--- a/src/test/resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
+++ b/src/test/resources/core2/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
@@ -14,8 +14,8 @@
     x6
     x7
     {x9 ?_2}
-    {x10 (cast-tstz (max x4 ?_0))}
-    {x11 (cast-tstz (min x5 ?_1))}]
+    {x10 (cast-tstz (greatest x4 ?_0))}
+    {x11 (cast-tstz (least x5 ?_1))}]
    [:rename
     {id x1,
      _iid x2,

--- a/src/test/resources/core2/sql/plan_test_expectations/test-sql-delete-plan.edn
+++ b/src/test/resources/core2/sql/plan_test_expectations/test-sql-delete-plan.edn
@@ -12,8 +12,8 @@
     x3
     x6
     x7
-    {x9 (cast-tstz (max x4 #time/date "2020-05-01"))}
-    {x10 (cast-tstz (min x5 #time/date "9999-12-31"))}]
+    {x9 (cast-tstz (greatest x4 #time/date "2020-05-01"))}
+    {x10 (cast-tstz (least x5 #time/date "9999-12-31"))}]
    [:rename
     {id x1,
      _iid x2,

--- a/src/test/resources/core2/sql/plan_test_expectations/test-sql-update-plan.edn
+++ b/src/test/resources/core2/sql/plan_test_expectations/test-sql-update-plan.edn
@@ -14,8 +14,8 @@
     x6
     x7
     {x9 "Sue"}
-    {x10 (cast-tstz (max x4 #time/date "2021-07-01"))}
-    {x11 (cast-tstz (min x5 #time/date "9999-12-31"))}]
+    {x10 (cast-tstz (greatest x4 #time/date "2021-07-01"))}
+    {x11 (cast-tstz (least x5 #time/date "9999-12-31"))}]
    [:rename
     {id x1,
      _iid x2,


### PR DESCRIPTION
Least/greatest reflects the SQL terminology and avoids naming collisions with the Datalog min/max aggregates.