### PR TITLE
Scalar sub-query nesting via placeholder replacement

### DIFF
--- a/core/src/main/clojure/xtdb/core/datalog.clj
+++ b/core/src/main/clojure/xtdb/core/datalog.clj
@@ -581,12 +581,10 @@
 
 (defn- wrap-scalar-sub-query [plan binding-sym scalar-sub-query param-vars]
   (let [sq-plan (plan-sub-query scalar-sub-query)
-        {::keys [apply-mapping]} (meta sq-plan)
-        columns (lp/relation-columns sq-plan)
-        _ (when (not= 1 (count columns))
-            (throw (err/illegal-arg :scalar-sub-query-requires-one-column {::err/message "scalar sub query requires exactly one column"})))
-        col (first columns)
-        sq-plan (vary-meta [:rename {col binding-sym} sq-plan] assoc ::vars #{binding-sym})
+        {sq-vars ::vars, ::keys [apply-mapping]} (meta sq-plan)
+        _ (when (not= 1 (count sq-vars)) (throw (err/illegal-arg :scalar-sub-query-requires-one-column {::err/message "scalar sub query requires exactly one column"})))
+        sq-var (first sq-vars)
+        sq-plan (vary-meta [:rename {sq-var binding-sym} sq-plan] assoc ::vars #{binding-sym})
         [plan-u sq-plan-u :as rels] (with-unique-cols [plan sq-plan] param-vars)
         apply-mapping-u (update-keys apply-mapping (::var->col (meta plan-u)))]
     (-> [:apply :single-join apply-mapping-u plan-u sq-plan-u]

--- a/core/src/main/clojure/xtdb/core/datalog.clj
+++ b/core/src/main/clojure/xtdb/core/datalog.clj
@@ -30,9 +30,9 @@
 
 (s/def ::form
   (s/or :logic-var ::logic-var
+        :sub-query ::sub-query
         :fn-call ::fn-call
-        :literal ::value
-        :sub-query ::sub-query))
+        :literal ::value))
 
 (s/def ::find-arg
   (s/or :logic-var ::logic-var

--- a/src/test/clojure/xtdb/core/datalog_test.clj
+++ b/src/test/clojure/xtdb/core/datalog_test.clj
@@ -1645,8 +1645,8 @@
             "Case 8: Application-time sequenced and system-time nonsequenced"))))
 
 (deftest sub-query-projection-in-where-test
-  (xt/submit-tx tu/*node* [[:put :customer {:id 0, :firstname "bob"}]
-                           [:put :customer {:id 1, :firstname "alice"}]
+  (xt/submit-tx tu/*node* [[:put :customer {:id 0, :firstname "bob", :lastname "smith"}]
+                           [:put :customer {:id 1, :firstname "alice" :lastname "carrol"}]
                            [:put :order {:id 0, :customer 0, :items [{:sku "eggs", :qty 1}]}]
                            [:put :order {:id 1, :customer 0, :items [{:sku "cheese", :qty 3}]}]
                            [:put :order {:id 2, :customer 1, :items [{:sku "bread", :qty 1} {:sku "eggs", :qty 2}]}]])
@@ -1713,9 +1713,37 @@
                firstname]]}
     [{:order 0, :firstname "bob"}
      {:order 1, :firstname "bob"}
-     {:order 2, :firstname "alice"}])
+     {:order 2, :firstname "alice"}]
 
-  (t/testing "cardinality violation error"
+    '{:find [order fullname]
+      :where [(match :order {:id order, :customer customer})
+              [(concat
+                 (q {:find [fn]
+                     :in [customer]
+                     :where [(match :customer {:id customer, :firstname fn})]})
+                 " "
+                 (q {:find [ln]
+                     :in [customer]
+                     :where [(match :customer {:id customer, :lastname ln})]}))
+               fullname]]}
+    [{:order 0, :fullname "bob smith"}
+     {:order 1, :fullname "bob smith"}
+     {:order 2, :fullname "alice carrol"}]
+
+    ;; this query does not yet work (dlog compiles correctly, but the predicate
+    ;; is pushed into the dependent side incorrectly causing an erroneous result
+    ;; see
+    #_#_
+    '{:find [order]
+      :where [(match :order {:id order, :customer customer})
+              [(= (q {:find [fn]
+                      :in [customer]
+                      :where [(match :customer {:id customer, :firstname fn})]})
+                  "bob")]]}
+    [{:order 0}
+     {:order 1}])
+
+(t/testing "cardinality violation error"
     (t/is (thrown-with-msg? xtdb.RuntimeException #"cardinality violation"
                             (->> '{:find [firstname]
                                    :where [[(q {:find [firstname],


### PR DESCRIPTION
This PR includes nesting of subqueries in datalog `:where` forms (projection & predicates).

I will have to return to the tests due to #733

This progresses to #667, `:find` clauses remaining (and any bugs!)
