### PR TITLE
Add current-row-id cache

### DIFF
--- a/core/src/main/clojure/core2/operator/scan.clj
+++ b/core/src/main/clojure/core2/operator/scan.clj
@@ -12,10 +12,11 @@
             [core2.temporal :as temporal]
             [core2.types :as types]
             [core2.util :as util]
+            [core2.vector :as vec]
             [core2.vector.indirect :as iv]
             core2.watermark
             [juxt.clojars-mirrors.integrant.core :as ig])
-  (:import clojure.lang.MapEntry
+  (:import (clojure.lang MapEntry IPersistentSet)
            core2.api.TransactionInstant
            core2.buffer_pool.IBufferPool
            core2.ICursor
@@ -24,13 +25,13 @@
            (core2.vector IIndirectRelation IIndirectVector)
            core2.watermark.IWatermark
            java.time.temporal.Temporal
-           [java.util Date LinkedList List Map Queue]
+           [java.util Date LinkedList List Map Queue ArrayList]
            [java.util.function Consumer]
            org.apache.arrow.memory.BufferAllocator
            [org.apache.arrow.vector BigIntVector VarBinaryVector]
            [org.roaringbitmap IntConsumer RoaringBitmap]
            org.roaringbitmap.buffer.MutableRoaringBitmap
-           org.roaringbitmap.longlong.Roaring64Bitmap))
+           (org.roaringbitmap.longlong LongConsumer Roaring64Bitmap)))
 
 (s/def ::table simple-symbol?)
 
@@ -184,6 +185,31 @@
                              temporal-max-range
                              atemporal-row-id-bitmap)))
 
+(defn- ->atemporal-rel ^core2.vector.IIndirectRelation  [^BufferAllocator allocator, ^Roaring64Bitmap atemporal-row-id-bitmap current-row-ids]
+  (let [cols (ArrayList. 1)
+        row-count (long-array [0])]
+    (try
+
+      (let [col-name "_row-id"
+            col-type (types/col-type->field col-name (get temporal/temporal-col-types col-name))
+            ^BigIntVector row-id-vec (.createVector col-type allocator)
+            row-id-vec-wtr (vec/->mono-writer row-id-vec col-type)]
+        (.forEach atemporal-row-id-bitmap
+                  (reify LongConsumer
+                    (accept [_ row-id]
+                      (when (contains? current-row-ids row-id)
+                        (aset row-count 0 (inc (aget row-count 0)))
+                        (.writeLong row-id-vec-wtr row-id)))))
+
+        (.setValueCount row-id-vec (aget row-count 0))
+        (.add cols (iv/->direct-vec row-id-vec)))
+
+      (iv/->indirect-rel cols (aget row-count 0))
+
+      (catch Throwable e
+        (run! util/try-close cols)
+        (throw e)))))
+
 (defn- apply-temporal-preds ^core2.vector.IIndirectRelation [^IIndirectRelation temporal-rel, ^BufferAllocator allocator, ^Map col-preds, params]
   (->> (for [^IIndirectVector col temporal-rel
              :let [col-pred (get col-preds (.getName col))]
@@ -206,6 +232,7 @@
                      ^Map col-preds
                      ^longs temporal-min-range
                      ^longs temporal-max-range
+                     ^IPersistentSet current-row-ids
                      ^ICursor #_#_<Map<String, IIR>> blocks
                      params]
   ICursor
@@ -221,17 +248,21 @@
                                  (accept [_ in-roots]
                                    (let [^Map in-roots in-roots
                                          atemporal-row-id-bitmap (->atemporal-row-id-bitmap allocator content-col-names col-preds in-roots params)
-                                         temporal-rel (->temporal-rel watermark allocator temporal-col-names temporal-min-range temporal-max-range atemporal-row-id-bitmap)]
+                                         base-rel (if current-row-ids
+                                                    (->atemporal-rel allocator atemporal-row-id-bitmap current-row-ids)
+                                                    (->temporal-rel watermark allocator temporal-col-names temporal-min-range temporal-max-range atemporal-row-id-bitmap))]
                                      (try
-                                       (let [temporal-rel (-> temporal-rel (apply-temporal-preds allocator col-preds params))
-                                             read-rel (cond-> (align/align-vectors (.values in-roots) temporal-rel)
+                                       (let [base-rel (if current-row-ids
+                                                        base-rel
+                                                        (-> base-rel (apply-temporal-preds allocator col-preds params)))
+                                             read-rel (cond-> (align/align-vectors (.values in-roots) base-rel)
                                                         (not keep-row-id-col?) (remove-col "_row-id")
                                                         (not keep-id-col?) (remove-col "id"))]
                                          (when (and read-rel (pos? (.rowCount read-rel)))
                                            (.accept c read-rel)
                                            (vreset! !advanced? true)))
                                        (finally
-                                         (util/try-close temporal-rel)))))))))
+                                         (util/try-close base-rel)))))))))
       (boolean @!advanced?)))
 
   (close [_]
@@ -320,6 +351,31 @@
 
     [min-range max-range]))
 
+(defn- scan-op-at-now [scan-op]
+  (= :now (first (second scan-op))))
+
+(defn- at-now? [{:keys [for-app-time for-sys-time]}]
+  (and
+    (scan-op-at-now for-app-time)
+    ;; cannot treat nil for app-time as "now" because of the app-time-as-of-now flag
+    ;; which is not currently supported in datalog
+    (or (nil? for-sys-time)
+        (scan-op-at-now for-sys-time))))
+
+(defn use-current-row-id-cache? [^IWatermark watermark scan-opts basis temporal-col-names]
+  (and (at-now? scan-opts)
+       (>= (util/instant->micros (:current-time basis))
+           (util/instant->micros (:sys-time (:tx basis))))
+       (= (:tx basis)
+          (.txBasis watermark))
+       (empty? (remove #(= % "id") temporal-col-names))))
+
+(defn get-current-row-ids [^IWatermark watermark basis]
+  (.getCurrentRowIds
+    ^core2.temporal.ITemporalRelationSource
+    (.temporalRootsSource watermark)
+    (util/instant->micros (:current-time basis))))
+
 (defmethod ig/prep-key ::scan-emitter [_ opts]
   (merge opts
          {:metadata-mgr (ig/ref ::meta/metadata-manager)
@@ -384,14 +440,17 @@
 
         {:col-types (dissoc col-types '_table)
          :stats {:row-count row-count}
-         :->cursor (fn [{:keys [allocator, ^IWatermark watermark, basis, params] :as foo}]
+         :->cursor (fn [{:keys [allocator, ^IWatermark watermark, basis, params]}]
                      (let [metadata-pred (expr.meta/->metadata-selector (cons 'and metadata-args) (set col-names) params)
                            [temporal-min-range temporal-max-range] (->temporal-min-max-range params basis scan-opts selects)
                            content-col-names (mapv name content-col-names)
-                           temporal-col-names (mapv name temporal-col-names)]
+                           temporal-col-names (mapv name temporal-col-names)
+                           current-row-ids (when (use-current-row-id-cache? watermark scan-opts basis temporal-col-names)
+                                             (get-current-row-ids watermark basis))]
+
                        (-> (ScanCursor. allocator metadata-mgr watermark
                                         content-col-names temporal-col-names col-preds
-                                        temporal-min-range temporal-max-range
+                                        temporal-min-range temporal-max-range current-row-ids
                                         (util/->concat-cursor (->content-chunks metadata-mgr buffer-pool
                                                                                 (name table) content-col-names
                                                                                 metadata-pred)

--- a/src/test/clojure/core2/current_row_ids_test.clj
+++ b/src/test/clojure/core2/current_row_ids_test.clj
@@ -1,0 +1,760 @@
+(ns core2.current-row-ids-test
+  (:require [clojure.test :as t :refer [deftest]]
+            [core2.datalog :as c2]
+            [core2.operator.scan :as scan]
+            [core2.temporal :as temporal]
+            [core2.temporal.kd-tree-test :refer [as-micros ->coordinates]]
+            [core2.test-util :as tu]
+            [core2.util :as util])
+  (:import org.roaringbitmap.longlong.Roaring64Bitmap
+           java.io.Closeable
+           org.apache.arrow.memory.RootAllocator
+           java.time.Duration))
+
+(t/use-fixtures :each tu/with-mock-clock tu/with-node)
+
+(def
+  tx1
+  '[[:put xt_docs {:id :ivan, :first-name "Ivan"}]
+    [:put xt_docs {:id :petr, :first-name "Petr"}
+     {:app-time-start #inst "2020-01-02T12:00:00Z"}]
+    [:put xt_docs {:id :susie, :first-name "Susie"}
+     {:app-time-end #inst "2020-01-02T13:00:00Z"}]
+    [:put xt_docs {:id :sam, :first-name "Sam"}]
+    [:put xt_docs {:id :petr, :first-name "Petr"}
+     {:app-time-start #inst "2020-01-04T12:00:00Z"}]
+    [:put xt_docs {:id :jen, :first-name "Jen"}
+     {:app-time-end #inst "2020-01-04T13:00:00Z"}]
+    [:put xt_docs {:id :james, :first-name "James"}
+     {:app-time-start #inst "2020-01-01T12:00:00Z"}]
+    [:put xt_docs {:id :jon, :first-name "Jon"}
+     {:app-time-end #inst "2020-01-01T12:00:00Z"}]
+    [:put xt_docs {:id :lucy :first-name "Lucy"}]])
+
+(deftest test-current-row-ids
+  (c2/submit-tx
+    tu/*node*
+    tx1)
+
+  (c2/submit-tx
+    tu/*node*
+    '[[:put xt_docs {:id :ivan, :first-name "Ivan-2"}
+       {:app-time-start #inst "2020-01-02T14:00:00Z"}]
+      [:put xt_docs {:id :ben, :first-name "Ben"}
+       {:app-time-start #inst "2020-01-02T14:00:00Z"
+        :app-time-end #inst "2020-01-02T15:00:00Z"}]
+      [:evict xt_docs :lucy]])
+
+  (t/is (= [{:name "Ivan-2"}
+            {:name "James"}
+            {:name "Jen"}
+            {:name "Petr"}
+            {:name "Sam"}]
+           (c2/q
+             tu/*node*
+             (-> '{:find [name]
+                   :where [(match xt_docs {:first-name name})]
+                   :order-by [[name :asc]]}
+                 (assoc :basis {:current-time #time/instant "2020-01-03T00:00:00Z"})))))) ;; timing
+
+(defn valid-ids-at [current-time]
+  (c2/q
+    tu/*node*
+    (-> '{:find [id]
+          :where [(match xt_docs {:id id})]}
+        (assoc :basis {:current-time current-time}))))
+
+(deftest test-current-row-ids-app-time-start-inclusivity
+  (t/testing "app-time-start"
+    (c2/submit-tx
+      tu/*node*
+      '[[:put xt_docs {:id 1}
+         {:app-time-start #inst "2020-01-01T00:00:02Z"}]])
+
+    (t/is (= []
+             (valid-ids-at #time/instant "2020-01-01T00:00:01Z")))
+    (t/is (= [{:id 1}]
+             (valid-ids-at #time/instant "2020-01-01T00:00:02Z")))
+    (t/is (= [{:id 1}]
+             (valid-ids-at #time/instant "2020-01-01T00:00:03Z")))))
+
+(deftest test-current-row-ids-app-time-end-inclusivity
+  (t/testing "app-time-start"
+    (c2/submit-tx
+      tu/*node*
+      '[[:put xt_docs {:id 1}
+         {:app-time-end #inst "2020-01-01T00:00:02Z"}]])
+
+    (t/is (= [{:id 1}]
+             (valid-ids-at #time/instant "2020-01-01T00:00:01Z")))
+    (t/is (= []
+             (valid-ids-at #time/instant "2020-01-01T00:00:02Z")))
+    (t/is (= []
+             (valid-ids-at #time/instant "2020-01-01T00:00:03Z")))))
+
+
+(deftest remove-evicted-row-ids-test
+  (t/is
+    (= #{1 3}
+       (temporal/remove-evicted-row-ids
+         #{1 2 3}
+         (doto
+           (Roaring64Bitmap.)
+           (.addLong (long 2)))))))
+
+(deftest current-row-ids-can-be-built-at-startup
+  (let [node-dir (util/->path "target/can-build-current-row-ids-at-startup")
+        expectation [{:name "Ivan"}
+                     {:name "James"}
+                     {:name "Jen"}
+                     {:name "Lucy"}
+                     {:name "Petr"}
+                     {:name "Sam"}]]
+    (util/delete-dir node-dir)
+
+    (with-open [node (tu/->local-node {:node-dir node-dir})]
+
+      (-> (c2/submit-tx node tx1)
+          (tu/then-await-tx* node (Duration/ofMillis 2000)))
+
+      (tu/finish-chunk! node)
+
+      (t/is (= expectation
+               (c2/q
+                 node
+                 (-> '{:find [name]
+                       :where [(match xt_docs {:first-name name})]
+                       :order-by [[name :asc]]}
+                     (assoc :basis {:current-time #time/instant "2020-01-03T00:00:00Z"}))))))
+
+    (with-open [node (tu/->local-node {:node-dir node-dir})]
+      (t/is (= expectation
+               (c2/q
+                 node
+                 (-> '{:find [name]
+                       :where [(match xt_docs {:first-name name})]
+                       :order-by [[name :asc]]}
+                     (assoc :basis {:current-time #time/instant "2020-01-03T00:00:00Z"}))))))))
+
+(deftest test-queries-that-can-use-current-row-id-cache
+  (let [tx1 (c2/submit-tx
+              tu/*node*
+              '[[:put xt_docs {:id 1}]])
+        tx2 (c2/submit-tx
+              tu/*node*
+              '[[:put xt_docs {:id 2}]])]
+
+    (with-redefs [scan/get-current-row-ids
+                  (fn [_ _]
+                    (throw (Exception. "Scan tried to use current-row-id cache")))]
+
+      (t/testing "queries that can use current-row-ids cache"
+
+        (t/is
+          (thrown-with-msg?
+            Exception
+            #"Scan tried to use current-row-id cache"
+            (c2/q
+              tu/*node*
+              (-> '{:find [id]
+                    :where [(match xt_docs {:id id})]})))
+          "query with no temporal constraints")
+
+        (t/is
+          (thrown-with-msg?
+            Exception
+            #"Scan tried to use current-row-id cache"
+            (c2/q
+              tu/*node*
+              (-> '{:find [id]
+                    :where [(match xt_docs {:id id})]}
+                  (assoc :basis {:tx tx2}))))
+          "query at latest tx")
+
+        (t/is
+          (thrown-with-msg?
+            Exception
+            #"Scan tried to use current-row-id cache"
+            (c2/q
+              tu/*node*
+              (-> '{:find [id]
+                    :where [(match xt_docs {:id id})]}
+                  (assoc :basis {:current-time #time/instant "2020-01-03T00:00:00Z"}))))
+          "query with current-time now or in future")
+
+        (t/is
+          (thrown-with-msg?
+            Exception
+            #"Scan tried to use current-row-id cache"
+            (c2/q
+              tu/*node*
+              (-> '{:find [id]
+                    :where [(match xt_docs {:id id}
+                                   {:for-app-time [:at :now]
+                                    :for-sys-time [:at :now]})]})))
+          "query where all table temporal constaints are now"))
+
+      (t/testing "queries that cannot use current-row-ids cache"
+
+        (t/is
+          (c2/q
+            tu/*node*
+            (-> '{:find [id]
+                  :where [(match xt_docs {:id id})]}
+                (assoc :basis {:tx tx1})))
+          "query at previous tx")
+
+        (t/is
+          (c2/q
+            tu/*node*
+            (-> '{:find [id]
+                  :where [(match xt_docs {:id id})]}
+                (assoc :basis {:current-time #time/instant "2020-01-01T00:00:00Z"})))
+          "query with current-time in past")
+
+        (t/is
+          (c2/q
+            tu/*node*
+            (-> '{:find [id]
+                  :where [(match xt_docs {:id id}
+                                 {:for-app-time [:at :now]
+                                  :for-sys-time [:at #inst "2020-01-01"]})]}))
+          "query where all any table temporal constaints aside from now are set")
+
+        (t/is
+          (c2/q
+            tu/*node*
+            (-> '{:find [id]
+                  :where [(match xt_docs {:id id}
+                                 {:for-app-time :all-time})]}))
+          "query where all any table temporal constaints aside from now are set")
+
+        (t/is
+          (c2/q
+            tu/*node*
+            (-> '{:find [id]
+                  :where [(match
+                            xt_docs
+                            {:id id
+                             :application_time_start application_time_start}
+                            {:for-app-time :all-time})]}))
+          "query where all any temporal cols are projected out")))))
+
+(defn current-rows-for [sys-time inserts]
+  (let [kd-tree nil
+        !current-row-ids (volatile! #{})]
+    (with-open [allocator (RootAllocator.)
+                ^Closeable kd-tree (reduce
+                                     (fn [cur-kd-tree coords]
+                                       (temporal/insert-coordinates cur-kd-tree
+                                                                    allocator
+                                                                    coords
+                                                                    !current-row-ids
+                                                                    (as-micros sys-time)))
+                                     kd-tree
+                                     inserts)]
+      @!current-row-ids)))
+
+(deftest current-row-ids-inserts
+  (let [sys-time #inst "2020-01-02"]
+    (t/is (=
+           #{1}
+           (current-rows-for
+             sys-time
+             [(->coordinates {:id 101
+                              :row-id 1
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-02"
+                              :new-entity? true})]))
+          "app-time-start equal to sys-time"))
+
+  (let [sys-time #inst "2020-01-02"]
+    (t/is (=
+           #{1}
+           (current-rows-for
+             sys-time
+             [(->coordinates {:id 101
+                              :row-id 1
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-01"
+                              :new-entity? true})]))
+         "app-time-start before sys-time"))
+
+  (let [sys-time #inst "2020-01-02"]
+    (t/is (=
+           #{}
+           (current-rows-for
+             sys-time
+             [(->coordinates {:id 101
+                              :row-id 1
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-03"
+                              :new-entity? true})]))
+          "app-time-start after sys-time"))
+
+  (let [sys-time #inst "2020-01-02"]
+    (t/is (=
+           #{}
+           (current-rows-for
+             sys-time
+             [(->coordinates {:id 101
+                              :row-id 1
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-01"
+                              :app-time-end #inst "2020-01-02"
+                              :new-entity? true})]))
+          "app-time-start and end before sys-time"))
+
+  (let [sys-time #inst "2020-01-02"]
+    (t/is (=
+           #{1 2}
+           (current-rows-for
+             sys-time
+             [(->coordinates {:id 101
+                              :row-id 1
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-02"
+                              :new-entity? true})
+              (->coordinates {:id 102
+                              :row-id 2
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-01"
+                              :new-entity? true})]))
+          "one row for each entity is added")))
+
+(deftest current-row-ids-overlaps
+  (let [sys-time #inst "2020-01-02"]
+    (t/is (=
+           #{}
+           (current-rows-for
+             sys-time
+             [(->coordinates {:id 101
+                              :row-id 1
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-02"
+                              :new-entity? true})
+              (->coordinates {:id 101
+                              :row-id 2
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-02"
+                              :new-entity? false
+                              :tombstone? true})]))
+          "delete overlapping at current sys-time"))
+
+  (let [sys-time #inst "2020-01-02"]
+    (t/is (=
+           #{1}
+           (current-rows-for
+             sys-time
+             [(->coordinates {:id 101
+                              :row-id 1
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-02"
+                              :app-time-end #inst "2020-01-10"
+                              :new-entity? true})
+              (->coordinates {:id 101
+                              :row-id 2
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-03"
+                              :app-time-end #inst "2020-01-20"
+                              :new-entity? false
+                              :tombstone? true})]))
+          "delete overlapping after current sys-time"))
+
+  (let [sys-time #inst "2020-01-02"]
+    (t/is (=
+           #{}
+           (current-rows-for
+             sys-time
+             [(->coordinates {:id 101
+                              :row-id 1
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-01"
+                              :app-time-end #inst "2020-01-10"
+                              :new-entity? true})
+              (->coordinates {:id 101
+                              :row-id 2
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-02"
+                              :app-time-end #inst "2020-01-04"
+                              :new-entity? false
+                              :tombstone? true})]))
+          "delete overlapping before current sys-time"))
+
+  (let [sys-time #inst "2020-01-02"]
+    (t/is (=
+           #{2}
+           (current-rows-for
+             sys-time
+             [(->coordinates {:id 101
+                              :row-id 1
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-01"
+                              :new-entity? true})
+              (->coordinates {:id 101
+                              :row-id 2
+                              :sys-time-start sys-time
+                              :app-time-start #inst "2020-01-02"
+                              :new-entity? false})]))
+          "new put overlapping at current sys-time")))
+
+(deftest advance-current-row-ids-add-app-time-start-upper-bound
+  (let [sys-time #time/instant "2020-01-01T00:00:01.000001Z"
+        kd-tree nil
+        !current-row-ids (volatile! #{})]
+    (with-open [allocator (RootAllocator.)
+                ^Closeable kd-tree (reduce
+                                     (fn [cur-kd-tree coords]
+                                       (temporal/insert-coordinates cur-kd-tree
+                                                                    allocator
+                                                                    coords
+                                                                    !current-row-ids
+                                                                    (util/instant->micros sys-time)))
+                                     kd-tree
+                                     [(->coordinates {:id 101
+                                                      :row-id 1
+                                                      :sys-time-start sys-time
+                                                      :app-time-start #time/instant "2020-01-01T00:00:01.000010Z"
+                                                      :new-entity? true})])]
+      (t/is (= #{}
+               @!current-row-ids))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000009Z"))))
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000010Z"))))
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000011Z")))))))
+
+(deftest advance-current-row-ids-add-app-time-start-lower-bound
+  (let [sys-time #time/instant "2020-01-01T00:00:01.000001Z"
+        kd-tree nil
+        !current-row-ids (volatile! #{})]
+    (with-open [allocator (RootAllocator.)
+                ^Closeable kd-tree (reduce
+                                     (fn [cur-kd-tree coords]
+                                       (temporal/insert-coordinates cur-kd-tree
+                                                                    allocator
+                                                                    coords
+                                                                    !current-row-ids
+                                                                    (util/instant->micros sys-time)))
+                                     kd-tree
+                                     [(->coordinates {:id 101
+                                                      :row-id 1
+                                                      :sys-time-start sys-time
+                                                      :app-time-start #time/instant "2020-01-01T00:00:01.000002Z"
+                                                      :new-entity? true})])]
+      (t/is (= #{}
+               @!current-row-ids))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000001Z"))))
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000002Z"))))
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000003Z")))))))
+
+
+(deftest advance-current-row-ids-add-app-time-end-lower-bound
+  (let [sys-time #time/instant "2020-01-01T00:00:01.000001Z"
+        kd-tree nil
+        !current-row-ids (volatile! #{})]
+    (with-open [allocator (RootAllocator.)
+                ^Closeable kd-tree (reduce
+                                     (fn [cur-kd-tree coords]
+                                       (temporal/insert-coordinates cur-kd-tree
+                                                                    allocator
+                                                                    coords
+                                                                    !current-row-ids
+                                                                    (util/instant->micros sys-time)))
+                                     kd-tree
+                                     [(->coordinates {:id 101
+                                                      :row-id 1
+                                                      :sys-time-start sys-time
+                                                      :app-time-start #time/instant "2020-01-01T00:00:01.000008Z"
+                                                      :app-time-end #time/instant "2020-01-01T00:00:01.000010Z"
+                                                      :new-entity? true})])]
+      (t/is (= #{}
+               @!current-row-ids))
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000009Z"))))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000010Z"))))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000011Z")))))))
+
+
+(deftest advance-current-row-ids-remove-app-time-end-upper-bound
+  (let [sys-time #time/instant "2020-01-01T00:00:01.000001Z"
+        kd-tree nil
+        !current-row-ids (volatile! #{})]
+    (with-open [allocator (RootAllocator.)
+                ^Closeable kd-tree (reduce
+                                     (fn [cur-kd-tree coords]
+                                       (temporal/insert-coordinates cur-kd-tree
+                                                                    allocator
+                                                                    coords
+                                                                    !current-row-ids
+                                                                    (util/instant->micros sys-time)))
+                                     kd-tree
+                                     [(->coordinates {:id 101
+                                                      :row-id 1
+                                                      :sys-time-start sys-time
+                                                      :app-time-end #time/instant "2020-01-01T00:00:01.000010Z"
+                                                      :new-entity? true})])]
+      (t/is (= #{1}
+               @!current-row-ids))
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000009Z"))))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000010Z"))))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000011Z")))))))
+
+(deftest advance-current-row-ids-remove-app-time-end-lower-bound
+  (let [sys-time #time/instant "2020-01-01T00:00:01.000001Z"
+        kd-tree nil
+        !current-row-ids (volatile! #{})]
+    (with-open [allocator (RootAllocator.)
+                ^Closeable kd-tree (reduce
+                                     (fn [cur-kd-tree coords]
+                                       (temporal/insert-coordinates cur-kd-tree
+                                                                    allocator
+                                                                    coords
+                                                                    !current-row-ids
+                                                                    (util/instant->micros sys-time)))
+                                     kd-tree
+                                     [(->coordinates {:id 101
+                                                      :row-id 1
+                                                      :sys-time-start sys-time
+                                                      :app-time-end #time/instant "2020-01-01T00:00:01.000002Z"
+                                                      :new-entity? true})])]
+      (t/is (= #{1}
+               @!current-row-ids))
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000001Z"))))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000002Z"))))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000003Z")))))))
+
+(deftest advance-current-row-ids-remove-app-time-start-lower-bound
+  (let [sys-time #time/instant "2020-01-01T00:00:01.000001Z"
+        kd-tree nil
+        !current-row-ids (volatile! #{})]
+    (with-open [allocator (RootAllocator.)
+                ^Closeable kd-tree (reduce
+                                     (fn [cur-kd-tree coords]
+                                       (temporal/insert-coordinates cur-kd-tree
+                                                                    allocator
+                                                                    coords
+                                                                    !current-row-ids
+                                                                    (util/instant->micros sys-time)))
+                                     kd-tree
+                                     [(->coordinates {:id 101
+                                                      :row-id 1
+                                                      :sys-time-start sys-time
+                                                      :app-time-start #time/instant "2020-01-01T00:00:01.000001Z"
+                                                      :app-time-end #time/instant "2020-01-01T00:00:01.000002Z"
+                                                      :new-entity? true})])]
+      (t/is (= #{1}
+               @!current-row-ids))
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000001Z"))))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000002Z"))))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000003Z")))))))
+
+(deftest current-row-ids-from-start-test
+  (let [sys-time #time/instant "2020-01-01T00:00:01.000001Z"
+        kd-tree nil
+        !current-row-ids (volatile! #{})]
+    (with-open [allocator (RootAllocator.)
+                ^Closeable kd-tree (reduce
+                                     (fn [cur-kd-tree coords]
+                                       (temporal/insert-coordinates cur-kd-tree
+                                                                    allocator
+                                                                    coords
+                                                                    !current-row-ids
+                                                                    (util/instant->micros sys-time)))
+                                     kd-tree
+                                     [(->coordinates {:id 101
+                                                      :row-id 1
+                                                      :sys-time-start sys-time
+                                                      :app-time-start sys-time
+                                                      :new-entity? true})
+                                      (->coordinates {:id 101
+                                                      :row-id 2
+                                                      :sys-time-start sys-time
+                                                      :app-time-start #time/instant "2020-01-01T00:00:01.000010Z"
+                                                      :new-entity? false})])]
+      (t/is (= #{1}
+               (temporal/current-row-ids-from-start
+                 kd-tree
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000009Z"))))
+
+      (t/is (= #{2}
+               (temporal/current-row-ids-from-start
+                 kd-tree
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000010Z"))))
+
+      (t/is (= #{2}
+               (temporal/current-row-ids-from-start
+                 kd-tree
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000011Z")))))))
+
+(deftest advance-current-row-ids-multiple-periods
+  ;; test proves the need to sort additions/removals by valid time
+  (let [sys-time #time/instant "2020-01-01T00:00:01.000001Z"
+        kd-tree nil
+        !current-row-ids (volatile! #{})]
+    (with-open [allocator (RootAllocator.)
+                ^Closeable kd-tree (reduce
+                                     (fn [cur-kd-tree coords]
+                                       (temporal/insert-coordinates cur-kd-tree
+                                                                    allocator
+                                                                    coords
+                                                                    !current-row-ids
+                                                                    (util/instant->micros sys-time)))
+                                     kd-tree
+                                     [(->coordinates {:id 101
+                                                      :row-id 1
+                                                      :sys-time-start sys-time
+                                                      :app-time-start sys-time
+                                                      :new-entity? true})
+                                      (->coordinates {:id 101
+                                                      :row-id 2
+                                                      :sys-time-start sys-time
+                                                      :app-time-start #time/instant "2020-01-01T00:00:01.000003Z"
+                                                      :app-time-end #time/instant "2020-01-01T00:00:01.000004Z"
+                                                      :new-entity? false
+                                                      :tombstone? true})
+                                      (->coordinates {:id 101
+                                                      :row-id 3
+                                                      :sys-time-start sys-time
+                                                      :app-time-start #time/instant "2020-01-01T00:00:01.000006Z"
+                                                      :app-time-end  #time/instant "2020-01-01T00:00:01.000008Z"
+                                                      :new-entity? false
+                                                      :tombstone? true})])]
+      (t/is (= #{1}
+               @!current-row-ids))
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000002Z"))))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000003Z"))))
+
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000004Z"))))
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000005Z"))))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000006Z"))))
+
+      (t/is (= #{}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000007Z"))))
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000008Z"))))
+
+      (t/is (= #{1}
+               (temporal/advance-current-row-ids
+                 @!current-row-ids kd-tree
+                 (util/instant->micros sys-time)
+                 (util/instant->micros #time/instant "2020-01-01T00:00:01.000009Z")))))))


### PR DESCRIPTION
fixes #634 

This cache was introduced to alleviate the cost of temporal resolution for as of now queries. We do this by maintaining a clojure set of currently valid row ids where app/sys time is now, and during transaction processing add and remove row ids for changes for that affect "now".

However due to being a bitemp system app (valid) time moves forward irrespective of new transactions coming in. To alleviate this we query the temporal index for changes since the last time the cache was updated (latest transaction) and now, and use those changes to adjust the current-row-id cache. We do this both on every transaction (so that previously future changes are folded into the shared cache) and on every scan (so that the cache can be used as long as the current time of the scan after the tx-time of the query basis).

We rely on the current-row-id cache being a persistent data structure as we need the ability to give versions of it to a watermark, this is so that we maintain the correctness of any given scan/query even if the cache has subsequently been updated before that scan has been run.

Currently the current-row-id cache is not persisted to disk and so on startup a query from the beginning of app-time is performed on the kd-tree to find the set of currently-valid row-ids.

There is an option to also maintain a sorted list of future changes in app-time so that we don't have to query the kd-tree at all at query time and instead apply a subset of said changes based on the current-time.