### PR TITLE
Permit simple scalar sub-query projection in datalog `:where`

### DIFF
--- a/core/src/main/clojure/core2/core/datalog.clj
+++ b/core/src/main/clojure/core2/core/datalog.clj
@@ -150,6 +150,11 @@
 
 (s/def ::rules (s/coll-of ::rule-definition :kind vector?))
 
+(s/def ::sub-query-projection
+  (s/and vector?
+         (s/cat :sub-query (s/spec ::sub-query)
+                :binding ::binding)))
+
 (s/def ::term
   (s/or :semi-join ::semi-join
         :anti-join ::anti-join
@@ -158,8 +163,10 @@
         :triple ::triple
         :call ::call-clause
         :sub-query ::sub-query
+        :sub-query-projection ::sub-query-projection
         :match ::match
         :rule ::rule))
+
 
 (s/def ::where
   (s/coll-of ::term :kind vector? :min-count 1))
@@ -206,7 +213,8 @@
         [:select (list* 'and predicates) plan])
       (with-meta (meta plan))))
 
-(defn- unify-preds [var->cols]
+(defn- unify-preds
+  [var->cols]
   ;; this enumerates all the binary join conditions
   ;; once mega-join has multi-way joins we could throw the multi-way `=` over the fence
   (->> (vals var->cols)
@@ -552,6 +560,22 @@
 
     (mega-join (into [plan] sub-queries) param-vars)))
 
+(defn- wrap-scalar-sub-query [plan scalar-sub-query param-vars]
+  (let [{:keys [sub-query binding]} scalar-sub-query
+        {::keys [apply-mapping]} (meta sub-query)
+        columns (lp/relation-columns sub-query)
+        _ (when (not= 1 (count columns)) (throw (err/illegal-arg :scalar-sub-query-requires-one-column)))
+        col (first columns)
+        binding-sym (second binding)
+        sq-plan (vary-meta [:rename {col binding-sym} sub-query] assoc ::vars #{binding-sym})
+        [plan-u sq-plan-u :as rels] (with-unique-cols [plan sq-plan] param-vars)
+        apply-mapping-u (update-keys apply-mapping (::var->col (meta plan-u)))]
+    (-> [:apply :single-join apply-mapping-u plan-u sq-plan-u]
+        (wrap-unify (::var->cols (meta rels))))))
+
+(defn- wrap-scalar-sub-queries [plan sub-queries param-vars]
+  (reduce #(wrap-scalar-sub-query %1 %2 param-vars) plan sub-queries))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;
 ;; rule substitution
 ;;;;;;;;;;;;;;;;;;;;;;;;
@@ -783,7 +807,8 @@
         _ (check-rule-arity rule-name->rules)
         where-clauses (expand-rules rule-name->rules where-clauses)
 
-        {match-clauses :match, triple-clauses :triple, call-clauses :call, sub-query-clauses :sub-query
+        {match-clauses :match, triple-clauses :triple, call-clauses :call
+         sub-query-clauses :sub-query, sub-query-projection-clauses :sub-query-projection
          semi-join-clauses :semi-join, anti-join-clauses :anti-join, union-join-clauses :union-join}
         (-> where-clauses
             (->> (group-by first))
@@ -794,12 +819,13 @@
                            (concat param-vars apply-mapping))
 
            calls (some->> call-clauses (mapv plan-call))
+           sub-queries (some->> sub-query-clauses (mapv plan-sub-query))
+           sub-query-projections (some->> sub-query-projection-clauses (mapv #(update % :sub-query plan-sub-query)))
            union-joins (some->> union-join-clauses (mapv plan-union-join))
            semi-joins (some->> semi-join-clauses (mapv (partial plan-semi-join :semi-join)))
-           anti-joins (some->> anti-join-clauses (mapv (partial plan-semi-join :anti-join)))
-           sub-queries (some->> sub-query-clauses (mapv plan-sub-query))]
+           anti-joins (some->> anti-join-clauses (mapv (partial plan-semi-join :anti-join)))]
 
-      (if (and (empty? calls) (empty? sub-queries)
+      (if (and (empty? calls) (empty? sub-queries) (empty? sub-query-projections)
                (empty? semi-joins) (empty? anti-joins) (empty? union-joins))
         (-> plan
             (vary-meta assoc ::in-bindings (::in-bindings (meta in-rels))))
@@ -810,11 +836,12 @@
 
             (let [{available-calls true, unavailable-calls false} (->> calls (group-by available?))
                   {available-sqs true, unavailable-sqs false} (->> sub-queries (group-by available?))
+                  {available-sqps true, unavailable-sqps false} (->> sub-query-projections (group-by available?))
                   {available-ujs true, unavailable-ujs false} (->> union-joins (group-by available?))
                   {available-sjs true, unavailable-sjs false} (->> semi-joins (group-by available?))
                   {available-ajs true, unavailable-ajs false} (->> anti-joins (group-by available?))]
 
-              (if (and (empty? available-calls) (empty? available-sqs)
+              (if (and (empty? available-calls) (empty? available-sqs) (empty? available-sqps)
                        (empty? available-ujs) (empty? available-sjs) (empty? available-ajs))
                 (throw (err/illegal-arg :no-available-clauses
                                         {:available-vars available-vars
@@ -825,13 +852,14 @@
                                          :unavailable-anti-joins unavailable-ajs}))
 
                 (recur (cond-> plan
-                         union-joins (wrap-union-joins union-joins param-vars)
-                         available-calls (wrap-calls available-calls)
-                         available-sjs (wrap-semi-joins :semi-join available-sjs)
-                         available-ajs (wrap-semi-joins :anti-join available-ajs)
-                         available-sqs (wrap-sub-queries available-sqs param-vars))
+                               union-joins (wrap-union-joins union-joins param-vars)
+                               available-calls (wrap-calls available-calls)
+                               available-sjs (wrap-semi-joins :semi-join available-sjs)
+                               available-ajs (wrap-semi-joins :anti-join available-ajs)
+                               available-sqs (wrap-sub-queries available-sqs param-vars)
+                               available-sqps (wrap-scalar-sub-queries available-sqps param-vars))
 
-                       unavailable-calls unavailable-sqs
+                       unavailable-calls unavailable-sqs unavailable-sqps
                        unavailable-ujs unavailable-sjs unavailable-ajs)))))))))
 
 ;; HACK these are just the grouping-fns used in TPC-H

--- a/core/src/main/clojure/core2/core/datalog.clj
+++ b/core/src/main/clojure/core2/core/datalog.clj
@@ -564,7 +564,8 @@
   (let [{:keys [sub-query binding]} scalar-sub-query
         {::keys [apply-mapping]} (meta sub-query)
         columns (lp/relation-columns sub-query)
-        _ (when (not= 1 (count columns)) (throw (err/illegal-arg :scalar-sub-query-requires-one-column)))
+        _ (when (not= 1 (count columns))
+            (throw (err/illegal-arg :scalar-sub-query-requires-one-column {::err/message "scalar sub query requires exactly one column"})))
         col (first columns)
         binding-sym (second binding)
         sq-plan (vary-meta [:rename {col binding-sym} sub-query] assoc ::vars #{binding-sym})

--- a/src/test/clojure/core2/core/datalog_test.clj
+++ b/src/test/clojure/core2/core/datalog_test.clj
@@ -1517,8 +1517,16 @@
 
   (t/testing "cardinality violation error"
     (t/is (thrown-with-msg? core2.RuntimeException #"cardinality violation"
-            (->> '{:find [firstname]
-                   :where [[(q {:find [firstname],
-                                :where [(match customer {:firstname firstname})]})
-                            firstname]]}
-                 (c2/q tu/*node*))))))
+                            (->> '{:find [firstname]
+                                   :where [[(q {:find [firstname],
+                                                :where [(match customer {:firstname firstname})]})
+                                            firstname]]}
+                                 (c2/q tu/*node*)))))
+
+  (t/testing "multiple column error"
+    (t/is (thrown-with-msg? core2.IllegalArgumentException #"scalar sub query requires exactly one column"
+                            (->> '{:find [n-customers]
+                                   :where [[(q {:find [firstname (count customer)],
+                                                :where [(match customer {:customer customer, :firstname firstname})]})
+                                            n-customers]]}
+                                 (c2/q tu/*node*))))))

--- a/src/test/clojure/core2/core/datalog_test.clj
+++ b/src/test/clojure/core2/core/datalog_test.clj
@@ -1443,3 +1443,74 @@
                     :order-by [[app-start :asc]]}
                   tx7, nil, 7797))
             "Case 8: Application-time sequenced and system-time nonsequenced"))))
+
+(deftest sub-query-projection-in-where-test
+  (c2/submit-tx tu/*node* [[:put 'customer {:id 0, :firstname "bob"}]
+                           [:put 'customer {:id 1, :firstname "alice"}]
+                           [:put 'order {:id 0, :customer 0, :items [{:sku "eggs", :qty 1}]}]
+                           [:put 'order {:id 1, :customer 0, :items [{:sku "cheese", :qty 3}]}]
+                           [:put 'order {:id 2, :customer 1, :items [{:sku "bread", :qty 1} {:sku "eggs", :qty 2}]}]])
+
+  (t/are [q result]
+    (= result (c2/q tu/*node* q))
+
+
+    '{:find [n-customers]
+      :where [[(q {:find [(count id)]
+                   :where [(match customer {:id id})]})
+               n-customers]]}
+    [{:n-customers 2}]
+
+
+    '{:find [customer, n-orders]
+      :where [(match customer {:id customer})
+              [(q {:find [(count order)]
+                   :in [customer]
+                   :where [(match order {:customer customer, :id order})]})
+               n-orders]]}
+    [{:customer 0, :n-orders 2}
+     {:customer 1, :n-orders 1}]
+
+    '{:find [customer, n-orders, n-qty]
+      :where [(match customer {:id customer})
+              [(q {:find [(count order)]
+                   :in [customer]
+                   :where [(match order {:customer customer, :id order})]})
+               n-orders]
+              [(q {:find [(sum qty2)]
+                   :in [customer]
+                   :where [(match order {:customer customer, :id order, :items [item ...]})
+                           [(. item :qty) qty2]]})
+               n-qty]]}
+    [{:customer 0, :n-orders 2, :n-qty 4}
+     {:customer 1, :n-orders 1, :n-qty 3}]
+
+    '{:find [n-orders, n-qty]
+      :where [[(q {:find [(count order)]
+                   :where [(match order {:id order})]})
+               n-orders]
+              [(q {:find [(sum qty2)]
+                   :where [(match order {:id order, :items [item ...]})
+                           [(. item :qty) qty2]]})
+               n-qty]]}
+    [{:n-orders 3, :n-qty 7}]
+
+    '{:find [order firstname]
+      :where [(match order {:id order, :customer customer})
+              [(q {:find [firstname]
+                   :in [customer]
+                   :where [(match customer {:id customer, :firstname firstname})]})
+               firstname]]}
+    [{:order 0, :firstname "bob"}
+     {:order 1, :firstname "bob"}
+     {:order 2, :firstname "alice"}]
+
+    '{:find [order firstname]
+      :where [(match order {:id order, :customer customer})
+              [(q {:find [firstname2]
+                   :in [customer]
+                   :where [(match customer {:id customer, :firstname firstname2})]})
+               firstname]]}
+    [{:order 0, :firstname "bob"}
+     {:order 1, :firstname "bob"}
+     {:order 2, :firstname "alice"}]))

--- a/src/test/clojure/core2/core/datalog_test.clj
+++ b/src/test/clojure/core2/core/datalog_test.clj
@@ -1513,4 +1513,12 @@
                firstname]]}
     [{:order 0, :firstname "bob"}
      {:order 1, :firstname "bob"}
-     {:order 2, :firstname "alice"}]))
+     {:order 2, :firstname "alice"}])
+
+  (t/testing "cardinality violation error"
+    (t/is (thrown-with-msg? core2.RuntimeException #"cardinality violation"
+            (->> '{:find [firstname]
+                   :where [[(q {:find [firstname],
+                                :where [(match customer {:firstname firstname})]})
+                            firstname]]}
+                 (c2/q tu/*node*))))))


### PR DESCRIPTION
Introduces a new term type for now.

Cannot yet nest sub-queries in expressions e.g `(< 3 (q ...))`

Progress towards #667