### PR TITLE
Don't normalize PeriodDuration on disk for derived types IntervalDayTime and IntervalMonthDayNano

### DIFF
--- a/api/src/main/java/xtdb/types/IntervalDayTime.java
+++ b/api/src/main/java/xtdb/types/IntervalDayTime.java
@@ -3,12 +3,17 @@ package xtdb.types;
 import java.time.Duration;
 import java.time.Period;
 import java.util.Objects;
+import clojure.lang.PersistentHashMap;
 
 public final class IntervalDayTime {
     public final Period period;
     public final Duration duration;
 
     public IntervalDayTime(Period period, Duration duration) {
+        if ( period.getYears() != 0 || period.getMonths() != 0)
+            throw new xtdb.IllegalArgumentException("Period can not contain years or months!",
+                                                    PersistentHashMap.EMPTY,
+                                                    null);
         this.period = period;
         this.duration = duration;
     }

--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -634,6 +634,14 @@
   (tcp/for-all [i (tcg/one-of [interval-ym-gen interval-dt-gen interval-mdn-gen])]
     (= i (et/project1 '(+ a b) {:a i, :b (pd-zero i)}))))
 
+(deftest bug-interval-day-time-normalization-738
+  (let [i #xt/interval-dt ["P0D" "PT-23H-59M-59.001S"]]
+    (t/is (=  i
+              (et/project1 '(+ a b) {:a i, :b (pd-zero i)}))))
+  (let [i #xt/interval-mdn ["P33M244D" "PT48H0.003444443S"] ]
+    (t/is (=  i
+              (et/project1 '(+ a b) {:a i, :b (pd-zero i)})))))
+
 (tct/defspec interval-sub-identity-prop
   (tcp/for-all [i (tcg/one-of [interval-ym-gen interval-dt-gen interval-mdn-gen])]
     (= i (et/project1 '(- a b) {:a i, :b (pd-zero i)}))))


### PR DESCRIPTION
Fixes #738.

Also dissallow years and months in IntervalDayTime construction