### PR TITLE
Allow row alias match in datalog compiler

### DIFF
--- a/core/src/main/clojure/xtdb/metadata.clj
+++ b/core/src/main/clojure/xtdb/metadata.clj
@@ -58,6 +58,7 @@
   (^void finishChunk [^long chunkIdx, newChunkMetadata])
   (^java.util.NavigableMap chunksMetadata [])
   (^java.util.concurrent.CompletableFuture withMetadata [^long chunkIdx, ^String tableName, ^java.util.function.Function #_<ITableMetadata> f])
+  (columnTypes [^String tableName])
   (columnType [^String tableName, ^String colName]))
 
 #_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
@@ -489,6 +490,7 @@
   (chunksMetadata [_] chunks-metadata)
 
   (columnType [_ table-name col-name] (get-in col-types [table-name col-name]))
+  (columnTypes [_ table-name] (get col-types table-name))
 
   AutoCloseable
   (close [_]

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -48,7 +48,7 @@
 (defrecord Node [^BufferAllocator allocator
                  ^Ingester ingester, ^IIndexer indexer
                  ^ITxProducer tx-producer
-                 ^IRaQuerySource ra-src, wm-src
+                 ^IRaQuerySource ra-src, wm-src, scan-emitter
                  default-tz
                  !latest-submitted-tx
                  system, close-fn]
@@ -59,7 +59,7 @@
       (-> (.awaitTxAsync ingester (get-in query [:basis :after-tx]) (:basis-timeout query))
           (util/then-apply
             (fn [_]
-              (d/open-datalog-query allocator ra-src wm-src query args))))))
+              (d/open-datalog-query allocator ra-src wm-src scan-emitter query args))))))
 
   (open-sql& [_ query query-opts]
     (let [query-opts (-> (into {:default-tz default-tz} query-opts)
@@ -104,7 +104,8 @@
           :ingester (ig/ref :xtdb/ingester)
           :tx-producer (ig/ref ::txp/tx-producer)
           :default-tz (ig/ref :xtdb/default-tz)
-          :ra-src (ig/ref :xtdb.operator/ra-query-source)}
+          :ra-src (ig/ref :xtdb.operator/ra-query-source)
+          :scan-emitter (ig/ref :xtdb.operator.scan/scan-emitter)}
          opts))
 
 (defmethod ig/init-key ::node [_ deps]

--- a/src/test/clojure/xtdb/core/datalog_test.clj
+++ b/src/test/clojure/xtdb/core/datalog_test.clj
@@ -2104,3 +2104,9 @@
            (xt/q tu/*node*
                  '{:find [foo]
                    :where [(match :bar [foo])]}))))
+
+(t/deftest test-row-alias
+  (let [docs [{:id 42, :firstname "bob"}
+              {:id 43, :firstname "alice", :lastname "carrol"}]]
+    (xt/submit-tx tu/*node* (map (partial vector :put :customer) docs))
+    (t/is (= (mapv (fn [doc] {:c doc}) docs) (xt/q tu/*node* '{:find [c] :where [($ :customer {:xt/* c})]})))))


### PR DESCRIPTION
Use scan emitter to provide the column names and rewrite scans matching the :xt/* pseudo-column