### PR TITLE
Require transaction ops to have a bag specified

### DIFF
--- a/modules/datasets/src/main/clojure/core2/datasets/tpch.clj
+++ b/modules/datasets/src/main/clojure/core2/datasets/tpch.clj
@@ -34,10 +34,10 @@
                        [(keyword (.getColumnName col))
                         (read-tpch-cell col entity)])
                      (into {}))]
-        (assoc doc
-               :id (->> (mapv doc (get table->pkey table-name))
-                         (str/join "___"))
-               :_table table-name)))))
+        (-> (assoc doc
+                   :id (->> (mapv doc (get table->pkey table-name))
+                            (str/join "___")))
+            (with-meta {:table (symbol table-name)}))))))
 
 (defn submit-docs! [tx-producer scale-factor]
   (log/debug "Transacting TPC-H tables...")
@@ -48,7 +48,7 @@
                                                  (reduce (fn [[_!last-tx last-doc-count] batch]
                                                            [(c2.d/submit-tx& tx-producer
                                                                              (vec (for [doc batch]
-                                                                                    [:put doc])))
+                                                                                    [:put (:table (meta doc)) doc])))
                                                             (+ last-doc-count (count batch))])
                                                          [nil 0]))]
                    (log/debug "Transacted" doc-count (.getTableName t))

--- a/modules/datasets/src/main/clojure/core2/ts_devices.clj
+++ b/modules/datasets/src/main/clojure/core2/ts_devices.clj
@@ -8,36 +8,36 @@
   (:import java.util.zip.GZIPInputStream))
 
 (defn device-info-csv->doc [[device-id api-version manufacturer model os-name]]
-  {:id device-id
-   :_table :device-info
-   :device-id device-id
-   :api-version api-version
-   :manufacturer manufacturer
-   :model model
-   :os-name os-name})
+  (with-meta {:id device-id
+              :device-id device-id
+              :api-version api-version
+              :manufacturer manufacturer
+              :model model
+              :os-name os-name}
+    {:table 'device-info}))
 
 (defn readings-csv->doc [[time device-id battery-level battery-status
                           battery-temperature bssid
                           cpu-avg-1min cpu-avg-5min cpu-avg-15min
                           mem-free mem-used rssi ssid]]
-  {:id device-id
-   :_table :device-readings
-   :time (inst/read-instant-date
-          (-> time
-              (str/replace " " "T")
-              (str/replace #"-(\d\d)$" ".000-$1:00")))
-   :device-id device-id
-   :battery-level (Double/parseDouble battery-level)
-   :battery-status battery-status
-   :battery-temperature (Double/parseDouble battery-temperature)
-   :bssid bssid
-   :cpu-avg-1min (Double/parseDouble cpu-avg-1min)
-   :cpu-avg-5min (Double/parseDouble cpu-avg-5min)
-   :cpu-avg-15min (Double/parseDouble cpu-avg-15min)
-   :mem-free (Double/parseDouble mem-free)
-   :mem-used (Double/parseDouble mem-used)
-   :rssi (Double/parseDouble rssi)
-   :ssid ssid})
+  (with-meta {:id device-id
+              :time (inst/read-instant-date
+                     (-> time
+                         (str/replace " " "T")
+                         (str/replace #"-(\d\d)$" ".000-$1:00")))
+              :device-id device-id
+              :battery-level (Double/parseDouble battery-level)
+              :battery-status battery-status
+              :battery-temperature (Double/parseDouble battery-temperature)
+              :bssid bssid
+              :cpu-avg-1min (Double/parseDouble cpu-avg-1min)
+              :cpu-avg-5min (Double/parseDouble cpu-avg-5min)
+              :cpu-avg-15min (Double/parseDouble cpu-avg-15min)
+              :mem-free (Double/parseDouble mem-free)
+              :mem-used (Double/parseDouble mem-used)
+              :rssi (Double/parseDouble rssi)
+              :ssid ssid}
+    {:table 'device-readings}))
 
 (defn local-ts-devices-file [size file]
   (io/resource (format "ts-devices/small/devices_%s_%s.csv.gz"

--- a/src/test/clojure/core2/align_test.clj
+++ b/src/test/clojure/core2/align_test.clj
@@ -48,9 +48,9 @@
 
 (t/deftest test-aligns-temporal-columns-correctly-363
   (with-open [node (node/start-node {})]
-    (c2/submit-tx node [[:put {:id :my-doc, :last_updated "tx1" :_table "foo"}]] {:sys-time #inst "3000"})
+    (c2/submit-tx node [[:put 'foo {:id :my-doc, :last_updated "tx1"}]] {:sys-time #inst "3000"})
 
-    (c2/submit-tx node [[:put {:id :my-doc, :last_updated "tx2" :_table "foo"}]] {:sys-time #inst "3001"})
+    (c2/submit-tx node [[:put 'foo {:id :my-doc, :last_updated "tx2"}]] {:sys-time #inst "3001"})
 
     (t/is (= [{:system_time_start (util/->zdt #inst "3000")
                :system_time_end (util/->zdt #inst "3001")

--- a/src/test/clojure/core2/as_of_test.clj
+++ b/src/test/clojure/core2/as_of_test.clj
@@ -10,8 +10,8 @@
 (def end-of-time-zdt (util/->zdt util/end-of-time))
 
 (t/deftest test-as-of-tx
-  (let [tx1 (c2/submit-tx tu/*node* [[:put {:id :my-doc, :last-updated "tx1"}]])
-        tx2 (c2/submit-tx tu/*node* [[:put {:id :my-doc, :last-updated "tx2"}]])]
+  (let [tx1 (c2/submit-tx tu/*node* [[:put 'xt_docs {:id :my-doc, :last-updated "tx1"}]])
+        tx2 (c2/submit-tx tu/*node* [[:put 'xt_docs {:id :my-doc, :last-updated "tx2"}]])]
 
     (t/is (= #{{:last-updated "tx1"} {:last-updated "tx2"}}
              (set (tu/query-ra '[:scan {:table xt_docs} [last-updated]]
@@ -35,8 +35,8 @@
                               (assoc :basis {:tx tx1})))))))))
 
 (t/deftest test-app-time
-  (let [{:keys [sys-time]} (c2/submit-tx tu/*node* [[:put {:id :doc, :version 1}]
-                                                    [:put {:id :doc-with-app-time}
+  (let [{:keys [sys-time]} (c2/submit-tx tu/*node* [[:put 'xt_docs {:id :doc, :version 1}]
+                                                    [:put 'xt_docs {:id :doc-with-app-time}
                                                      {:app-time-start #inst "2021"}]])
         sys-time (util/->zdt sys-time)]
 
@@ -58,10 +58,10 @@
                   (into {} (map (juxt :id identity))))))))
 
 (t/deftest test-sys-time
-  (let [tx1 (c2/submit-tx tu/*node* [[:put {:id :doc, :version 0}]])
+  (let [tx1 (c2/submit-tx tu/*node* [[:put 'xt_docs {:id :doc, :version 0}]])
         tt1 (util/->zdt (:sys-time tx1))
 
-        tx2 (c2/submit-tx tu/*node* [[:put {:id :doc, :version 1}]])
+        tx2 (c2/submit-tx tu/*node* [[:put 'xt_docs {:id :doc, :version 1}]])
 
         tt2 (util/->zdt (:sys-time tx2))
 
@@ -110,15 +110,15 @@
                  (map :id)
                  frequencies))]
 
-    (c2/submit-tx tu/*node* [[:put {:id :doc, :version 0}]
-                             [:put {:id :other-doc, :version 0}]])
+    (c2/submit-tx tu/*node* [[:put 'xt_docs {:id :doc, :version 0}]
+                             [:put 'xt_docs {:id :other-doc, :version 0}]])
 
-    (c2/submit-tx tu/*node* [[:put {:id :doc, :version 1}]])
+    (c2/submit-tx tu/*node* [[:put 'xt_docs {:id :doc, :version 1}]])
 
     (t/is (= {:doc 3, :other-doc 1} (all-time-docs))
           "documents present before evict")
 
-    (c2/submit-tx tu/*node* [[:evict :doc]])
+    (c2/submit-tx tu/*node* [[:evict 'xt_docs :doc]])
 
     (t/is (= {:other-doc 1} (all-time-docs))
           "documents removed after evict")))

--- a/src/test/clojure/core2/core/datalog_test.clj
+++ b/src/test/clojure/core2/core/datalog_test.clj
@@ -15,8 +15,8 @@
 (t/use-fixtures :each tu/with-mock-clock tu/with-node)
 
 (def ivan+petr
-  [[:put {:id :ivan, :first-name "Ivan", :last-name "Ivanov"}]
-   [:put {:id :petr, :first-name "Petr", :last-name "Petrov"}]])
+  '[[:put xt_docs {:id :ivan, :first-name "Ivan", :last-name "Ivanov"}]
+    [:put xt_docs {:id :petr, :first-name "Petr", :last-name "Petrov"}]])
 
 (deftest test-scan
   (let [tx (c2/submit-tx tu/*node* ivan+petr)]
@@ -105,10 +105,10 @@
 ;; https://github.com/tonsky/datascript/blob/1.1.0/test/datascript/test/query.cljc#L12-L36
 (deftest datascript-test-joins
   (let [tx (c2/submit-tx tu/*node*
-                         [[:put {:id 1, :name "Ivan", :age 15}]
-                          [:put {:id 2, :name "Petr", :age 37}]
-                          [:put {:id 3, :name "Ivan", :age 37}]
-                          [:put {:id 4, :age 15}]])]
+                         '[[:put xt_docs {:id 1, :name "Ivan", :age 15}]
+                           [:put xt_docs {:id 2, :name "Petr", :age 37}]
+                           [:put xt_docs {:id 3, :name "Ivan", :age 37}]
+                           [:put xt_docs {:id 4, :age 15}]])]
 
     (t/is (= #{{:e 1} {:e 2} {:e 3}}
              (set (c2/q tu/*node*
@@ -201,10 +201,10 @@
 ;; https://github.com/tonsky/datascript/blob/1.1.0/test/datascript/test/query_aggregates.cljc#L14-L39
 (t/deftest datascript-test-aggregates
   (let [tx (c2/submit-tx tu/*node*
-                         [[:put {:id :cerberus, :heads 3}]
-                          [:put {:id :medusa, :heads 1}]
-                          [:put {:id :cyclops, :heads 1}]
-                          [:put {:id :chimera, :heads 1}]])]
+                         '[[:put xt_docs {:id :cerberus, :heads 3}]
+                           [:put xt_docs {:id :medusa, :heads 1}]
+                           [:put xt_docs {:id :cyclops, :heads 1}]
+                           [:put xt_docs {:id :chimera, :heads 1}]])]
     (t/is (= #{{:heads 1, :count-heads 3} {:heads 3, :count-heads 1}}
              (set (c2/q tu/*node*
                         (-> '{:find [heads (count heads)]
@@ -225,9 +225,9 @@
           "various aggs")))
 
 (t/deftest test-find-exprs
-  (let [tx (c2/submit-tx tu/*node* [[:put {:id :o1, :unit-price 1.49, :quantity 4}]
-                                    [:put {:id :o2, :unit-price 5.39, :quantity 1}]
-                                    [:put {:id :o3, :unit-price 0.59, :quantity 7}]])]
+  (let [tx (c2/submit-tx tu/*node* '[[:put xt_docs {:id :o1, :unit-price 1.49, :quantity 4}]
+                                     [:put xt_docs {:id :o2, :unit-price 5.39, :quantity 1}]
+                                     [:put xt_docs {:id :o3, :unit-price 0.59, :quantity 7}]])]
     (t/is (= [{:oid :o1, :o-value 5.96}
               {:oid :o2, :o-value 5.39}
               {:oid :o3, :o-value 4.13}]
@@ -239,9 +239,9 @@
                        (assoc :basis {:tx tx})))))))
 
 (deftest test-aggregate-exprs
-  (let [tx (c2/submit-tx tu/*node* [[:put {:id :foo, :category :c0, :v 1}]
-                                    [:put {:id :bar, :category :c0, :v 2}]
-                                    [:put {:id :baz, :category :c1, :v 4}]])]
+  (let [tx (c2/submit-tx tu/*node* '[[:put xt_docs {:id :foo, :category :c0, :v 1}]
+                                     [:put xt_docs {:id :bar, :category :c0, :v 2}]
+                                     [:put xt_docs {:id :baz, :category :c1, :v 4}]])]
     (t/is (= [{:category :c0, :sum-doubles 6}
               {:category :c1, :sum-doubles 8}]
              (c2/q tu/*node*
@@ -436,8 +436,8 @@
 (deftest test-value-unification
   (let [tx (c2/submit-tx tu/*node*
                          (conj ivan+petr
-                               [:put {:id :sergei :first-name "Sergei" :last-name "Sergei"}]
-                               [:put {:id :jeff :first-name "Sergei" :last-name "but-different"}]))]
+                               '[:put xt_docs {:id :sergei :first-name "Sergei" :last-name "Sergei"}]
+                               '[:put xt_docs {:id :jeff :first-name "Sergei" :last-name "but-different"}]))]
     (t/is (= [{:e :sergei, :n "Sergei"}]
              (c2/q
               tu/*node*
@@ -456,10 +456,10 @@
 
 (deftest test-semi-join
   (let [tx (c2/submit-tx tu/*node*
-                         [[:put {:id :ivan, :name "Ivan"}]
-                          [:put {:id :petr, :name "Petr", :parent :ivan}]
-                          [:put {:id :sergei, :name "Sergei", :parent :petr}]
-                          [:put {:id :jeff, :name "Jeff", :parent :petr}]])]
+                         '[[:put xt_docs {:id :ivan, :name "Ivan"}]
+                           [:put xt_docs {:id :petr, :name "Petr", :parent :ivan}]
+                           [:put xt_docs {:id :sergei, :name "Sergei", :parent :petr}]
+                           [:put xt_docs {:id :jeff, :name "Jeff", :parent :petr}]])]
 
     (t/is (= [{:e :ivan} {:e :petr}]
              (c2/q tu/*node*
@@ -493,9 +493,9 @@
 (deftest test-anti-join
   (let [tx (c2/submit-tx
             tu/*node*
-            [[:put {:id :ivan, :first-name "Ivan", :last-name "Ivanov" :foo 1}]
-             [:put {:id :petr, :first-name "Petr", :last-name "Petrov" :foo 1}]
-             [:put {:id :sergei :first-name "Sergei" :last-name "Sergei" :foo 1}]])]
+            '[[:put xt_docs {:id :ivan, :first-name "Ivan", :last-name "Ivanov" :foo 1}]
+              [:put xt_docs {:id :petr, :first-name "Petr", :last-name "Petrov" :foo 1}]
+              [:put xt_docs {:id :sergei :first-name "Sergei" :last-name "Sergei" :foo 1}]])]
 
     (t/is (= [{:e :ivan} {:e :sergei}]
              (c2/q tu/*node*
@@ -645,9 +645,9 @@
 
 (deftest calling-a-function-580
   (let [tx (c2/submit-tx tu/*node*
-                         [[:put {:id :ivan, :age 15}]
-                          [:put {:id :petr, :age 22}]
-                          [:put {:id :slava, :age 37}]])]
+                         '[[:put xt_docs {:id :ivan, :age 15}]
+                           [:put xt_docs {:id :petr, :age 22}]
+                           [:put xt_docs {:id :slava, :age 37}]])]
     (t/is (= #{{:e1 :petr, :e2 :ivan, :e3 :slava}
                {:e1 :ivan, :e2 :petr, :e3 :slava}}
              (set
@@ -673,9 +673,9 @@
 
 (deftest test-nested-expressions-581
   (let [tx (c2/submit-tx tu/*node*
-                         [[:put {:id :ivan, :age 15}]
-                          [:put {:id :petr, :age 22, :height 240, :parent 1}]
-                          [:put {:id :slava, :age 37, :parent 2}]])]
+                         '[[:put xt_docs {:id :ivan, :age 15}]
+                           [:put xt_docs {:id :petr, :age 22, :height 240, :parent 1}]
+                           [:put xt_docs {:id :slava, :age 37, :parent 2}]])]
 
     (t/is (= [{:e1 :ivan, :e2 :petr, :e3 :slava}
               {:e1 :petr, :e2 :ivan, :e3 :slava}]
@@ -719,10 +719,10 @@
                          (assoc :basis {:tx tx}))))))))
 
 (deftest test-union-join
-  (let [tx (c2/submit-tx tu/*node* [[:put {:id :ivan, :age 20, :role :developer}]
-                                    [:put {:id :oleg, :age 30, :role :manager}]
-                                    [:put {:id :petr, :age 35, :role :qa}]
-                                    [:put {:id :sergei, :age 35, :role :manager}]])]
+  (let [tx (c2/submit-tx tu/*node* '[[:put xt_docs {:id :ivan, :age 20, :role :developer}]
+                                     [:put xt_docs {:id :oleg, :age 30, :role :manager}]
+                                     [:put xt_docs {:id :petr, :age 35, :role :qa}]
+                                     [:put xt_docs {:id :sergei, :age 35, :role :manager}]])]
 
     (letfn [(q [query]
               (c2/q tu/*node*
@@ -754,10 +754,10 @@
                                           [(+ age 10) older-age])]})))))))
 
 (deftest test-union-join-with-subquery-638
-  (let [tx (c2/submit-tx tu/*node* [[:put {:id :ivan, :age 20, :role :developer}]
-                                    [:put {:id :oleg, :age 30, :role :manager}]
-                                    [:put {:id :petr, :age 35, :role :qa}]
-                                    [:put {:id :sergei, :age 35, :role :manager}]])]
+  (let [tx (c2/submit-tx tu/*node* '[[:put xt_docs {:id :ivan, :age 20, :role :developer}]
+                                     [:put xt_docs {:id :oleg, :age 30, :role :manager}]
+                                     [:put xt_docs {:id :petr, :age 35, :role :qa}]
+                                     [:put xt_docs {:id :sergei, :age 35, :role :manager}]])]
     (t/is (= [{:e :oleg}]
              (c2/q tu/*node* (-> '{:find [e]
                                    :where [(union-join [e]
@@ -789,10 +789,10 @@
                        (assoc :basis {:tx tx}))))
           "films made by the Bond with the most films"))
 
-  (let [tx (c2/submit-tx tu/*node* [[:put {:id :a1, :a 1}]
-                                    [:put {:id :a2, :a 2}]
-                                    [:put {:id :b2, :b 2}]
-                                    [:put {:id :b3, :b 3}]])]
+  (let [tx (c2/submit-tx tu/*node* '[[:put xt_docs {:id :a1, :a 1}]
+                                     [:put xt_docs {:id :a2, :a 2}]
+                                     [:put xt_docs {:id :b2, :b 2}]
+                                     [:put xt_docs {:id :b3, :b 3}]])]
     (t/is (= [{:aid :a2, :bid :b2}]
              (c2/q tu/*node*
                    (-> '{:find [aid bid]
@@ -829,9 +829,9 @@
   (with-open [node (node/start-node {:core2/live-chunk {:rows-per-block 10, :rows-per-chunk 1000}})]
     (letfn [(submit-ops! [ids]
               (last (for [tx-ops (->> (for [id ids]
-                                        [:put {:id id,
-                                               :data (str "data" id)
-                                               :_table :t1}])
+                                        [:put 't1 {:id id,
+                                                   :data (str "data" id)
+                                                   }])
                                       (partition-all 20))]
                       (c2/submit-tx node tx-ops))))
 
@@ -853,13 +853,12 @@
   (with-open [node (node/start-node {:core2/live-chunk {:rows-per-block 10, :rows-per-chunk 1000}})]
     (letfn [(submit-ops! [ids]
               (last (for [tx-ops (->> (for [id ids]
-                                        [:put {:id id,
-                                               :data (str "data" id)
-                                               :_table :t1}])
+                                        [:put 't1 {:id id,
+                                                   :data (str "data" id)}])
                                       (partition-all 20))]
                       (c2/submit-tx node tx-ops))))]
 
-      (let [_tx1 (c2/submit-tx node [[:put {:id 0 :foo :bar}]])
+      (let [_tx1 (c2/submit-tx node '[[:put xt_docs {:id 0 :foo :bar}]])
             tx2 (submit-ops! (range 1010))]
         (t/is (= 1010 (-> (c2/q node '{:find [(count id)]
                                        :keys [id-count]
@@ -874,12 +873,11 @@
   (with-open [node (node/start-node {:core2/live-chunk {:rows-per-block 10, :rows-per-chunk 1000}})]
     (letfn [(submit-ops! [ids]
               (last (for [tx-ops (->> (for [id ids]
-                                        [:put {:id id,
-                                               :data (str "data" id)
-                                               :_table :t1}])
+                                        [:put 't1 {:id id,
+                                                   :data (str "data" id)}])
                                       (partition-all 20))]
                       (c2/submit-tx node tx-ops))))]
-      (let [_tx1 (c2/submit-tx node [[:put {:id :some-doc}]])
+      (let [_tx1 (c2/submit-tx node '[[:put xt_docs {:id :some-doc}]])
             ;; going over the chunk boundary
             tx2 (submit-ops! (range 200))]
         (t/is (= [{:id :some-doc}]
@@ -888,9 +886,9 @@
                                 (assoc :basis {:tx tx2})))))))))
 
 (deftest test-subquery-unification
-  (let [tx (c2/submit-tx tu/*node* [[:put {:id :a1, :a 2 :b 1 :_table "a"}]
-                                    [:put {:id :a2, :a 2 :b 3 :_table "a"}]
-                                    [:put {:id :a3, :a 2 :b 0 :_table "a"}]])]
+  (let [tx (c2/submit-tx tu/*node* '[[:put a {:id :a1, :a 2 :b 1}]
+                                     [:put a {:id :a2, :a 2 :b 3}]
+                                     [:put a {:id :a3, :a 2 :b 0}]])]
 
     (t/testing "variables returned from subqueries that must be run as an apply are unified"
 
@@ -916,9 +914,9 @@
               "b is unified")))))
 
 (deftest test-basic-rules
-  (c2/submit-tx tu/*node* [[:put {:id :ivan :name "Ivan" :last-name "Ivanov" :age 21}]
-                           [:put {:id :petr :name "Petr" :last-name "Petrov" :age 18}]
-                           [:put {:id :georgy :name "Georgy" :last-name "George" :age 17}]])
+  (c2/submit-tx tu/*node* '[[:put xt_docs {:id :ivan :name "Ivan" :last-name "Ivanov" :age 21}]
+                            [:put xt_docs {:id :petr :name "Petr" :last-name "Petrov" :age 18}]
+                            [:put xt_docs {:id :georgy :name "Georgy" :last-name "George" :age 17}]])
   (letfn [(q [query & args]
             (apply c2/q tu/*node* query args))]
 
@@ -1174,13 +1172,13 @@
     ;; 2023: Matthew, Mark (again)
     ;; 2024+: Matthew
 
-    (let [tx0 (c2/submit-tx tu/*node* [[:put {:id :matthew} {:app-time-start #inst "2015"}]
-                                       [:put {:id :mark} {:app-time-start #inst "2018", :app-time-end #inst "2020"}]
-                                       [:put {:id :luke} {:app-time-start #inst "2021"}]])
+    (let [tx0 (c2/submit-tx tu/*node* '[[:put xt_docs {:id :matthew} {:app-time-start #inst "2015"}]
+                                        [:put xt_docs {:id :mark} {:app-time-start #inst "2018", :app-time-end #inst "2020"}]
+                                        [:put xt_docs {:id :luke} {:app-time-start #inst "2021"}]])
 
-          tx1 (c2/submit-tx tu/*node* [[:delete :luke {:app-time-start #inst "2022"}]
-                                       [:put {:id :mark} {:app-time-start #inst "2023", :app-time-end #inst "2024"}]
-                                       [:put {:id :john} {:app-time-start #inst "2016", :app-time-end #inst "2020"}]])]
+          tx1 (c2/submit-tx tu/*node* '[[:delete xt_docs :luke {:app-time-start #inst "2022"}]
+                                        [:put xt_docs {:id :mark} {:app-time-start #inst "2023", :app-time-end #inst "2024"}]
+                                        [:put xt_docs {:id :john} {:app-time-start #inst "2016", :app-time-end #inst "2020"}]])]
 
       (t/is (= [{:id :matthew}, {:id :mark}]
                (q '{:find [id], :where [[id :id]]}, tx1, #inst "2023")))
@@ -1271,51 +1269,51 @@
                    in))]
 
     (let [tx0 (c2/submit-tx tu/*node*
-                            [[:put {:id 1 :customer-number 145 :property-number 7797} {:app-time-start #inst "1998-01-10"}]]
+                            '[[:put xt_docs {:id 1 :customer-number 145 :property-number 7797} {:app-time-start #inst "1998-01-10"}]]
                             {:sys-time #inst "1998-01-10"})
 
           tx1 (c2/submit-tx tu/*node*
-                            [[:put {:id 1 :customer-number 827 :property-number 7797} {:app-time-start #inst "1998-01-15"}]]
+                            '[[:put xt_docs {:id 1 :customer-number 827 :property-number 7797} {:app-time-start #inst "1998-01-15"}]]
                             {:sys-time #inst "1998-01-15"})
 
           tx2 (c2/submit-tx tu/*node*
-                            [[:delete 1 {:app-time-start #inst "1998-01-20"}]]
+                            '[[:delete xt_docs 1 {:app-time-start #inst "1998-01-20"}]]
                             {:sys-time #inst "1998-01-20"})
 
           tx3 (c2/submit-tx tu/*node*
-                            [[:put {:id 1 :customer-number 145 :property-number 7797} {:app-time-start #inst "1998-01-03"
-                                                                                       :app-time-end #inst "1998-01-10"}]]
+                            '[[:put xt_docs {:id 1 :customer-number 145 :property-number 7797} {:app-time-start #inst "1998-01-03"
+                                                                                                :app-time-end #inst "1998-01-10"}]]
                             {:sys-time #inst "1998-01-23"})
 
           tx4 (c2/submit-tx tu/*node*
-                            [[:delete 1 {:app-time-start #inst "1998-01-03" :app-time-end #inst "1998-01-05"}]]
+                            '[[:delete xt_docs 1 {:app-time-start #inst "1998-01-03" :app-time-end #inst "1998-01-05"}]]
                             {:sys-time #inst "1998-01-26"})
 
           tx5 (c2/submit-tx tu/*node*
-                            [[:put {:id 1 :customer-number 145 :property-number 7797} {:app-time-start #inst "1998-01-05"
-                                                                                       :app-time-end #inst "1998-01-12"}]
-                             [:put {:id 1 :customer-number 827 :property-number 7797} {:app-time-start #inst "1998-01-12"
-                                                                                       :app-time-end #inst "1998-01-20"}]]
+                            '[[:put xt_docs {:id 1 :customer-number 145 :property-number 7797} {:app-time-start #inst "1998-01-05"
+                                                                                                :app-time-end #inst "1998-01-12"}]
+                              [:put xt_docs {:id 1 :customer-number 827 :property-number 7797} {:app-time-start #inst "1998-01-12"
+                                                                                                :app-time-end #inst "1998-01-20"}]]
                             {:sys-time #inst "1998-01-28"})
 
           tx6 (c2/submit-tx tu/*node*
-                            [[:put {:id :delete-1-week-records,
-                                    :fn #c2/clj-form (fn delete-1-weeks-records []
-                                                       (->> (q '{:find [id app-start app-end]
-                                                                 :where [(match xt_docs [id
-                                                                                         {:application_time_start app-start
-                                                                                          :application_time_end app-end}]
-                                                                                {:for-app-time :all-time})
-                                                                         [(= (- #inst "1970-01-08" #inst "1970-01-01")
-                                                                             (- app-end app-start))]]})
-                                                            (map (fn [{:keys [id app-start app-end]}]
-                                                                   [:delete id {:app-time-start app-start
-                                                                                :app-time-end app-end}]))))}]
+                            [[:put 'xt_docs {:id :delete-1-week-records,
+                                             :fn #c2/clj-form (fn delete-1-weeks-records []
+                                                                (->> (q '{:find [id app-start app-end]
+                                                                          :where [(match xt_docs [id
+                                                                                                  {:application_time_start app-start
+                                                                                                   :application_time_end app-end}]
+                                                                                         {:for-app-time :all-time})
+                                                                                  [(= (- #inst "1970-01-08" #inst "1970-01-01")
+                                                                                      (- app-end app-start))]]})
+                                                                     (map (fn [{:keys [id app-start app-end]}]
+                                                                            [:delete 'xt_docs id {:app-time-start app-start
+                                                                                                  :app-time-end app-end}]))))}]
                              [:call :delete-1-week-records]]
                             {:sys-time #inst "1998-01-30"})
 
           tx7 (c2/submit-tx tu/*node*
-                            [[:put {:id 2 :customer-number 827 :property-number 3621} {:app-time-start #inst "1998-01-15"}]]
+                            '[[:put xt_docs {:id 2 :customer-number 827 :property-number 3621} {:app-time-start #inst "1998-01-15"}]]
                             {:sys-time #inst "1998-01-31"})]
 
       (t/is (= [{:cust 145 :app-start (util/->zdt #inst "1998-01-10")}]

--- a/src/test/clojure/core2/datalog/temporal_test.clj
+++ b/src/test/clojure/core2/datalog/temporal_test.clj
@@ -7,8 +7,8 @@
 (t/use-fixtures :each tu/with-node)
 
 (deftest simple-temporal-tests
-  (let [tx1 (c2/submit-tx tu/*node* [[:put {:id 1 :foo "2000-4000"} {:app-time-start #inst "2000" :app-time-end #inst "4000"}]])
-        tx2 (c2/submit-tx tu/*node* [[:put {:id 1 :foo "3000-"} {:app-time-start #inst "3000"}]])]
+  (let [tx1 (c2/submit-tx tu/*node* [[:put 'xt_docs {:id 1 :foo "2000-4000"} {:app-time-start #inst "2000" :app-time-end #inst "4000"}]])
+        tx2 (c2/submit-tx tu/*node* [[:put 'xt_docs {:id 1 :foo "3000-"} {:app-time-start #inst "3000"}]])]
 
     ;; as of tx tests
     (t/is (= [{:foo "2000-4000"}]

--- a/src/test/clojure/core2/indexer_test.clj
+++ b/src/test/clojure/core2/indexer_test.clj
@@ -40,44 +40,44 @@
 (t/use-fixtures :once tu/with-allocator)
 
 (def txs
-  [[[:put {:id "device-info-demo000000",
-           :api-version "23",
-           :manufacturer "iobeam",
-           :model "pinto",
-           :os-name "6.0.1"}]
-    [:put {:id "reading-demo000000",
-           :device-id "device-info-demo000000",
-           :cpu-avg-15min 8.654,
-           :rssi -50.0,
-           :cpu-avg-5min 10.802,
-           :battery-status "discharging",
-           :ssid "demo-net",
-           :time #inst "2016-11-15T12:00:00.000-00:00",
-           :battery-level 59.0,
-           :bssid "01:02:03:04:05:06",
-           :battery-temperature 89.5,
-           :cpu-avg-1min 24.81,
-           :mem-free 4.10011078E8,
-           :mem-used 5.89988922E8}]]
-   [[:put {:id "device-info-demo000001",
-           :api-version "23",
-           :manufacturer "iobeam",
-           :model "mustang",
-           :os-name "6.0.1"}]
-    [:put {:id "reading-demo000001",
-           :device-id "device-info-demo000001",
-           :cpu-avg-15min 8.822,
-           :rssi -61.0,
-           :cpu-avg-5min 8.106,
-           :battery-status "discharging",
-           :ssid "stealth-net",
-           :time #inst "2016-11-15T12:00:00.000-00:00",
-           :battery-level 86.0,
-           :bssid "A0:B1:C5:D2:E0:F3",
-           :battery-temperature 93.7,
-           :cpu-avg-1min 4.93,
-           :mem-free 7.20742332E8,
-           :mem-used 2.79257668E8}]]])
+  [[[:put 'xt_docs {:id "device-info-demo000000",
+                    :api-version "23",
+                    :manufacturer "iobeam",
+                    :model "pinto",
+                    :os-name "6.0.1"}]
+    [:put 'xt_docs {:id "reading-demo000000",
+                    :device-id "device-info-demo000000",
+                    :cpu-avg-15min 8.654,
+                    :rssi -50.0,
+                    :cpu-avg-5min 10.802,
+                    :battery-status "discharging",
+                    :ssid "demo-net",
+                    :time #inst "2016-11-15T12:00:00.000-00:00",
+                    :battery-level 59.0,
+                    :bssid "01:02:03:04:05:06",
+                    :battery-temperature 89.5,
+                    :cpu-avg-1min 24.81,
+                    :mem-free 4.10011078E8,
+                    :mem-used 5.89988922E8}]]
+   [[:put 'xt_docs {:id "device-info-demo000001",
+                    :api-version "23",
+                    :manufacturer "iobeam",
+                    :model "mustang",
+                    :os-name "6.0.1"}]
+    [:put 'xt_docs {:id "reading-demo000001",
+                    :device-id "device-info-demo000001",
+                    :cpu-avg-15min 8.822,
+                    :rssi -61.0,
+                    :cpu-avg-5min 8.106,
+                    :battery-status "discharging",
+                    :ssid "stealth-net",
+                    :time #inst "2016-11-15T12:00:00.000-00:00",
+                    :battery-level 86.0,
+                    :bssid "A0:B1:C5:D2:E0:F3",
+                    :battery-temperature 93.7,
+                    :cpu-avg-1min 4.93,
+                    :mem-free 7.20742332E8,
+                    :mem-used 2.79257668E8}]]])
 
 (t/deftest can-build-chunk-as-arrow-ipc-file-format
   (let [node-dir (util/->path "target/can-build-chunk-as-arrow-ipc-file-format")
@@ -190,7 +190,7 @@
 
 (t/deftest temporal-watermark-is-immutable-567
   (with-open [node (node/start-node {})]
-    (let [{tt :sys-time} (c2.d/submit-tx node [[:put {:id :foo, :version 0}]]
+    (let [{tt :sys-time} (c2.d/submit-tx node [[:put 'xt_docs {:id :foo, :version 0}]]
                                          {:app-time-as-of-now? true})]
       (t/is (= [{:id :foo, :version 0,
                  :application_time_start (util/->zdt tt)
@@ -203,7 +203,7 @@
                                system_time_start, system_time_end]]
                             {:node node})))
 
-      (let [{tt2 :sys-time} (c2.d/submit-tx node [[:put {:id :foo, :version 1}]]
+      (let [{tt2 :sys-time} (c2.d/submit-tx node [[:put 'xt_docs {:id :foo, :version 1}]]
                                             {:app-time-as-of-now? true})]
         (t/is (= [{:id :foo, :version 0,
                    :application_time_start (util/->zdt tt)
@@ -241,16 +241,16 @@
 
 (t/deftest can-handle-dynamic-cols-in-same-block
   (let [node-dir (util/->path "target/can-handle-dynamic-cols-in-same-block")
-        tx-ops [[:put {:id "foo"
-                       :list [12.0 "foo"]}]
-                [:put {:id 24.0}]
-                [:put {:id "bar"
-                       :list [#inst "2020-01-01" false]}]
-                [:put {:id #inst "2021-01-01"
-                       :struct {:a 1, :b "b"}}]
-                [:put {:id 52.0}]
-                [:put {:id #inst "2020-01-01"
-                       :struct {:a true, :c "c"}}]]]
+        tx-ops [[:put 'xt_docs {:id "foo"
+                                :list [12.0 "foo"]}]
+                [:put 'xt_docs {:id 24.0}]
+                [:put 'xt_docs {:id "bar"
+                                :list [#inst "2020-01-01" false]}]
+                [:put 'xt_docs {:id #inst "2021-01-01"
+                                :struct {:a 1, :b "b"}}]
+                [:put 'xt_docs {:id 52.0}]
+                [:put 'xt_docs {:id #inst "2020-01-01"
+                                :struct {:a true, :c "c"}}]]]
     (util/delete-dir node-dir)
 
     (with-open [node (tu/->local-node {:node-dir node-dir})]
@@ -264,16 +264,16 @@
 
 (t/deftest test-multi-block-metadata
   (let [node-dir (util/->path "target/multi-block-metadata")
-        tx0 [[:put {:id "foo"
-                    :list [12.0 "foo"]}]
-             [:put {:id #inst "2021-01-01"
-                    :struct {:a 1, :b "b"}}]
-             [:put {:id "bar"
-                    :list [#inst "2020-01-01" false]}]
-             [:put {:id 24.0}]]
-        tx1 [[:put {:id 52.0}]
-             [:put {:id #inst "2020-01-01"
-                    :struct {:a true, :b {:c "c", :d "d"}}}]]]
+        tx0 [[:put 'xt_docs {:id "foo"
+                             :list [12.0 "foo"]}]
+             [:put 'xt_docs {:id #inst "2021-01-01"
+                             :struct {:a 1, :b "b"}}]
+             [:put 'xt_docs {:id "bar"
+                             :list [#inst "2020-01-01" false]}]
+             [:put 'xt_docs {:id 24.0}]]
+        tx1 [[:put 'xt_docs {:id 52.0}]
+             [:put 'xt_docs {:id #inst "2020-01-01"
+                             :struct {:a true, :b {:c "c", :d "d"}}}]]]
     (util/delete-dir node-dir)
 
     (with-open [node (tu/->local-node {:node-dir node-dir, :rows-per-block 3})]
@@ -301,11 +301,11 @@
 
 (t/deftest round-trips-nils
   (with-open [node (node/start-node {})]
-    (c2.d/submit-tx node [[:put {:id "nil-bar"
-                                 :foo "foo"
-                                 :bar nil}]
-                          [:put {:id "no-bar"
-                                 :foo "foo"}]])
+    (c2.d/submit-tx node [[:put 'xt_docs {:id "nil-bar"
+                                          :foo "foo"
+                                          :bar nil}]
+                          [:put 'xt_docs {:id "no-bar"
+                                          :foo "foo"}]])
     (t/is (= [{:id "nil-bar", :foo "foo", :bar nil}]
              (c2.d/q node '{:find [id foo bar]
                             :where [[e :id id]
@@ -318,7 +318,7 @@
     (util/delete-dir node-dir)
 
     (with-open [node (tu/->local-node {:node-dir node-dir})]
-      (-> (c2.d/submit-tx node [[:put {:id :foo, :uuid uuid}]])
+      (-> (c2.d/submit-tx node [[:put 'xt_docs {:id :foo, :uuid uuid}]])
           (tu/then-await-tx* node (Duration/ofMillis 2000)))
 
       (tu/finish-chunk! node)
@@ -337,14 +337,14 @@
     (util/delete-dir node-dir)
 
     (with-open [node (tu/->local-node {:node-dir node-dir})]
-      (c2.d/submit-tx node [[:put {:id "foo"}]
-                            [:put {:id "bar"}]])
+      (c2.d/submit-tx node [[:put 'xt_docs {:id "foo"}]
+                            [:put 'xt_docs {:id "bar"}]])
 
       ;; aborted tx shows up in log
       (c2.d/submit-tx node [[:sql "INSERT INTO foo (id, application_time_start, application_time_end) VALUES (1, DATE '2020-01-01', DATE '2019-01-01')"]])
 
-      (-> (c2.d/submit-tx node [[:delete "xt_docs" "foo" {:app-time-start #inst "2020-04-01"}]
-                                [:put {:id "bar", :month "april"},
+      (-> (c2.d/submit-tx node [[:delete 'xt_docs "foo" {:app-time-start #inst "2020-04-01"}]
+                                [:put 'xt_docs {:id "bar", :month "april"},
                                  {:app-time-start #inst "2020-04-01"
                                   :app-time-end #inst "2020-05-01"}]])
           (tu/then-await-tx* node))
@@ -391,7 +391,7 @@
             readings (map ts/readings-csv->doc (csv/read-csv readings-reader))
             [initial-readings rest-readings] (split-at (count device-infos) readings)
             tx-ops (for [doc (concat (interleave device-infos initial-readings) rest-readings)]
-                     [:put doc])]
+                     [:put (:table (meta doc)) doc])]
 
         (t/is (= 11000 (count tx-ops)))
 
@@ -479,7 +479,7 @@
             readings (map ts/readings-csv->doc (csv/read-csv readings-reader))
             [initial-readings rest-readings] (split-at (count device-infos) readings)
             tx-ops (for [doc (concat (interleave device-infos initial-readings) rest-readings)]
-                     [:put doc])]
+                     [:put (:table (meta doc)) doc])]
 
         (t/is (= 11000 (count tx-ops)))
 
@@ -516,7 +516,7 @@
             readings (map ts/readings-csv->doc (csv/read-csv readings-reader))
             [initial-readings rest-readings] (split-at (count device-infos) readings)
             tx-ops (for [doc (concat (interleave device-infos initial-readings) rest-readings)]
-                     [:put doc])
+                     [:put (:table (meta doc)) doc])
             [first-half-tx-ops second-half-tx-ops] (split-at (/ (count tx-ops) 2) tx-ops)]
 
         (t/is (= 5500 (count first-half-tx-ops)))
@@ -612,16 +612,16 @@
     (with-open [node1 (tu/->local-node (assoc node-opts :buffers-dir "buffers-1"))]
       (let [^IMetadataManager mm1 (tu/component node1 ::meta/metadata-manager)]
 
-        (-> (c2.d/submit-tx node1 [[:put {:id "foo"}]])
+        (-> (c2.d/submit-tx node1 [[:put 'xt_docs {:id "foo"}]])
             (tu/then-await-tx* node1 (Duration/ofSeconds 1)))
 
         (tu/finish-chunk! node1)
 
         (t/is (= :utf8 (.columnType mm1 "xt_docs" "id")))
 
-        (let [tx2 (c2.d/submit-tx node1 [[:put {:id :bar}]
-                                         [:put {:id #uuid "8b190984-2196-4144-9fa7-245eb9a82da8"}]
-                                         [:put {:id #c2/clj-form :foo}]])]
+        (let [tx2 (c2.d/submit-tx node1 [[:put 'xt_docs {:id :bar}]
+                                         [:put 'xt_docs {:id #uuid "8b190984-2196-4144-9fa7-245eb9a82da8"}]
+                                         [:put 'xt_docs {:id #c2/clj-form :foo}]])]
           (tu/then-await-tx* tx2 node1 (Duration/ofMillis 200))
 
           (tu/finish-chunk! node1)
@@ -646,7 +646,7 @@
                                  (log* logger level throwable message))))]
       (with-open [node (node/start-node {})]
         (t/is (thrown-with-msg? Exception #"oh no!"
-                                (-> (c2.d/submit-tx node [[:put {:id "foo", :count 42}]])
+                                (-> (c2.d/submit-tx node [[:put 'xt_docs {:id "foo", :count 42}]])
                                     (tu/then-await-tx* node (Duration/ofSeconds 1)))))))))
 
 (t/deftest test-indexes-sql-insert
@@ -674,16 +674,16 @@
 
 (t/deftest test-skips-irrelevant-live-blocks-632
   (with-open [node (node/start-node {:core2/live-chunk {:rows-per-block 2, :rows-per-chunk 10}})]
-    (-> (c2.d/submit-tx node [[:put {:name "Håkan", :id :hak}]])
+    (-> (c2.d/submit-tx node [[:put 'xt_docs {:name "Håkan", :id :hak}]])
         (tu/then-await-tx* node))
 
     (tu/finish-chunk! node)
 
-    (c2.d/submit-tx node [[:put {:name "Dan", :id :dan}]
-                          [:put {:name "Ivan", :id :iva}]])
+    (c2.d/submit-tx node [[:put 'xt_docs {:name "Dan", :id :dan}]
+                          [:put 'xt_docs {:name "Ivan", :id :iva}]])
 
-    (-> (c2.d/submit-tx node [[:put {:name "James", :id :jms}]
-                              [:put {:name "Jon", :id :jon}]])
+    (-> (c2.d/submit-tx node [[:put 'xt_docs {:name "James", :id :jms}]
+                              [:put 'xt_docs {:name "Jon", :id :jon}]])
         (tu/then-await-tx* node))
 
     (let [^IMetadataManager metadata-mgr (tu/component node ::meta/metadata-manager)
@@ -719,7 +719,7 @@
                        (test-live-blocks wm1 gt-param-selector))
                     "only second block, param selector")
 
-              (let [next-tx (-> (c2.d/submit-tx node [[:put {:name "Jeremy", :id :jdt}]])
+              (let [next-tx (-> (c2.d/submit-tx node [[:put 'xt_docs {:name "Jeremy", :id :jdt}]])
                                 (tu/then-await-tx* node))]
 
                 (with-open [wm2 (.openWatermark wm-src next-tx)]

--- a/src/test/clojure/core2/james_bond.clj
+++ b/src/test/clojure/core2/james_bond.clj
@@ -4,7 +4,7 @@
 (def tx-ops
   (vec
    (for [doc (read-string (slurp (io/resource "james-bond.edn")))]
-     [:put
+     [:put 'xt_docs
       (-> doc
           ;; no sets as yet
           (update :film/vehicles vec)

--- a/src/test/clojure/core2/node_test.clj
+++ b/src/test/clojure/core2/node_test.clj
@@ -127,19 +127,19 @@ VALUES (1, 'Happy 2024!', DATE '2024-01-01'),
                  (into {})))]
 
     (c2.d/submit-tx tu/*node*
-                    [[:put {:id :foo, :v "implicit table"}]
-                     [:put {:id :foo, :_table "explicit_table1", :v "explicit table 1"}]
-                     [:put {:id :foo, :_table "explicit_table2", :v "explicit table 2"}]])
+                    [[:put 'xt_docs {:id :foo, :v "implicit table"}]
+                     [:put 'explicit_table1 {:id :foo, :v "explicit table 1"}]
+                     [:put 'explicit_table2 {:id :foo, :v "explicit table 2"}]])
 
     (t/is (= {:xt #{"implicit table"}, :t1 #{"explicit table 1"}, :t2 #{"explicit table 2"}}
              (foos)))
 
-    (c2.d/submit-tx tu/*node* [[:delete :foo]])
+    (c2.d/submit-tx tu/*node* [[:delete 'xt_docs :foo]])
 
     (t/is (= {:xt #{}, :t1 #{"explicit table 1"}, :t2 #{"explicit table 2"}}
              (foos)))
 
-    (c2.d/submit-tx tu/*node* [[:delete "explicit_table1" :foo]])
+    (c2.d/submit-tx tu/*node* [[:delete 'explicit_table1 :foo]])
 
     (t/is (= {:xt #{}, :t1 #{}, :t2 #{"explicit table 2"}}
              (foos)))))
@@ -294,11 +294,11 @@ ORDER BY foo.application_time_start"
            (c2.sql/q tu/*node* "SELECT foo.id foo, foo.x FROM foo LEFT JOIN bar USING (id) WHERE foo.x = bar.x"))))
 
 (t/deftest test-c1-importer-abort-op
-  (c2.d/submit-tx tu/*node* [[:put {:id :foo}]])
+  (c2.d/submit-tx tu/*node* [[:put 'xt_docs {:id :foo}]])
 
-  (c2.d/submit-tx tu/*node* [[:put {:id :bar}]
+  (c2.d/submit-tx tu/*node* [[:put 'xt_docs {:id :bar}]
                              [:abort]
-                             [:put {:id :baz}]])
+                             [:put 'xt_docs {:id :baz}]])
   (t/is (= [{:id :foo}]
            (c2.d/q tu/*node*
                    '{:find [id]

--- a/src/test/clojure/core2/operator_test.clj
+++ b/src/test/clojure/core2/operator_test.clj
@@ -13,16 +13,16 @@
 
 (t/deftest test-find-gt-ivan
   (with-open [node (node/start-node {:core2/live-chunk {:rows-per-block 2, :rows-per-chunk 10}})]
-    (-> (c2/submit-tx node [[:put {:name "Håkan", :id :hak}]])
+    (-> (c2/submit-tx node [[:put 'xt_docs {:name "Håkan", :id :hak}]])
         (tu/then-await-tx* node))
 
     (tu/finish-chunk! node)
 
-    (c2/submit-tx node [[:put {:name "Dan", :id :dan}]
-                        [:put {:name "Ivan", :id :iva}]])
+    (c2/submit-tx node [[:put 'xt_docs {:name "Dan", :id :dan}]
+                        [:put 'xt_docs {:name "Ivan", :id :iva}]])
 
-    (let [tx1 (-> (c2/submit-tx node [[:put {:name "James", :id :jms}]
-                                      [:put {:name "Jon", :id :jon}]])
+    (let [tx1 (-> (c2/submit-tx node [[:put 'xt_docs {:name "James", :id :jms}]
+                                      [:put 'xt_docs {:name "Jon", :id :jon}]])
                   (tu/then-await-tx* node))]
 
       (tu/finish-chunk! node)
@@ -51,7 +51,7 @@
                                              (expr.meta/->metadata-selector '(> name ?name) '#{name} params))))
                   "only needs to scan chunk 1, block 1"))
 
-          (let [tx2 (c2/submit-tx node [[:put {:name "Jeremy", :id :jdt}]])]
+          (let [tx2 (c2/submit-tx node [[:put 'xt_docs {:name "Jeremy", :id :jdt}]])]
 
             (test-query-ivan #{{:id :jms, :name "James"}
                                {:id :jon, :name "Jon"}}
@@ -64,15 +64,15 @@
 
 (t/deftest test-find-eq-ivan
   (with-open [node (node/start-node {:core2/live-chunk {:rows-per-block 3, :rows-per-chunk 10}})]
-    (-> (c2/submit-tx node [[:put {:name "Håkan", :id :hak}]
-                            [:put {:name "James", :id :jms}]
-                            [:put {:name "Ivan", :id :iva}]])
+    (-> (c2/submit-tx node [[:put 'xt_docs {:name "Håkan", :id :hak}]
+                            [:put 'xt_docs {:name "James", :id :jms}]
+                            [:put 'xt_docs {:name "Ivan", :id :iva}]])
         (tu/then-await-tx* node))
 
     (tu/finish-chunk! node)
+    (-> (c2/submit-tx node [[:put 'xt_docs {:name "Håkan", :id :hak}]
 
-    (-> (c2/submit-tx node [[:put {:name "Håkan", :id :hak}]
-                            [:put {:name "James", :id :jms}]])
+                            [:put 'xt_docs {:name "James", :id :jms}]])
         (tu/then-await-tx* node))
 
     (tu/finish-chunk! node)
@@ -101,8 +101,8 @@
 
 (t/deftest test-temporal-bounds
   (with-open [node (node/start-node {})]
-    (let [{tt1 :sys-time} (c2/submit-tx node [[:put {:id :my-doc, :last-updated "tx1"}]])
-          {tt2 :sys-time} (c2/submit-tx node [[:put {:id :my-doc, :last-updated "tx2"}]])]
+    (let [{tt1 :sys-time} (c2/submit-tx node [[:put 'xt_docs {:id :my-doc, :last-updated "tx1"}]])
+          {tt2 :sys-time} (c2/submit-tx node [[:put 'xt_docs {:id :my-doc, :last-updated "tx2"}]])]
       (letfn [(q [& temporal-constraints]
                 (->> (tu/query-ra [:scan '{:table xt_docs, :for-sys-time :all-time}
                                    (into '[last-updated] temporal-constraints)]

--- a/src/test/clojure/core2/sql/logic_test/runner_test.clj
+++ b/src/test/clojure/core2/sql/logic_test/runner_test.clj
@@ -51,6 +51,8 @@ SELECT t1.a FROM t1
 104
 ")]
 
+
+
     (t/is (= 3 (count records)))
     (t/is (= {"t1" ["a" "b" "c" "d" "e"]} (:tables (:db-engine (slt/execute-records tu/*node* records)))))))
 
@@ -143,10 +145,12 @@ CREATE UNIQUE INDEX t1i0 ON t1(
         (fn [sql-insert-string]
           (xtdb-engine/insert->docs (assoc tu/*node* :tables tables) (p/parse sql-insert-string :insert_statement)))]
     (binding [r/*memo* (HashMap.)]
-      (t/is (= [{:e 103 :c 102 :b 100 :d 101 :a 104 :_table "t1"}]
-               (execute-statement "INSERT INTO t1(e,c,b,d,a) VALUES(103,102,100,101,104)")))
-      (t/is (= [{:a nil :b -102 :c true :d "101" :e 104.5 :_table "t1"}]
-               (execute-statement "INSERT INTO t1 VALUES(NULL,-102,TRUE,'101',104.5)"))))))
+      (let [docs (execute-statement "INSERT INTO t1(e,c,b,d,a) VALUES(103,102,100,101,104)")]
+        (t/is (= [{:e 103 :c 102 :b 100 :d 101 :a 104}] docs))
+        (t/is (= 't1 (:table (meta (first docs))))))
+      (let [docs (execute-statement "INSERT INTO t1 VALUES(NULL,-102,TRUE,'101',104.5)")]
+        (t/is (= [{:a nil :b -102 :c true :d "101" :e 104.5}] docs))
+        (t/is (= 't1 (:table (meta (first docs)))))))))
 
 (comment
 

--- a/src/test/clojure/core2/sql/logic_test/xtdb_engine.clj
+++ b/src/test/clojure/core2/sql/logic_test/xtdb_engine.clj
@@ -181,11 +181,12 @@
                     (->> (flatten insert-column-list)
                          (filter string?))))]
     (for [row from-subquery-results]
-      (into {:_table table} (zipmap (map keyword columns) row)))))
+      (-> (zipmap (map keyword columns) row)
+          (with-meta {:table (symbol table)})))))
 
 (defn- insert-statement [node insert-statement]
   (c2.d/submit-tx node (vec (for [doc (insert->docs node insert-statement)]
-                              [:put (merge {:id (UUID/randomUUID)} doc)])))
+                              [:put (:table (meta doc)) (merge {:id (UUID/randomUUID)} doc)])))
   node)
 
 (defn skip-statement? [^String x]

--- a/src/test/clojure/core2/sql/temporal_test.clj
+++ b/src/test/clojure/core2/sql/temporal_test.clj
@@ -10,186 +10,186 @@
   (c2.sql/q tu/*node* query {:basis {:tx tx}}))
 
 (deftest all-system-time
-  (let [_tx (c2.d/submit-tx tu/*node* [[:put {:id :my-doc, :last_updated "tx1" :_table "foo"}]] {:sys-time #inst "3000"})
-        tx2 (c2.d/submit-tx tu/*node* [[:put {:id :my-doc, :last_updated "tx2" :_table "foo"}]] {:sys-time #inst "3001"})]
+  (let [_tx (c2.d/submit-tx tu/*node* [[:put 'foo {:id :my-doc, :last_updated "tx1"}]] {:sys-time #inst "3000"})
+        tx2 (c2.d/submit-tx tu/*node* [[:put 'foo {:id :my-doc, :last_updated "tx2"}]] {:sys-time #inst "3001"})]
 
     (is (= [{:last_updated "tx1"} {:last_updated "tx2"}]
            (query-at-tx
-             "SELECT foo.last_updated FROM foo"
-             tx2)))
+            "SELECT foo.last_updated FROM foo"
+            tx2)))
 
     (is (= [{:last_updated "tx1"} {:last_updated "tx1"} {:last_updated "tx2"}]
            (query-at-tx
-             "SELECT foo.last_updated FROM foo FOR ALL SYSTEM_TIME"
-             tx2)))))
+            "SELECT foo.last_updated FROM foo FOR ALL SYSTEM_TIME"
+            tx2)))))
 
 (deftest system-time-as-of
-  (let [tx (c2.d/submit-tx tu/*node* [[:put {:id :my-doc, :last_updated "tx1" :_table "foo"}]] {:sys-time #inst "3000"})
-        tx2 (c2.d/submit-tx tu/*node* [[:put {:id :my-doc, :last_updated "tx2" :_table "foo"}]] {:sys-time #inst "3001"})]
+  (let [tx (c2.d/submit-tx tu/*node* [[:put 'foo {:id :my-doc, :last_updated "tx1"}]] {:sys-time #inst "3000"})
+        tx2 (c2.d/submit-tx tu/*node* [[:put 'foo {:id :my-doc, :last_updated "tx2"}]] {:sys-time #inst "3001"})]
 
     (is (= []
            (query-at-tx
-             "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME AS OF TIMESTAMP '2999-01-01 00:00:00+00:00'"
-             tx)))
+            "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME AS OF TIMESTAMP '2999-01-01 00:00:00+00:00'"
+            tx)))
 
     (is (= [{:last_updated "tx1"}]
            (query-at-tx
-             "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME AS OF TIMESTAMP '3000-01-01 00:00:00+00:00'"
-             tx)))
+            "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME AS OF TIMESTAMP '3000-01-01 00:00:00+00:00'"
+            tx)))
 
     (is (= [{:last_updated "tx1"} {:last_updated "tx2"}]
            (query-at-tx
-             "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME AS OF TIMESTAMP '3002-01-01 00:00:00+00:00'"
-             tx2)))))
+            "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME AS OF TIMESTAMP '3002-01-01 00:00:00+00:00'"
+            tx2)))))
 
 (deftest system-time-from-a-to-b
-  (let [tx (c2.d/submit-tx tu/*node* [[:put {:id :my-doc, :last_updated "tx1" :_table "foo"}]] {:sys-time #inst "3000"})
-        tx2 (c2.d/submit-tx tu/*node* [[:put {:id :my-doc, :last_updated "tx2" :_table "foo"}]] {:sys-time #inst "3001"})]
+  (let [tx (c2.d/submit-tx tu/*node* [[:put 'foo {:id :my-doc, :last_updated "tx1"}]] {:sys-time #inst "3000"})
+        tx2 (c2.d/submit-tx tu/*node* [[:put 'foo {:id :my-doc, :last_updated "tx2"}]] {:sys-time #inst "3001"})]
 
     (is (= []
            (query-at-tx
-             "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME FROM DATE '2999-01-01' TO TIMESTAMP '3000-01-01 00:00:00+00:00'"
-             tx)))
+            "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME FROM DATE '2999-01-01' TO TIMESTAMP '3000-01-01 00:00:00+00:00'"
+            tx)))
 
     (is (= [{:last_updated "tx1"}]
            (query-at-tx
-             "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME FROM DATE '2999-01-01' TO TIMESTAMP '3001-01-01 00:00:00+00:00'"
-             tx)))
+            "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME FROM DATE '2999-01-01' TO TIMESTAMP '3001-01-01 00:00:00+00:00'"
+            tx)))
 
     (is (= [{:last_updated "tx1"} {:last_updated "tx1"} {:last_updated "tx2"}]
-             (query-at-tx
-               "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME FROM DATE '2999-01-01' TO TIMESTAMP '3002-01-01 00:00:00+00:00'"
-               tx2)))
+           (query-at-tx
+            "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME FROM DATE '2999-01-01' TO TIMESTAMP '3002-01-01 00:00:00+00:00'"
+            tx2)))
 
     (is (= [{:last_updated "tx1"} {:last_updated "tx2"}]
-             (query-at-tx
-               "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME FROM DATE '3001-01-01' TO TIMESTAMP '3002-01-01 00:00:00+00:00'"
-               tx2)))))
+           (query-at-tx
+            "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME FROM DATE '3001-01-01' TO TIMESTAMP '3002-01-01 00:00:00+00:00'"
+            tx2)))))
 
 (deftest system-time-between-a-to-b
-  (let [tx (c2.d/submit-tx tu/*node* [[:put {:id :my-doc, :last_updated "tx1" :_table "foo"}]] {:sys-time #inst "3000"})
-        tx2 (c2.d/submit-tx tu/*node* [[:put {:id :my-doc, :last_updated "tx2" :_table "foo"}]] {:sys-time #inst "3001"})]
+  (let [tx (c2.d/submit-tx tu/*node* [[:put 'foo {:id :my-doc, :last_updated "tx1"}]] {:sys-time #inst "3000"})
+        tx2 (c2.d/submit-tx tu/*node* [[:put 'foo {:id :my-doc, :last_updated "tx2"}]] {:sys-time #inst "3001"})]
     (is (= []
            (query-at-tx
-             "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME BETWEEN DATE '2998-01-01' AND TIMESTAMP '2999-01-01 00:00:00+00:00'"
-             tx)))
+            "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME BETWEEN DATE '2998-01-01' AND TIMESTAMP '2999-01-01 00:00:00+00:00'"
+            tx)))
 
     (is (= [{:last_updated "tx1"}]
            (query-at-tx
-             "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME BETWEEN DATE '2999-01-01' AND TIMESTAMP '3000-01-01 00:00:00+00:00'"
-             tx))
+            "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME BETWEEN DATE '2999-01-01' AND TIMESTAMP '3000-01-01 00:00:00+00:00'"
+            tx))
         "second point in time is inclusive for between")
 
     (is (= [{:last_updated "tx1"}]
            (query-at-tx
-             "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME BETWEEN DATE '2999-01-01' AND TIMESTAMP '3001-01-01 00:00:00+00:00'"
-             tx)))
+            "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME BETWEEN DATE '2999-01-01' AND TIMESTAMP '3001-01-01 00:00:00+00:00'"
+            tx)))
 
     (is (= [{:last_updated "tx1"} {:last_updated "tx1"} {:last_updated "tx2"}]
            (query-at-tx
-             "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME BETWEEN DATE '2999-01-01' AND TIMESTAMP '3002-01-01 00:00:00+00:00'"
-             tx2)))
+            "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME BETWEEN DATE '2999-01-01' AND TIMESTAMP '3002-01-01 00:00:00+00:00'"
+            tx2)))
 
     (is (= [{:last_updated "tx1"} {:last_updated "tx2"}]
            (query-at-tx
-             "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME BETWEEN DATE '3001-01-01' AND TIMESTAMP '3002-01-01 00:00:00+00:00'"
-             tx2)))))
+            "SELECT foo.last_updated FROM foo FOR SYSTEM_TIME BETWEEN DATE '3001-01-01' AND TIMESTAMP '3002-01-01 00:00:00+00:00'"
+            tx2)))))
 
 (deftest app-time-period-predicates
   (testing "OVERLAPS"
-    (let [tx (c2.d/submit-tx tu/*node* [[:put {:id :my-doc, :last_updated "2000" :_table "foo"}
+    (let [tx (c2.d/submit-tx tu/*node* [[:put 'foo {:id :my-doc, :last_updated "2000"}
                                          {:app-time-start #inst "2000"}]
-                                        [:put {:id :my-doc, :last_updated "3000" :_table "foo"}
+                                        [:put 'foo {:id :my-doc, :last_updated "3000"}
                                          {:app-time-start #inst "3000"}]
-                                        [:put {:id :some-other-doc, :last_updated "4000" :_table "foo"}
+                                        [:put 'foo {:id :some-other-doc, :last_updated "4000"}
                                          {:app-time-start #inst "4000"
                                           :app-time-end #inst "4001"}]])]
 
       (is (= [{:last_updated "2000"} {:last_updated "3000"} {:last_updated "4000"}]
              (query-at-tx
-               "SELECT foo.last_updated FROM foo"
-               tx)))
+              "SELECT foo.last_updated FROM foo"
+              tx)))
 
       (is (= [{:last_updated "2000"}]
              (query-at-tx
-               "SELECT foo.last_updated FROM foo WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')"
-               tx)))
+              "SELECT foo.last_updated FROM foo WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')"
+              tx)))
 
       (is (= [{:last_updated "3000"}]
              (query-at-tx
-               "SELECT foo.last_updated FROM foo WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '3000-01-01 00:00:00', TIMESTAMP '3001-01-01 00:00:00')"
-               tx)))
+              "SELECT foo.last_updated FROM foo WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '3000-01-01 00:00:00', TIMESTAMP '3001-01-01 00:00:00')"
+              tx)))
 
       (is (= [{:last_updated "3000"} {:last_updated "4000"}]
              (query-at-tx
-               "SELECT foo.last_updated FROM foo WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '4000-01-01 00:00:00', TIMESTAMP '4001-01-01 00:00:00')"
-               tx)))
+              "SELECT foo.last_updated FROM foo WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '4000-01-01 00:00:00', TIMESTAMP '4001-01-01 00:00:00')"
+              tx)))
 
       (is (= [{:last_updated "3000"}]
              (query-at-tx
-               "SELECT foo.last_updated FROM foo WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '4002-01-01 00:00:00', TIMESTAMP '9999-01-01 00:00:00')"
-               tx))))))
+              "SELECT foo.last_updated FROM foo WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '4002-01-01 00:00:00', TIMESTAMP '9999-01-01 00:00:00')"
+              tx))))))
 
 (deftest app-time-multiple-tables
-  (let [tx (c2.d/submit-tx tu/*node* [[:put {:id :foo-doc, :last_updated "2001" :_table "foo"}
+  (let [tx (c2.d/submit-tx tu/*node* [[:put 'foo {:id :foo-doc, :last_updated "2001" }
                                        {:app-time-start #inst "2000"
                                         :app-time-end #inst "2001"}]
-                                      [:put {:id :bar-doc, :l_updated "2003" :_table "bar"}
+                                      [:put 'bar {:id :bar-doc, :l_updated "2003" }
                                        {:app-time-start #inst "2002"
                                         :app-time-end #inst "2003"}]])]
 
     (is (= [{:last_updated "2001"}]
            (query-at-tx
-             "SELECT foo.last_updated FROM foo
+            "SELECT foo.last_updated FROM foo
              WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '1999-01-01 00:00:00', TIMESTAMP '2002-01-01 00:00:00')"
-             tx)))
+            tx)))
 
     (is (= [{:l_updated "2003"}]
            (query-at-tx
-             "SELECT bar.l_updated FROM bar
+            "SELECT bar.l_updated FROM bar
              WHERE bar.APP_TIME OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00', TIMESTAMP '2003-01-01 00:00:00')"
-             tx)))
+            tx)))
 
     (is (= []
            (query-at-tx
-             "SELECT foo.last_updated, bar.l_updated FROM foo, bar
+            "SELECT foo.last_updated, bar.l_updated FROM foo, bar
              WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '1999-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')
              AND
              bar.APP_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')"
-             tx)))
+            tx)))
 
     (is (= [{:last_updated "2001", :l_updated "2003"}]
            (query-at-tx
-             "SELECT foo.last_updated, bar.l_updated FROM foo, bar
+            "SELECT foo.last_updated, bar.l_updated FROM foo, bar
              WHERE foo.APP_TIME OVERLAPS PERIOD (TIMESTAMP '2000-01-01 00:00:00', TIMESTAMP '2001-01-01 00:00:00')
              AND
              bar.APP_TIME OVERLAPS PERIOD (TIMESTAMP '2002-01-01 00:00:00', TIMESTAMP '2003-01-01 00:00:00')"
-             tx)))
+            tx)))
 
     (is (= []
            (query-at-tx
-             "SELECT foo.last_updated, bar.name FROM foo, bar
+            "SELECT foo.last_updated, bar.name FROM foo, bar
              WHERE foo.APP_TIME OVERLAPS bar.APP_TIME" tx)))))
 
 (deftest app-time-joins
 
-  (let [tx (c2.d/submit-tx tu/*node* [[:put {:id :bill, :name "Bill" :_table "foo"}
+  (let [tx (c2.d/submit-tx tu/*node* [[:put 'foo {:id :bill, :name "Bill"}
                                        {:app-time-start #inst "2016"
                                         :app-time-end #inst "2019"}]
-                                      [:put {:id :jeff, :also_name "Jeff" :_table "bar"}
+                                      [:put 'bar {:id :jeff, :also_name "Jeff"}
                                        {:app-time-start #inst "2018"
                                         :app-time-end #inst "2020"}]])]
 
     (is (= []
            (query-at-tx
-             "SELECT foo.name, bar.also_name
+            "SELECT foo.name, bar.also_name
              FROM foo, bar
              WHERE foo.APP_TIME SUCCEEDS bar.APP_TIME"
-             tx)))
+            tx)))
 
     (is (= [{:name "Bill" :also_name "Jeff"}]
            (query-at-tx
-             "SELECT foo.name, bar.also_name
+            "SELECT foo.name, bar.also_name
              FROM foo, bar
              WHERE foo.APPLICATION_TIME OVERLAPS bar.APP_TIME"
-             tx)))))
+            tx)))))

--- a/src/test/clojure/core2/stats_test.clj
+++ b/src/test/clojure/core2/stats_test.clj
@@ -11,14 +11,14 @@
 (deftest test-scan
   (with-open [node (node/start-node {:core2/live-chunk {:rows-per-block 2 , :rows-per-chunk 2}})]
     (let [scan-emitter (util/component node :core2.operator.scan/scan-emitter)]
-      (c2/submit-tx node [[:put {:id "foo1" :_table "foo"}]
-                          [:put {:id "bar1" :_table "bar"}]])
+      (c2/submit-tx node [[:put 'foo {:id "foo1"}]
+                          [:put 'bar {:id "bar1"}]])
 
-      (c2/submit-tx node [[:put {:id "foo2" :_table "foo"}]
-                          [:put {:id "baz1" :_table "baz"}]])
+      (c2/submit-tx node [[:put 'foo {:id "foo2"}]
+                          [:put 'baz {:id "baz1"}]])
 
-      (-> (c2/submit-tx node [[:put {:id "foo3" :_table "foo"}]
-                              [:put {:id "bar2" :_table "bar"}]])
+      (-> (c2/submit-tx node [[:put 'foo {:id "foo3"}]
+                              [:put 'bar {:id "bar2"}]])
           (tu/then-await-tx* node))
 
       (t/is (= {:row-count 3}

--- a/src/test/clojure/core2/tx_producer_test.clj
+++ b/src/test/clojure/core2/tx_producer_test.clj
@@ -15,31 +15,31 @@
     (t/is (= (json/parse-string (slurp expected-file))
              (-> (txp/serialize-tx-ops
                   a
-                  [[:put {:id "device-info-demo000000",
-                          :api-version "23",
-                          :manufacturer "iobeam",
-                          :model "pinto",
-                          :os-name "6.0.1"}
+                  [[:put 'xt_docs {:id "device-info-demo000000",
+                                   :api-version "23",
+                                   :manufacturer "iobeam",
+                                   :model "pinto",
+                                   :os-name "6.0.1"}
                     {:app-time-start #inst "2022", :app-time-end #inst "2025"}]
 
-                   [:put {:id "reading-demo000000",
-                          :cpu-avg-15min 8.654,
-                          :rssi -50.0,
-                          :cpu-avg-5min 10.802,
-                          :battery-status "discharging",
-                          :ssid "demo-net",
-                          :time #inst "2016-11-15T12:00:00.000-00:00",
-                          :battery-level 59.0,
-                          :bssid "01:02:03:04:05:06",
-                          :battery-temperature 89.5,
-                          :cpu-avg-1min 24.81,
-                          :mem-free 4.10011078E8,
-                          :mem-used 5.89988922E8}]
+                   [:put 'xt_docs {:id "reading-demo000000",
+                                   :cpu-avg-15min 8.654,
+                                   :rssi -50.0,
+                                   :cpu-avg-5min 10.802,
+                                   :battery-status "discharging",
+                                   :ssid "demo-net",
+                                   :time #inst "2016-11-15T12:00:00.000-00:00",
+                                   :battery-level 59.0,
+                                   :bssid "01:02:03:04:05:06",
+                                   :battery-temperature 89.5,
+                                   :cpu-avg-1min 24.81,
+                                   :mem-free 4.10011078E8,
+                                   :mem-used 5.89988922E8}]
 
-                   [:delete "xt_docs" "device-info-demo000000"
+                   [:delete 'xt_docs "device-info-demo000000"
                     {:app-time-start #inst "2024", :app-time-end #inst "2025"}]
 
-                   [:delete "reading-demo000000"]
+                   [:delete 'xt_docs "reading-demo000000"]
 
                    [:sql "INSERT INTO foo (id) VALUES (0)"]
 


### PR DESCRIPTION
This still defaults to `xt_docs` on the query side if nothing is specified and a lot of tests rely on this behavior.

Closes #657.