### PR TITLE
Initial cut of `:from` clause - document match syntax

### DIFF
--- a/modules/datasets/src/main/clojure/core2/datasets/tpch/datalog.clj
+++ b/modules/datasets/src/main/clojure/core2/datasets/tpch/datalog.clj
@@ -17,86 +17,49 @@
            (count l)]
     :keys [l_returnflag l_linestatus sum_qty sum_base_price sum_disc_price
            sum_charge avg_qty avg_price avg_disc count_order]
-    :where [[l :_table :lineitem]
-            [l :l_shipdate l_shipdate]
-            [l :l_quantity l_quantity]
-            [l :l_extendedprice l_extendedprice]
-            [l :l_discount l_discount]
-            [l :l_tax l_tax]
-            [l :l_returnflag l_returnflag]
-            [l :l_linestatus l_linestatus]
-            [(<= l_shipdate #time/date "1998-09-02")]]
+    :from [(lineitem [{:id l} l_shipdate l_quantity
+                       l_extendedprice l_discount l_tax
+                       l_returnflag l_linestatus])]
+    :where [[(<= l_shipdate #time/date "1998-09-02")]]
     :order-by [[l_returnflag :asc] [l_linestatus :asc]]})
 
 (def q2
   '{:find [s_acctbal s_name n_name p p_mfgr s_address s_phone s_comment]
     :keys [s_acctbal s_name n_name p_partkey p_mfgr s_address s_phone s_comment]
-    :where [[p :_table :part]
-            [ps :_table :partsupp]
-            [s :_table :supplier]
-            [n :_table :nation]
-            [r :_table :region]
 
-            [p :p_mfgr p_mfgr]
-            [p :p_size 15]
-            [p :p_type p_type]
-            [(like p_type "%BRASS")]
+    :from [(part [{:id p} p_mfgr {:p_size 15} p_type])
+           (partsupp [{:ps_partkey p, :ps_suppkey s} ps_supplycost])
+           (supplier [{:id s, :s_nationkey n}
+                       s_acctbal s_address s_name s_phone s_comment])
+           (nation [{:id n, :n_regionkey r} n_name])
+           (region {:id r, :r_name "EUROPE"})]
 
-            [ps :ps_partkey p]
-            [ps :ps_supplycost ps_supplycost]
-            [ps :ps_suppkey s]
+    :where [[(like p_type "%BRASS")]
 
             (q {:find [(min ps_supplycost)]
                 :keys [ps_supplycost]
                 :in [p]
-                :where [[ps :_table :partsupp]
-                        [s :_table :supplier]
-                        [n :_table :nation]
-                        [r :_table :region]
-                        [ps :ps_partkey p]
-                        [ps :ps_supplycost ps_supplycost]
-                        [ps :ps_suppkey s]
-                        [s :s_nationkey n]
-                        [n :n_regionkey r]
-                        [r :r_name "EUROPE"]]})
+                :from [(partsupp [{:ps_partkey p, :ps_suppkey s}
+                                  ps_supplycost])
+                       (supplier {:id s, :s_nationkey n})
+                       (nation {:id n, :n_regionkey r})
+                       (region {:id r, :r_name "EUROPE"})]})]
 
-            [s :s_acctbal s_acctbal]
-            [s :s_address s_address]
-            [s :s_name s_name]
-            [s :s_phone s_phone]
-            [s :s_comment s_comment]
-            [s :s_nationkey n]
-
-            [n :n_name n_name]
-            [n :n_regionkey r]
-
-            [r :r_name "EUROPE"]]
-
-    :order-by [[s_acctbal :desc]
-               [n_name :asc]
-               [s_name :asc]
-               [p :asc]]
+    :order-by [[s_acctbal :desc] [n_name :asc] [s_name :asc] [p :asc]]
     :limit 100})
 
 (def q3
   (-> '{:find [o (sum revenue) o_orderdate o_shippriority]
         :keys [l_orderkey revenue o_orderdate o_shippriority]
         :in [?segment]
-        :where [[c :_table :customer]
-                [o :_table :orders]
-                [l :_table :lineitem]
 
-                [c :c_mktsegment ?segment]
-                [o :o_custkey c]
-                [o :o_shippriority o_shippriority]
-                [o :o_orderdate o_orderdate]
-                [(< o_orderdate #time/date "1995-03-15")]
-                [l :l_orderkey o]
-                [l :l_discount l_discount]
-                [l :l_extendedprice l_extendedprice]
-                [l :l_shipdate l_shipdate]
+        :from [(customer {:id c, :c_mktsegment ?segment})
+               (orders [{:id o, :o_custkey c} o_shippriority o_orderdate])
+               (lineitem [{:l_orderkey o} l_discount l_extendedprice l_shipdate])]
+        :where [[(< o_orderdate #time/date "1995-03-15")]
                 [(> l_shipdate #time/date "1995-03-15")]
                 [(* l_extendedprice (- 1 l_discount)) revenue]]
+
         :order-by [[(sum revenue) :desc] [o_orderdate :asc]]
         :limit 10}
       (with-in-args ["BUILDING"])))
@@ -104,18 +67,13 @@
 (def q4
   '{:find [o_orderpriority (count o)]
     :keys [o_orderpriority order_count]
-    :where [[o :_table :orders]
-            [o :o_orderdate o_orderdate]
-            [o :o_orderpriority o_orderpriority]
-            [(>= o_orderdate #time/date "1993-07-01")]
+    :from [(orders [{:id o} o_orderdate o_orderpriority])]
+    :where [[(>= o_orderdate #time/date "1993-07-01")]
             [(< o_orderdate #time/date "1993-10-01")]
 
             (exists? {:find [o]
-                      :where [[l :_table :lineitem]
-                              [l :l_orderkey o]
-                              [l :l_commitdate l_commitdate]
-                              [l :l_receiptdate l_receiptdate]
-                              [(< l_commitdate l_receiptdate)]]})]
+                      :from [(lineitem [{:l_orderkey o} l_commitdate l_receiptdate])]
+                      :where [[(< l_commitdate l_receiptdate)]]})]
 
     :order-by [[o_orderpriority :asc]]})
 
@@ -123,40 +81,25 @@
   (-> '{:find [n_name (sum (* l_extendedprice (- 1 l_discount)))]
         :keys [n_name revenue]
         :in [region]
-        :where [[o :_table :orders]
-                [l :_table :lineitem]
-                [s :_table :supplier]
-                [c :_table :customer]
-                [n :_table :nation]
-                [r :_table :region]
+        :from [(orders [{:id o, :o_custkey c} o_orderdate])
+               (lineitem [{:l_orderkey o, :l_suppkey s}
+                          l_extendedprice l_discount])
 
-                [o :o_custkey c]
-                [o :o_orderdate o_orderdate]
-                [(>= o_orderdate #time/date "1994-01-01")]
-                [(< o_orderdate #time/date "1995-01-01")]
+               (supplier {:id s, :s_nationkey n})
+               (customer {:id c, :c_nationkey n})
+               (nation [{:id n, :n_regionkey r} n_name])
+               (region {:id r, :r_name region})]
+        :where [[(>= o_orderdate #time/date "1994-01-01")]
+                [(< o_orderdate #time/date "1995-01-01")]]
 
-                [l :l_orderkey o]
-                [l :l_suppkey s]
-                [l :l_extendedprice l_extendedprice]
-                [l :l_discount l_discount]
-
-                [s :s_nationkey n]
-                [c :c_nationkey n]
-                [n :n_name n_name]
-                [n :n_regionkey r]
-                [r :r_name region]]
         :order-by [[(sum (* l_extendedprice (- 1 l_discount))) :desc]]}
       (with-in-args ["ASIA"])))
 
 (def q6
   '{:find [(sum (* l_extendedprice l_discount))]
     :keys [revenue]
-    :where [[l :_table :lineitem]
-            [l :l_shipdate l_shipdate]
-            [l :l_quantity l_quantity]
-            [l :l_extendedprice l_extendedprice]
-            [l :l_discount l_discount]
-            [(>= l_shipdate #time/date "1994-01-01")]
+    :from [(lineitem [l_shipdate l_quantity l_extendedprice l_discount])]
+    :where [[(>= l_shipdate #time/date "1994-01-01")]
             [(< l_shipdate #time/date "1995-01-01")]
             [(>= l_discount 0.05)]
             [(<= l_discount 0.07)]
@@ -164,32 +107,23 @@
 
 (def q7
   '{:find [supp_nation cust_nation l_year (sum (* l_extendedprice (- 1 l_discount)))]
-    :where [[o :_table :orders]
-            [l :_table :lineitem]
-            [s :_table supplier]
-            [n1 :_table :nation]
-            [c :_table :customer]
-            [n2 :_table :nation]
+    :from [(orders {:o_custkey c})
+           (lineitem [{:l_orderkey o, :l_suppkey s}
+                       l_shipdate l_discount l_extendedprice])
+           (supplier {:id s, :s_nationkey n1})
+           (nation {:id n1, :n_name supp_nation})
+           (customer {:id c, :c_nationkey n2})
+           (nation {:id n2, :n_name cust_nation})]
 
-            [o :o_custkey c]
-            [l :l_orderkey o]
-            [l :l_suppkey s]
-            [l :l_shipdate l_shipdate]
-            [l :l_discount l_discount]
-            [l :l_extendedprice l_extendedprice]
-            [(>= l_shipdate #time/date "1995-01-01")]
+    :where [[(>= l_shipdate #time/date "1995-01-01")]
             [(<= l_shipdate #time/date "1996-12-31")]
             [(extract "YEAR" l_shipdate) l_year]
-
-            [s :s_nationkey n1]
-            [n1 :n_name supp_nation]
-            [c :c_nationkey n2]
-            [n2 :n_name cust_nation]
 
             [(or (and (= "FRANCE" supp_nation)
                       (= "GERMANY" cust_nation))
                  (and (= "GERMANY" supp_nation)
                       (= "FRANCE" cust_nation)))]]
+
     :order-by [[supp_nation :asc] [cust_nation :asc] [l_year :asc]]})
 
 (def q8
@@ -200,32 +134,20 @@
                 :keys [o_year brazil_volume volume]
                 :where [(q {:find [o_year (sum (* l_extendedprice (- 1 l_discount))) nation]
                             :keys [o_year volume nation]
-                            :where [[o :_table :orders]
-                                    [c :_table :customer]
-                                    [l :_table :lineitem]
-                                    [s :_table :supplier]
-                                    [n1 :_table :nation]
-                                    [r1 :_table :region]
-                                    [n2 :_table :nation]
-                                    [p :_table :part]
+                            :from [(orders [{:id o, :o_custkey c} o_orderdate])
+                                   (lineitem [{:id l, :l_orderkey o, :l_suppkey s, :l_partkey p}
+                                              l_extendedprice l_discount])
 
-                                    [o :o_custkey c]
-                                    [o :o_orderdate o_orderdate]
-                                    [(>= o_orderdate #time/date "1995-01-01")]
+                                   (customer {:id c, :c_nationkey n1})
+                                   (nation {:id n1, :n_regionkey r1})
+                                   (region {:id r1, :r_name "AMERICA"})
+
+                                   (supplier {:id s, :s_nationkey n2})
+                                   (nation {:id n2, :n_name nation})
+
+                                   (part {:id p, :p_type "ECONOMY ANODIZED STEEL"})]
+                            :where [[(>= o_orderdate #time/date "1995-01-01")]
                                     [(<= o_orderdate #time/date "1996-12-31")]
-
-                                    [l :l_orderkey o]
-                                    [l :l_suppkey s]
-                                    [l :l_partkey p]
-                                    [l :l_discount l_discount]
-                                    [l :l_extendedprice l_extendedprice]
-
-                                    [c :c_nationkey n1]
-                                    [n1 :n_regionkey r1]
-                                    [r1 :r_name "AMERICA"]
-                                    [s :s_nationkey n2]
-                                    [n2 :n_name nation]
-                                    [p :p_type "ECONOMY ANODIZED STEEL"]
                                     [(extract "YEAR" o_orderdate) o_year]]})]})
             [(/ brazil_volume volume) mkt_share]]
     :order-by [[o_year :asc]]})
@@ -235,32 +157,20 @@
            (sum (- (* l_extendedprice (- 1 l_discount))
                    (* ps_supplycost l_quantity)))]
     :keys [nation o_year sum_profit]
-    :where [[l :_table :lineitem]
-            [ps :_table :partsupp]
-            [s :_table :supplier]
-            [n :_table :nation]
-            [p :_table :part]
-            [o :_table :orders]
 
-            [l :l_orderkey o]
-            [l :l_suppkey s]
-            [l :l_partkey p]
-            [l :l_quantity l_quantity]
-            [l :l_discount l_discount]
-            [l :l_extendedprice l_extendedprice]
+    :from [(lineitem [{:l_orderkey o, :l_suppkey s, :l_partkey p}
+                      l_quantity l_extendedprice l_discount])
 
-            [ps :ps_partkey p]
-            [ps :ps_suppkey s]
-            [ps :ps_supplycost ps_supplycost]
+           (partsupp [{:ps_partkey p, :ps_suppkey s} ps_supplycost])
 
-            [s :s_nationkey n]
+           (supplier {:id s, :s_nationkey n})
+           (nation {:id n, :n_name nation})
 
-            [n :n_name nation]
+           (part [{:id p} p_name])
+           (orders [{:id o} o_orderdate])]
 
-            [p :p_name p_name]
-            [(like p_name "%green%")]
+    :where [[(like p_name "%green%")]
 
-            [o :o_orderdate o_orderdate]
             [(extract "YEAR" o_orderdate) o_year]]
 
     :order-by [[nation :asc] [o_year :desc]]})
@@ -270,26 +180,21 @@
            c_acctbal c_phone n_name c_address c_comment]
     :keys [c_custkey c_name revenue
            c_acctbal c_phone n_name c_address c_comment]
-    :where [[c :_table :customer]
-            [l :_table :lineitem]
-            [n :_table :nation]
-            [o :_table :orders]
 
-            [c :c_nationkey n]
-            [c :c_name c_name]
-            [c :c_acctbal c_acctbal]
-            [c :c_address c_address]
-            [c :c_phone c_phone]
-            [c :c_comment c_comment]
-            [o :o_custkey c]
-            [o :o_orderdate o_orderdate]
-            [(>= o_orderdate #time/date "1993-10-01")]
-            [(< o_orderdate #time/date "1994-01-01")]
-            [l :l_orderkey o]
-            [l :l_extendedprice l_extendedprice]
-            [l :l_discount l_discount]
-            [l :l_returnflag "R"]
-            [n :n_name n_name]]
+    :from [(customer [{:id c, :c_nationkey n}
+                      c_name c_address c_phone
+                      c_acctbal c_comment])
+
+           (nation {:id n, :n_name n_name})
+
+           (orders [{:id o, :o_custkey c}, o_orderdate])
+
+           (lineitem [{:l_orderkey o, :l_returnflag "R"}
+                      l_extendedprice l_discount])]
+
+    :where [[(>= o_orderdate #time/date "1993-10-01")]
+            [(< o_orderdate #time/date "1994-01-01")]]
+
     :order-by [[(sum (* l_extendedprice (- 1 l_discount))) :desc]]
     :limit 20})
 
@@ -297,27 +202,14 @@
   '{:find [ps_partkey value]
     :where [(q {:find [(sum (* ps_supplycost ps_availqty))]
                 :keys [total-value]
-                :where [[ps :_table :partsupp]
-                        [s :_table :supplier]
-                        [n :_table :nation]
-
-                        [ps :ps_availqty ps_availqty]
-                        [ps :ps_supplycost ps_supplycost]
-                        [ps :ps_suppkey s]
-                        [s :s_nationkey n]
-                        [n :n_name "GERMANY"]]})
+                :from [(partsupp [{:ps_suppkey s} ps_availqty ps_supplycost])
+                       (supplier [{:id s, :s_nationkey n}])
+                       (nation [{:id n, :n_name "GERMANY"}])]})
             (q {:find [ps_partkey (sum (* ps_supplycost ps_availqty))]
                 :keys [ps_partkey value]
-                :where [[ps :_table :partsupp]
-                        [s :_table :supplier]
-                        [n :_table :nation]
-
-                        [ps :ps_availqty ps_availqty]
-                        [ps :ps_supplycost ps_supplycost]
-                        [ps :ps_partkey ps_partkey]
-                        [ps :ps_suppkey s]
-                        [s :s_nationkey n]
-                        [n :n_name "GERMANY"]]})
+                :from [(partsupp [{:ps_suppkey s} ps_availqty ps_supplycost ps_partkey])
+                       (supplier [{:id s, :s_nationkey n}])
+                       (nation [{:id n, :n_name "GERMANY"}])]})
             [(> value (* 0.0001 total-value))]]
     :order-by [[value :desc]]})
 
@@ -327,35 +219,27 @@
                (sum (case o_orderpriority "1-URGENT" 0, "2-HIGH" 0, 1))]
         :keys [l_shipmode high_line_count low_line_count]
         :in [[l_shipmode ...]]
-        :where [[l :_table :lineitem]
-                [o :_table :orders]
-
-                [l :l_orderkey o]
-                [l :l_receiptdate l_receiptdate]
-                [l :l_commitdate l_commitdate]
-                [l :l_shipdate l_shipdate]
-                [l :l_shipmode l_shipmode]
-                [(>= l_receiptdate #time/date "1994-01-01")]
+        :from [(lineitem [{:l_orderkey o}
+                          l_receiptdate l_commitdate l_shipdate l_shipmode])
+               (orders [{:id o} o_orderpriority])]
+        :where [[(>= l_receiptdate #time/date "1994-01-01")]
                 [(< l_receiptdate #time/date "1995-01-01")]
                 [(< l_commitdate l_receiptdate)]
-                [(< l_shipdate l_commitdate)]
-
-                [o :o_orderpriority o_orderpriority]]
+                [(< l_shipdate l_commitdate)]]
         :order-by [[l_shipmode :asc]]}
 
       (with-in-args [#{"MAIL" "SHIP"}])))
 
+;; TODO left-join
 (def q13
   '{:find [c_count (count c_count)]
-    :where [(or [(q {:find [c (count o)]
-                     :keys [c c_count]
-                     :where [[o :_table :orders]
-                             [o :o_custkey c]
-                             [o :o_comment o_comment]
-                             (not [(re-find #".*special.*requests.*" o_comment)])]}) ]
-                (and [c :c_custkey]
-                     (not [_ :o_custkey c])
-                     [(identity 0) c_count]))]
+    :where [#_(or [(q {:find [c (count o)]
+                       :keys [c c_count]
+                       :from [(orders [{:o_custkey c} o_comment])]
+                       :where [(not [(re-find #".*special.*requests.*" o_comment)])]}) ]
+                  (and [c :c_custkey]
+                       (not [_ :o_custkey c])
+                       [(identity 0) c_count]))]
     :order-by [[(count c_count) :desc] [c_count :desc]]})
 
 (def q14
@@ -366,15 +250,10 @@
                               0))
                        (sum (* l_extendedprice (- 1 l_discount)))]
                 :keys [promo total]
-                :where [[l :_table :lineitem]
-                        [p :_table :part]
-
-                        [p :p_type p_type]
-                        [l :l_partkey p]
-                        [l :l_shipdate l_shipdate]
-                        [l :l_extendedprice l_extendedprice]
-                        [l :l_discount l_discount]
-                        [(>= l_shipdate #time/date "1995-09-01")]
+                :from [(lineitem [{:l_partkey p}
+                                  l_shipdate l_extendedprice l_discount])
+                       (part [{:id p} p_type])]
+                :where [[(>= l_shipdate #time/date "1995-09-01")]
                         [(< l_shipdate #time/date "1995-10-01")]]})]})
 
 (def q15
@@ -398,22 +277,14 @@
   (-> '{:find [p_brand p_type p_size (count-distinct s)]
         :keys [p_brand p_type p_size supplier_cnt]
         :in [[p_size ...]]
-        :where [[p :_table :part]
-                [ps :_table :partsupp]
-
-                [p :p_brand p_brand]
-                [(<> p_brand "Brand#45")]
-                [p :p_type p_type]
+        :from [(part [{:id p} p_brand p_type p_size])
+               (partsupp [{:ps_partkey p, :ps_suppkey s}])]
+        :where [[(<> p_brand "Brand#45")]
                 [(not (like p_type "MEDIUM POLISHED%"))]
-                [p :p_size p_size]
-
-                [ps :ps_partkey p]
-                [ps :ps_suppkey s]
 
                 (not-exists? {:find [s]
-                              :where [[s :_table :supplier]
-                                      [s :s_comment s_comment]
-                                      [(like "%Customer%Complaints%" s_comment)]]})]
+                              :from [(supplier [{:id s} s_comment])]
+                              :where [[(like "%Customer%Complaints%" s_comment)]]})]
         :order-by [[(count-distinct s) :desc]
                    [p_brand :asc]
                    [p_type :asc]
@@ -426,21 +297,12 @@
   '{:find [avg_yearly]
     :where [(q {:find [(sum l_extendedprice)]
                 :keys [sum_extendedprice]
-                :where [[p :_table :part]
-                        [l :_table :lineitem]
-
-                        [p :p_brand "Brand#23"]
-                        [p :p_container "MED BOX"]
-                        [l :l_partkey p]
-                        [l :l_quantity l_quantity]
-                        [l :l_extendedprice l_extendedprice]
-
-                        (q {:find [(avg l_quantity)]
+                :from [(part [{:id p, :p_brand "Brand#23", :p_container "MED BOX"}])
+                       (lineitem [{:l_partkey p} l_quantity l_extendedprice])]
+                :where [(q {:find [(avg l_quantity)]
                             :in [p]
                             :keys [avg_quantity]
-                            :where [[l :_table :lineitem]
-                                    [l :l_partkey p]
-                                    [l :l_quantity l_quantity]]})
+                            :from [(lineitem [{:l_partkey p} l_quantity])]})
 
                         [(< l_quantity (* 0.2 avg_quantity))]]})
 
@@ -449,36 +311,23 @@
 (def q18
   '{:find [c_name c o o_orderdate o_totalprice sum_quantity]
     :keys [c_name c_custkey o_orderkey o_orderdate o_totalprice sum_qty]
-    :where [[o :_table :orders]
-            [c :_table :customer]
-            (q {:find [o (sum l_quantity)]
+    :from [(customer [{:id c} c_name])
+           (orders [{:id o, :o_custkey c} o_orderdate o_totalprice])]
+    :where [(q {:find [o (sum l_quantity)]
                 :keys [o sum_quantity]
-                :where [[l :_table :lineitem]
-                        [l :l_orderkey o]
-                        [l :l_quantity l_quantity]]})
-            [(> sum_quantity 300.0)]
-            [o :o_custkey c]
-            [c :c_name c_name]
-            [o :o_orderdate o_orderdate]
-            [o :o_totalprice o_totalprice]]
+                :from [(lineitem [{:l_orderkey o} l_quantity])]})
+            [(> sum_quantity 300.0)]]
     :order-by [[o_totalprice :desc] [o_orderdate :asc]]
     :limit 100})
 
+;; TODO union-join with full query
 (def q19
   (-> '{:find [(sum (* l_extendedprice (- 1 l_discount)))]
         :in [[l_shipmode ...]]
-        :where [[l :_table :lineitem]
-                [p :_table :part]
-
-                [l :l_shipmode l_shipmode]
-                [l :l_shipinstruct "DELIVER IN PERSON"]
-                [l :l_discount l_discount]
-                [l :l_extendedprice l_extendedprice]
-                [l :l_partkey p]
-                [l :l_quantity l_quantity]
-                [p :p_size p_size]
-
-                (union-join [p l_quantity p_size]
+        :from [(part [{:id p} p_size])
+               (lineitem [{:l_shipinstruct "DELIVER IN PERSON", :l_partkey p}
+                          l_shipmode l_discount l_extendedprice l_quantity])]
+        :where [(union-join [p l_quantity p_size]
                             (and [p :p_brand "Brand#12"]
                                  [p :p_container #{"SM CASE" "SM BOX" "SM PACK" "SM PKG"}]
                                  [(>= l_quantity 1.0)]
@@ -502,70 +351,43 @@
 
 (def q20
   '{:find [s_name s_address]
-    :where [[ps :_table :partsupp]
-            [p :_table :part]
-            [s :_table :supplier]
-            [n :_table :nation]
+    :from [(partsupp [{:ps_suppkey s, :ps_partkey p}
+                      ps_availqty])
+           (part [{:id p} p_name])
+           (supplier [{:id s, :s_nationkey n}
+                      s_name s_address])
+           (nation {:id n, :n_name "CANADA"})]
+    :where [[(like p_name "forest%")]
 
-            [p :p_name p_name]
-            [(like p_name "forest%")]
-
-            [s :s_name s_name]
-            [s :s_address s_address]
-            [s :s_nationkey n]
-            [n :n_name "CANADA"]
-
-            [ps :ps_suppkey s]
-            [ps :ps_partkey p]
-            [ps :ps_availqty ps_availqty]
             (q {:find [(sum l_quantity)]
                 :keys [sum_quantity]
                 :in [p s]
-                :where [[l :_table :lineitem]
-                        [l :l_partkey p]
-                        [l :l_suppkey s]
-                        [l :l_shipdate l_shipdate]
-                        [(>= l_shipdate #time/date "1994-01-01")]
-                        [(< l_shipdate #time/date "1995-01-01")]
-                        [l :l_quantity l_quantity]]})
+                :from [(lineitem [{:l_partkey p, :l_suppkey s}
+                                  l_shipdate l_quantity])]
+                :where [[(>= l_shipdate #time/date "1994-01-01")]
+                        [(< l_shipdate #time/date "1995-01-01")]]})
             [(> ps_availqty (* sum_quantity 0.5))]]
     :order-by [[s_name :asc]]})
 
 (def q21
   '{:find [s_name (count l1)]
-    :where [[o :_table :orders]
-            [s :_table :supplier]
-            [l1 :_table :lineitem]
-            [n :_table :nation]
-
-            [o :o_orderstatus "F"]
-
-            [s :s_name s_name]
-            [s :s_nationkey n]
-            [n :n_name "SAUDI ARABIA"]
-
-            [l1 :l_suppkey s]
-            [l1 :l_orderkey o]
-            [l1 :l_receiptdate l_receiptdate]
-            [l1 :l_commitdate l_commitdate]
-
-            [(> l_receiptdate l_commitdate)]
+    :from [(orders [{:id o, :o_orderstatus "F"}])
+           (supplier [{:id s, :s_nationkey n} s_name])
+           (nation [{:id n, :n_name "SAUDI ARABIA"}])
+           (lineitem [{:id l1, :l_suppkey s, :l_orderkey o}
+                      l_receiptdate l_commitdate])]
+    :where [[(> l_receiptdate l_commitdate)]
 
             (exists? {:find [o]
                       :in [s]
-                      :where [[l2 :_table :lineitem]
-                              [l2 :l_orderkey o]
-                              [l2 :l_suppkey l2s]
-                              [(<> s l2s)]]})
+                      :from [(lineitem [{:l_orderkey o, :l_suppkey l2s}])]
+                      :where [[(<> s l2s)]]})
 
             (not-exists? {:find [o]
                           :in [s]
-                          :where [[l3 :_table :lineitem]
-                                  [l3 :l_orderkey o]
-                                  [l3 :l_suppkey l3s]
-                                  [(<> s l3s)]
-                                  [l3 :l_receiptdate l_receiptdate]
-                                  [l3 :l_commitdate l_commitdate]
+                          :from [(lineitem [{:l_orderkey o, :l_suppkey l3s}
+                                            l_receiptdate l_commitdate])]
+                          :where [[(<> s l3s)]
                                   [(> l_receiptdate l_commitdate)]]})]
 
     :order-by [[(count l1) :desc] [s_name :asc]]
@@ -573,23 +395,18 @@
 
 (def q22
   '{:find [cntrycode (count c) (sum c_acctbal)]
-    :where [[c :_table :customer]
-            [c :c_phone c_phone]
-            [(subs c_phone 0 2) cntrycode]
+    :from [(customer [c_phone c_acctbal])]
+    :where [[(subs c_phone 0 2) cntrycode]
             [(contains? #{"13" "31" "23" "29" "30" "18" "17"} cntrycode)]
             (q {:find [(avg c_acctbal)]
                 :keys [avg_acctbal]
-                :where [[c :_table :customer]
-                        [c :c_acctbal c_acctbal]
-                        [(> c_acctbal 0.0)]
-                        [c :c_phone c_phone]
+                :from [(customer [c_acctbal c_phone])]
+                :where [[(> c_acctbal 0.0)]
                         [(subs c_phone 0 2) cntrycode]
                         [(contains? #{"13" "31" "23" "29" "30" "18" "17"} cntrycode)]]})
-            [c :c_acctbal c_acctbal]
             [(> c_acctbal avg_acctbal)]
             (not-exists? {:find [c]
-                          :where [[o :_table :orders]
-                                  [o :o_custkey c]]})]
+                          :from [(orders {:o_custkey c})]})]
     :order-by [[cntrycode :asc]]})
 
 (def queries


### PR DESCRIPTION
Re-opening #624 and #625.

Rather than a handful of triple clauses, given that we now have tables available (and that we tend to call ourselves a document-graph database rather than a triple store), I've had a bit of a play with a graph-match syntax inspired by Cypher's [`MATCH`](https://neo4j.com/docs/cypher-manual/current/clauses/match/) and 'regular' (i.e. not EDN) Datalog relations.

* For this initial cut, I've included the doc-match under a separate `:from` key to avoid ambiguity with rule invocations. It _may_ be possible to include this under `:where`, but I wanted to get something merged so people can start playing with it sooner rather than later.
* I've also preserved triples for the time being - these still work albeit only with the `xt_docs` table (whose days are numbered with #658).

I've updated the Datalog TPC-H queries which pass our 0.01 result validation tests. I recommend the side-by-side diff in the changed files - but here's Q2:

```clojure
;; original

{:find [s_acctbal s_name n_name p p_mfgr s_address s_phone s_comment]
 :keys [s_acctbal s_name n_name p_partkey p_mfgr s_address s_phone s_comment]
 :where [[p :_table :part]
         [ps :_table :partsupp]
         [s :_table :supplier]
         [n :_table :nation]
         [r :_table :region]

         [p :p_mfgr p_mfgr]
         [p :p_size 15]
         [p :p_type p_type]
         [(like p_type "%BRASS")]

         [ps :ps_partkey p]
         [ps :ps_supplycost ps_supplycost]
         [ps :ps_suppkey s]

         (q {:find [(min ps_supplycost)]
             :keys [ps_supplycost]
             :in [p]
             :where [[ps :_table :partsupp]
                     [s :_table :supplier]
                     [n :_table :nation]
                     [r :_table :region]
                     [ps :ps_partkey p]
                     [ps :ps_supplycost ps_supplycost]
                     [ps :ps_suppkey s]
                     [s :s_nationkey n]
                     [n :n_regionkey r]
                     [r :r_name "EUROPE"]]})

         [s :s_acctbal s_acctbal]
         [s :s_address s_address]
         [s :s_name s_name]
         [s :s_phone s_phone]
         [s :s_comment s_comment]
         [s :s_nationkey n]

         [n :n_name n_name]
         [n :n_regionkey r]

         [r :r_name "EUROPE"]]

 :order-by [[s_acctbal :desc]
            [n_name :asc]
            [s_name :asc]
            [p :asc]]
 :limit 100}
```

```clojure
;; with graph-match syntax

{:find [s_acctbal s_name n_name p p_mfgr s_address s_phone s_comment]
 :keys [s_acctbal s_name n_name p_partkey p_mfgr s_address s_phone s_comment]

 :from [(part [{:id p} p_mfgr {:p_size 15} p_type])
        (partsupp [{:ps_partkey p, :ps_suppkey s} ps_supplycost])
        (supplier [{:id s, :s_nationkey n}
                   s_acctbal s_address s_name s_phone s_comment])
        (nation [{:id n, :n_regionkey r} n_name])
        (region {:id r, :r_name "EUROPE"})]

 :where [[(like p_type "%BRASS")]

         (q {:find [(min ps_supplycost)]
             :keys [ps_supplycost]
             :in [p]
             :from [(partsupp [{:ps_partkey p, :ps_suppkey s}
                               ps_supplycost])
                    (supplier {:id s, :s_nationkey n})
                    (nation {:id n, :n_regionkey r})
                    (region {:id r, :r_name "EUROPE"})]})]

 :order-by [[s_acctbal :desc] [n_name :asc] [s_name :asc] [p :asc]]
 :limit 100}
```

I've also included temporal filtering with this, again as a first cut. Slight alterations from what we've talked about in the week, so have a play, see what you think:

```clojure
(t/testing "entity history, all time"
  '{:find [id app-start app-end]
    :from [(xt_docs [id {:application_time_start app-start
                         :application_time_end app-end}]
                    {:for-app-time :all-time})]})

(t/testing "entity history, range"
  '{:find [id app-start app-end]
    :from [(xt_docs [id {:application_time_start app-start
                         :application_time_end app-end}]
                    {:for-app-time [:in #inst "2021", #inst "2023"]})]})

(t/testing "cross-time join - who was here in both 2018 and 2023?",
  '{:find [id],
    :from [(xt_docs [id]
                    {:for-app-time [:at #inst "2018"]})
           (xt_docs [id]
                    {:for-app-time [:at #inst "2023"]})]})
```