### PR TITLE
exists/not-exists take a sub-query instead

### DIFF
--- a/modules/datasets/src/main/clojure/core2/datasets/tpch/datalog.clj
+++ b/modules/datasets/src/main/clojure/core2/datasets/tpch/datalog.clj
@@ -110,12 +110,12 @@
             [(>= o_orderdate #time/date "1993-07-01")]
             [(< o_orderdate #time/date "1993-10-01")]
 
-            (exists? [o]
-                     [l :_table :lineitem]
-                     [l :l_orderkey o]
-                     [l :l_commitdate l_commitdate]
-                     [l :l_receiptdate l_receiptdate]
-                     [(< l_commitdate l_receiptdate)])]
+            (exists? {:find [o]
+                      :where [[l :_table :lineitem]
+                              [l :l_orderkey o]
+                              [l :l_commitdate l_commitdate]
+                              [l :l_receiptdate l_receiptdate]
+                              [(< l_commitdate l_receiptdate)]]})]
 
     :order-by [[o_orderpriority :asc]]})
 
@@ -410,10 +410,10 @@
                 [ps :ps_partkey p]
                 [ps :ps_suppkey s]
 
-                (not-exists? [s]
-                             [s :_table :supplier]
-                             [s :s_comment s_comment]
-                             [(like "%Customer%Complaints%" s_comment)])]
+                (not-exists? {:find [s]
+                              :where [[s :_table :supplier]
+                                      [s :s_comment s_comment]
+                                      [(like "%Customer%Complaints%" s_comment)]]})]
         :order-by [[(count-distinct s) :desc]
                    [p_brand :asc]
                    [p_type :asc]
@@ -551,20 +551,22 @@
 
             [(> l_receiptdate l_commitdate)]
 
-            (exists? [o s]
-                     [l2 :_table :lineitem]
-                     [l2 :l_orderkey o]
-                     [l2 :l_suppkey l2s]
-                     [(<> s l2s)])
+            (exists? {:find [o]
+                      :in [s]
+                      :where [[l2 :_table :lineitem]
+                              [l2 :l_orderkey o]
+                              [l2 :l_suppkey l2s]
+                              [(<> s l2s)]]})
 
-            (not-exists? [o s]
-                         [l3 :_table :lineitem]
-                         [l3 :l_orderkey o]
-                         [l3 :l_suppkey l3s]
-                         [(<> s l3s)]
-                         [l3 :l_receiptdate l_receiptdate]
-                         [l3 :l_commitdate l_commitdate]
-                         [(> l_receiptdate l_commitdate)])]
+            (not-exists? {:find [o]
+                          :in [s]
+                          :where [[l3 :_table :lineitem]
+                                  [l3 :l_orderkey o]
+                                  [l3 :l_suppkey l3s]
+                                  [(<> s l3s)]
+                                  [l3 :l_receiptdate l_receiptdate]
+                                  [l3 :l_commitdate l_commitdate]
+                                  [(> l_receiptdate l_commitdate)]]})]
 
     :order-by [[(count l1) :desc] [s_name :asc]]
     :limit 100})
@@ -585,9 +587,9 @@
                         [(contains? #{"13" "31" "23" "29" "30" "18" "17"} cntrycode)]]})
             [c :c_acctbal c_acctbal]
             [(> c_acctbal avg_acctbal)]
-            (not-exists? [c]
-                         [o :_table :orders]
-                         [o :o_custkey c])]
+            (not-exists? {:find [c]
+                          :where [[o :_table :orders]
+                                  [o :o_custkey c]]})]
     :order-by [[cntrycode :asc]]})
 
 (def queries


### PR DESCRIPTION
`exists?`/`not-exists?` previously took a collection of terms (i.e. a `:where` clause) - it now takes a full sub-query.

In addition to the power and composability of the sub-query rather than the terms, rather than the implicit nature of the args vector, a user now uses `:find` and `:in` on the inner query to determine what gets unified with the outer query:

```clojure
;; simple query, previously 
{:find [e]
 :where [[e :name name]
         (exists? [e]
                  [c :parent e])]}

;; now
{:find [e]
 :where [[e :name name]
         (exists? {:find [e]
                   :where [[c :parent e]]})]}
```

When the inner query requires correlated variables from the outside, these are declared as `:in` parameters, in line with how this already works in sub-queries, rather than the Datalog compiler needing to infer this from the args vector:

```clojure
;; previously
{:find [e]
 :where [[e :name name]
         [e :parent p]
         (exists? [e p]
                  [s :parent p]
                  [(<> e s)])]}

;; now
{:find [e]
 :where [[e :name name]
         [e :parent p]
         (exists? {:find [p] ; `e` not specified in `:find`
                   :in [e]
                   :where [[s :parent p]
                           [(<> e s)]]})]}
```

* To a user, this is likely more intuitive, as 'input' variables to the sub-query are explicitly specified in `:in`, and output variables from the sub-query (to unify with the outside) are specified explicitly in `:find`
* We could consider similar patterns for other syntactic structures (e.g. union-join, rules) that rely on this implicit args behaviour, and that only allow terms in the sub-query.